### PR TITLE
Fix OOM by adding batched activation extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "transformers>=4.30",
     "scikit-learn>=1.0",
     "numpy>=1.20",
+    "tqdm>=4.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Fixes out-of-memory errors when processing large numbers of prompts by adding batched activation extraction
- Adds `batch_size` parameter to `LinearProbe` (default: 8) for user control over memory/speed tradeoff
- Adds tqdm progress bar for visibility during long extraction runs

## Problem
When running `dogs_vs_cats.py` with ~200 prompts on Llama-3.1-8B, the script was OOM-ing because `extract_activations()` processed all prompts in a single forward pass.

## Solution
- Process prompts in configurable batch sizes (default: 8)
- Wrap extraction in `torch.no_grad()` to prevent gradient tracking
- Move tensors to CPU immediately after each batch to free GPU memory
- Pad and concatenate batches to handle varying sequence lengths

## Test plan
- [x] All unit tests pass (`pytest tests/ -v`)
- [x] `dogs_vs_cats.py` completes successfully with ~200 prompts
- [x] Progress bar displays correctly during extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)