### PR TITLE
Add global model cache to prevent OOM in experiments

### DIFF
--- a/src/lmprobe/__init__.py
+++ b/src/lmprobe/__init__.py
@@ -23,6 +23,7 @@ __version__ = "0.1.0"
 __all__ = [
     "LinearProbe",
     "PerLayerScaler",
+    "clear_model_cache",
     "plot_layer_importance",
     "plot_layer_importance_heatmap",
 ]
@@ -41,4 +42,8 @@ def __getattr__(name: str):
         from .scaling import PerLayerScaler
 
         return PerLayerScaler
+    if name == "clear_model_cache":
+        from .extraction import clear_model_cache
+
+        return clear_model_cache
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

- Fixes OOM issue when running experiments with many `LinearProbe` instances
- Each probe was loading its own copy of the model, causing memory to accumulate
- With 16+ probes in an experiment, this meant 32+ GB of RAM usage

## Changes

- Add `_MODEL_CACHE` dict to store loaded models by `(model_name, device)` key
- Add `get_cached_model()` to retrieve or load models from cache
- Add `clear_model_cache()` to manually free memory when needed
- Update `ActivationExtractor.model` property to use cached models
- Export `clear_model_cache` from `lmprobe` package

## Test plan

- [x] All 137 existing tests pass
- [x] Verified model cache shares same model object across multiple probes
- [x] Verified memory stays constant (~0.87 GB) during multi-probe experiment instead of growing

## Usage

The fix is automatic - no changes needed for existing code. For manual memory management:

```python
from lmprobe import clear_model_cache

# After all probes are done, free model memory
clear_model_cache()
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)