### PR TITLE
Add shuffled_labels sanity check baseline

### DIFF
--- a/src/lmprobe/baseline.py
+++ b/src/lmprobe/baseline.py
@@ -40,6 +40,8 @@ class BaselineProbe:
         - "sentence_length": Use character/word count features
         - "perplexity": Use model's own logprobs (requires model param)
         - "sentence_transformers": Use off-the-shelf embeddings
+        - "shuffled_labels": Sanity check — trains on shuffled labels using
+          features from base_method. Should get ~50% accuracy.
     classifier : str | BaseEstimator, default="logistic_regression"
         Classification model. Same options as LinearProbe.
         Ignored for method="random" and method="majority".
@@ -50,6 +52,9 @@ class BaselineProbe:
     ngram_range : tuple[int, int], default=(1, 1)
         N-gram range for bow/tfidf. (1, 1) = unigrams only,
         (1, 2) = unigrams and bigrams.
+    base_method : str, default="tfidf"
+        Feature extraction method to use when method="shuffled_labels".
+        Ignored for other methods.
     model : str | None, default=None
         HuggingFace model ID. Required for method="perplexity".
     device : str, default="auto"
@@ -82,6 +87,7 @@ class BaselineProbe:
         "sentence_length",
         "perplexity",
         "sentence_transformers",
+        "shuffled_labels",
     )
 
     def __init__(
@@ -91,6 +97,7 @@ class BaselineProbe:
         random_state: int | None = None,
         max_features: int | None = 10000,
         ngram_range: tuple[int, int] = (1, 1),
+        base_method: str = "tfidf",
         model: str | None = None,
         device: str = "auto",
         remote: bool = False,
@@ -105,11 +112,18 @@ class BaselineProbe:
                 "method='perplexity' requires the 'model' parameter to be specified."
             )
 
+        if method == "shuffled_labels" and base_method not in self.VALID_METHODS:
+            raise ValueError(
+                f"Unknown base_method: {base_method!r}. "
+                f"Valid options: {self.VALID_METHODS}"
+            )
+
         self.method = method
         self.classifier = classifier
         self.random_state = random_state
         self.max_features = max_features
         self.ngram_range = ngram_range
+        self.base_method = base_method
         self.model = model
         self.device = device
         self.remote = remote
@@ -152,28 +166,36 @@ class BaselineProbe:
         prompts = positive_prompts + negative_prompts
         labels = np.array([1] * len(positive_prompts) + [0] * len(negative_prompts))
 
+        # For shuffled_labels, use base_method for features
+        feature_method = self.base_method if self.method == "shuffled_labels" else self.method
+
         # Extract features based on method
-        if self.method == "bow":
+        if feature_method == "bow":
             self.vectorizer_ = CountVectorizer(
                 max_features=self.max_features,
                 ngram_range=self.ngram_range,
             )
             X = self.vectorizer_.fit_transform(prompts)
-        elif self.method == "tfidf":
+        elif feature_method == "tfidf":
             self.vectorizer_ = TfidfVectorizer(
                 max_features=self.max_features,
                 ngram_range=self.ngram_range,
             )
             X = self.vectorizer_.fit_transform(prompts)
-        elif self.method == "sentence_length":
+        elif feature_method == "sentence_length":
             X = self._extract_sentence_length_features(prompts)
-        elif self.method == "perplexity":
+        elif feature_method == "perplexity":
             X = self._compute_perplexity(prompts)
-        elif self.method == "sentence_transformers":
+        elif feature_method == "sentence_transformers":
             X = self._transform_sentence_transformers(prompts, fit=True)
         else:
             # random/majority - features don't matter, just need shape
             X = np.zeros((len(prompts), 1))
+
+        # Shuffle labels for sanity check baseline
+        if self.method == "shuffled_labels":
+            rng = np.random.RandomState(self.random_state)
+            labels = rng.permutation(labels)
 
         # Fit classifier
         self.classifier_ = clone(self._classifier_template)
@@ -252,14 +274,16 @@ class BaselineProbe:
 
     def _transform(self, prompts: list[str]) -> np.ndarray:
         """Transform prompts to feature matrix."""
-        if self.method in ("bow", "tfidf"):
+        feature_method = self.base_method if self.method == "shuffled_labels" else self.method
+
+        if feature_method in ("bow", "tfidf"):
             X = self.vectorizer_.transform(prompts)
             return self._ensure_dense_if_needed(X)
-        elif self.method == "sentence_length":
+        elif feature_method == "sentence_length":
             return self._extract_sentence_length_features(prompts)
-        elif self.method == "perplexity":
+        elif feature_method == "perplexity":
             return self._compute_perplexity(prompts)
-        elif self.method == "sentence_transformers":
+        elif feature_method == "sentence_transformers":
             return self._transform_sentence_transformers(prompts, fit=False)
         else:
             # random/majority

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -357,3 +357,91 @@ class TestBaselineProbeSentenceTransformers:
         # Should fail during fit when trying to import
         with pytest.raises(ImportError, match="sentence-transformers is required"):
             baseline.fit(POSITIVE_PROMPTS, NEGATIVE_PROMPTS)
+
+
+class TestBaselineProbeShuffledLabels:
+    """Test shuffled_labels sanity check baseline."""
+
+    def test_shuffled_labels_fit_predict(self):
+        """Shuffled labels baseline can fit and predict."""
+        baseline = BaselineProbe(
+            method="shuffled_labels",
+            base_method="tfidf",
+            random_state=42,
+        )
+        baseline.fit(POSITIVE_PROMPTS, NEGATIVE_PROMPTS)
+
+        predictions = baseline.predict(TEST_PROMPTS)
+        assert predictions.shape == (2,)
+        assert set(predictions).issubset({0, 1})
+
+    def test_shuffled_labels_predict_proba(self):
+        """Shuffled labels baseline supports predict_proba."""
+        baseline = BaselineProbe(
+            method="shuffled_labels",
+            base_method="tfidf",
+            random_state=42,
+        )
+        baseline.fit(POSITIVE_PROMPTS, NEGATIVE_PROMPTS)
+
+        proba = baseline.predict_proba(TEST_PROMPTS)
+        assert proba.shape == (2, 2)
+        np.testing.assert_allclose(proba.sum(axis=1), 1.0)
+
+    def test_shuffled_labels_low_accuracy(self):
+        """Shuffled labels should yield near-chance accuracy on average.
+
+        With shuffled labels, the probe shouldn't learn real signal.
+        Over multiple random seeds, mean accuracy should be near 0.5.
+        """
+        accuracies = []
+        for seed in range(20):
+            baseline = BaselineProbe(
+                method="shuffled_labels",
+                base_method="tfidf",
+                random_state=seed,
+            )
+            baseline.fit(POSITIVE_PROMPTS, NEGATIVE_PROMPTS)
+
+            train_prompts = POSITIVE_PROMPTS + NEGATIVE_PROMPTS
+            train_labels = [1] * len(POSITIVE_PROMPTS) + [0] * len(NEGATIVE_PROMPTS)
+            accuracies.append(baseline.score(train_prompts, train_labels))
+
+        mean_acc = np.mean(accuracies)
+        # Should be near chance (0.5), not consistently high
+        assert mean_acc < 0.85, (
+            f"Shuffled labels baseline too accurate ({mean_acc:.2f}), "
+            "suggesting labels aren't properly shuffled"
+        )
+
+    def test_shuffled_labels_reproducible(self):
+        """Same random_state gives same shuffled results."""
+        b1 = BaselineProbe(method="shuffled_labels", random_state=42)
+        b2 = BaselineProbe(method="shuffled_labels", random_state=42)
+
+        b1.fit(POSITIVE_PROMPTS, NEGATIVE_PROMPTS)
+        b2.fit(POSITIVE_PROMPTS, NEGATIVE_PROMPTS)
+
+        pred1 = b1.predict(TEST_PROMPTS)
+        pred2 = b2.predict(TEST_PROMPTS)
+        np.testing.assert_array_equal(pred1, pred2)
+
+    def test_shuffled_labels_default_base_method(self):
+        """Default base_method is tfidf."""
+        baseline = BaselineProbe(method="shuffled_labels", random_state=42)
+        assert baseline.base_method == "tfidf"
+        baseline.fit(POSITIVE_PROMPTS, NEGATIVE_PROMPTS)
+        predictions = baseline.predict(TEST_PROMPTS)
+        assert predictions.shape == (2,)
+
+    def test_shuffled_labels_with_bow(self):
+        """Shuffled labels works with bow base_method."""
+        baseline = BaselineProbe(
+            method="shuffled_labels",
+            base_method="bow",
+            random_state=42,
+        )
+        baseline.fit(POSITIVE_PROMPTS, NEGATIVE_PROMPTS)
+
+        predictions = baseline.predict(TEST_PROMPTS)
+        assert predictions.shape == (2,)


### PR DESCRIPTION
## Summary
- Adds `method="shuffled_labels"` to `BaselineProbe` (closes #11)
- Trains on randomly permuted labels using features from `base_method` (default: `tfidf`)
- A well-behaved probe should get ~50% accuracy with shuffled labels — if it scores higher, something is wrong

## Usage
```python
baseline = BaselineProbe(
    method="shuffled_labels",
    base_method="tfidf",
    random_state=42,
)
baseline.fit(positive_prompts, negative_prompts)
accuracy = baseline.score(test_prompts, test_labels)
# Should be ~50%
```

## Test plan
- [x] Shuffled labels baseline can fit and predict
- [x] predict_proba returns valid probabilities
- [x] Mean accuracy over multiple seeds is near chance (~50%)
- [x] Reproducible with random_state
- [x] Works with different base methods (tfidf, bow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)