### PR TITLE
Add dtype config for LocalBackend and acceptance tests for #19-#22

### DIFF
--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -173,7 +173,7 @@ class NnsightBackend(ExtractionBackend):
 
 # Global cache for locally-loaded HuggingFace models
 # Key: (model_name, device), Value: (model, tokenizer)
-_LOCAL_MODEL_CACHE: dict[tuple[str, str], tuple] = {}
+_LOCAL_MODEL_CACHE: dict[tuple, tuple] = {}
 
 
 def _get_decoder_layers(model) -> list:
@@ -228,7 +228,9 @@ def _get_decoder_layers(model) -> list:
     )
 
 
-def _get_local_model(model_name: str, device: str):
+def _get_local_model(
+    model_name: str, device: str, dtype: torch.dtype = torch.float32
+):
     """Load a HuggingFace model locally, with caching.
 
     Parameters
@@ -237,13 +239,15 @@ def _get_local_model(model_name: str, device: str):
         HuggingFace model ID or local path.
     device : str
         Device specification.
+    dtype : torch.dtype
+        Model dtype (e.g., torch.float32, torch.bfloat16).
 
     Returns
     -------
     tuple
         (model, tokenizer)
     """
-    cache_key = (model_name, device)
+    cache_key = (model_name, device, dtype)
     if cache_key not in _LOCAL_MODEL_CACHE:
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -261,7 +265,7 @@ def _get_local_model(model_name: str, device: str):
         model = AutoModelForCausalLM.from_pretrained(
             model_name,
             device_map=device_map,
-            torch_dtype=torch.float32,
+            torch_dtype=dtype,
         )
         model.eval()
         _LOCAL_MODEL_CACHE[cache_key] = (model, tokenizer)
@@ -287,17 +291,27 @@ class LocalBackend(ExtractionBackend):
         HuggingFace model ID or local path.
     device : str
         Device specification.
+    dtype : torch.dtype
+        Model dtype (e.g., torch.float32, torch.bfloat16).
     """
 
-    def __init__(self, model_name: str, device: str = "auto"):
+    def __init__(
+        self,
+        model_name: str,
+        device: str = "auto",
+        dtype: torch.dtype = torch.float32,
+    ):
         super().__init__(model_name, device)
+        self.dtype = dtype
         self._model = None
         self._tokenizer = None
 
     def _load(self):
         """Load model and tokenizer."""
         if self._model is None:
-            model, tokenizer = _get_local_model(self.model_name, self.device)
+            model, tokenizer = _get_local_model(
+                self.model_name, self.device, self.dtype
+            )
             self._model = model
             self._tokenizer = tokenizer
 
@@ -420,6 +434,7 @@ def resolve_backend(
     model_name: str,
     device: str = "auto",
     remote: bool = False,
+    dtype: torch.dtype | None = None,
 ) -> ExtractionBackend:
     """Create an ExtractionBackend from a string identifier.
 
@@ -433,6 +448,9 @@ def resolve_backend(
         Device specification.
     remote : bool
         Whether to use remote execution (only valid for nnsight backend).
+    dtype : torch.dtype or None
+        Model dtype for local backend (e.g., torch.float32, torch.bfloat16).
+        Defaults to torch.float32 if None. Ignored for nnsight backend.
 
     Returns
     -------
@@ -453,7 +471,8 @@ def resolve_backend(
                 "backend='local' does not support remote=True. "
                 "Use backend='nnsight' for remote execution."
             )
-        return LocalBackend(model_name, device)
+        local_dtype = dtype if dtype is not None else torch.float32
+        return LocalBackend(model_name, device, dtype=local_dtype)
     else:
         raise ValueError(
             f"Unknown backend: {backend!r}. Available backends: 'nnsight', 'local'."

--- a/src/lmprobe/extraction.py
+++ b/src/lmprobe/extraction.py
@@ -683,6 +683,7 @@ class ActivationExtractor:
         auto_candidates: list[int] | list[float] | None = None,
         remote: bool = False,
         backend: str = "nnsight",
+        dtype: torch.dtype | None = None,
     ):
         self.model_name = model_name
         self.device = device
@@ -695,7 +696,9 @@ class ActivationExtractor:
         # Create the backend
         from .backends import resolve_backend
 
-        self._backend = resolve_backend(backend, model_name, device, remote=remote)
+        self._backend = resolve_backend(
+            backend, model_name, device, remote=remote, dtype=dtype
+        )
 
         # Lazy-loaded
         self._model: LanguageModel | None = None

--- a/src/lmprobe/probe.py
+++ b/src/lmprobe/probe.py
@@ -31,6 +31,26 @@ if TYPE_CHECKING:
 
     from .scaling import PerLayerScaler
 
+_DTYPE_MAP = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
+
+
+def _resolve_dtype(dtype: str | None) -> torch.dtype | None:
+    """Resolve a dtype string to a torch.dtype, or None."""
+    if dtype is None:
+        return None
+    if isinstance(dtype, str):
+        if dtype not in _DTYPE_MAP:
+            raise ValueError(
+                f"Unknown dtype: {dtype!r}. "
+                f"Available: {list(_DTYPE_MAP.keys())}"
+            )
+        return _DTYPE_MAP[dtype]
+    return dtype
+
 
 class LinearProbe:
     """Train a linear probe on language model activations.
@@ -91,6 +111,9 @@ class LinearProbe:
         Extraction backend: "nnsight" (default) or "local".
         "local" uses HuggingFace transformers directly without nnsight,
         enabling use with models not supported by nnsight/NDIF.
+    dtype : str | None, default=None
+        Model dtype for local backend: "float32", "float16", or "bfloat16".
+        Defaults to "float32" if None. Ignored for nnsight backend.
 
     Attributes
     ----------
@@ -145,6 +168,7 @@ class LinearProbe:
         normalize_layers: bool | str = True,
         fast_auto_top_k: int | None = None,
         backend: str = "nnsight",
+        dtype: str | None = None,
     ):
         self.model = model
         self.layers = layers
@@ -161,6 +185,7 @@ class LinearProbe:
         self.normalize_layers = normalize_layers
         self.fast_auto_top_k = fast_auto_top_k
         self.backend = backend
+        self.dtype = dtype
 
         # Validate backend + remote compatibility
         if backend == "local" and remote:
@@ -179,9 +204,11 @@ class LinearProbe:
 
         # Create extractor (lazy loads model)
         # Pass remote flag so large models (e.g., 405B) don't download weights locally
+        _torch_dtype = _resolve_dtype(dtype)
         self._extractor = ActivationExtractor(
             model, device, layers, batch_size,
             auto_candidates=auto_candidates, remote=remote, backend=backend,
+            dtype=_torch_dtype,
         )
         self._cached_extractor = CachedExtractor(self._extractor)
 
@@ -1048,6 +1075,7 @@ class LinearProbe:
             "normalize_layers": self.normalize_layers,
             "fast_auto_top_k": self.fast_auto_top_k,
             "backend": self.backend,
+            "dtype": self.dtype,
             "classifier_": self.classifier_,
             "classes_": self.classes_,
             "selected_layers_": self.selected_layers_,
@@ -1103,6 +1131,7 @@ class LinearProbe:
             normalize_layers=state.get("normalize_layers", True),
             fast_auto_top_k=state.get("fast_auto_top_k"),
             backend=state.get("backend", "nnsight"),
+            dtype=state.get("dtype"),
         )
 
         # Restore original layers spec for reference

--- a/tests/test_backend_acceptance.py
+++ b/tests/test_backend_acceptance.py
@@ -1,0 +1,351 @@
+"""Tests for pluggable extraction backend acceptance criteria.
+
+Maps to GitHub issues #19-22:
+- #19: ExtractionBackend ABC interface defined, all consumption sites use it
+- #20: NnsightBackend wraps existing extraction, caching is backend-agnostic
+- #21: LocalBackend uses AutoModelForCausalLM + register_forward_hook
+- #22: Device/dtype configuration for LocalBackend
+"""
+
+from abc import ABC
+
+import pytest
+import torch
+
+from lmprobe import LinearProbe
+from lmprobe.backends import (
+    ExtractionBackend,
+    LocalBackend,
+    NnsightBackend,
+    _get_decoder_layers,
+    resolve_backend,
+)
+
+# ── Issue #19: ActivationSource interface ────────────────────────────────────
+
+class TestExtractionBackendABC:
+    """Verify ExtractionBackend is a proper ABC with required methods."""
+
+    def test_is_abstract_base_class(self):
+        assert issubclass(ExtractionBackend, ABC)
+
+    def test_cannot_instantiate_directly(self):
+        """ABC should not be directly instantiatable."""
+        with pytest.raises(TypeError, match="abstract"):
+            ExtractionBackend("some-model", "cpu")
+
+    def test_has_extract_batch(self):
+        assert hasattr(ExtractionBackend, "extract_batch")
+        assert getattr(ExtractionBackend.extract_batch, "__isabstractmethod__", False)
+
+    def test_has_extract_batch_with_logits(self):
+        assert hasattr(ExtractionBackend, "extract_batch_with_logits")
+        assert getattr(
+            ExtractionBackend.extract_batch_with_logits,
+            "__isabstractmethod__",
+            False,
+        )
+
+    def test_has_tokenizer_property(self):
+        assert isinstance(
+            ExtractionBackend.tokenizer, property
+        )
+
+    def test_has_model_property(self):
+        assert isinstance(
+            ExtractionBackend.model, property
+        )
+
+    def test_nnsight_implements_interface(self):
+        assert issubclass(NnsightBackend, ExtractionBackend)
+
+    def test_local_implements_interface(self):
+        assert issubclass(LocalBackend, ExtractionBackend)
+
+
+class TestAllConsumptionSitesUseBackend:
+    """Verify that probe pipeline goes through the backend interface."""
+
+    def test_probe_uses_backend(self, tiny_model):
+        """LinearProbe creates an extractor that uses the backend."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            device="cpu",
+            backend="local",
+        )
+        # The extractor should have a backend
+        assert hasattr(probe._extractor, "_backend")
+        assert isinstance(probe._extractor._backend, ExtractionBackend)
+        assert isinstance(probe._extractor._backend, LocalBackend)
+
+    def test_probe_nnsight_backend(self, tiny_model):
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            device="cpu",
+            backend="nnsight",
+        )
+        assert isinstance(probe._extractor._backend, NnsightBackend)
+
+
+# ── Issue #20: NnsightBackend wraps existing extraction ──────────────────────
+
+class TestNnsightBackend:
+    """Verify NnsightBackend properly wraps the existing nnsight code."""
+
+    def test_resolve_nnsight(self, tiny_model):
+        backend = resolve_backend("nnsight", tiny_model, "cpu")
+        assert isinstance(backend, NnsightBackend)
+
+    def test_nnsight_supports_remote_flag(self, tiny_model):
+        backend = resolve_backend("nnsight", tiny_model, "cpu", remote=True)
+        assert isinstance(backend, NnsightBackend)
+        assert backend.remote is True
+
+    def test_nnsight_default_not_remote(self, tiny_model):
+        backend = resolve_backend("nnsight", tiny_model, "cpu")
+        assert backend.remote is False
+
+    def test_nnsight_extract_batch(self, tiny_model):
+        """NnsightBackend.extract_batch produces correct shapes."""
+        backend = resolve_backend("nnsight", tiny_model, "cpu")
+        acts, mask = backend.extract_batch(["Hello world"], [0])
+        assert acts.ndim == 3  # (batch, seq_len, hidden_dim)
+        assert mask.ndim == 2  # (batch, seq_len)
+        assert acts.shape[0] == 1
+
+    def test_nnsight_tokenizer_accessible(self, tiny_model):
+        backend = resolve_backend("nnsight", tiny_model, "cpu")
+        tok = backend.tokenizer
+        assert tok is not None
+        result = tok("test", return_tensors="pt")
+        assert "input_ids" in result
+
+
+class TestCachingIsBackendAgnostic:
+    """Verify that caching works identically for both backends."""
+
+    def test_local_caching(self, tiny_model, tmp_path, monkeypatch):
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+        probe = LinearProbe(
+            model=tiny_model, layers=-1, device="cpu",
+            backend="local", random_state=42,
+        )
+        probe.fit(["positive"], ["negative"])
+        # Cache should have files
+        cache_files = list(tmp_path.rglob("*.pt"))
+        assert len(cache_files) > 0
+
+    def test_nnsight_caching(self, tiny_model, tmp_path, monkeypatch):
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+        probe = LinearProbe(
+            model=tiny_model, layers=-1, device="cpu",
+            backend="nnsight", random_state=42,
+        )
+        probe.fit(["positive"], ["negative"])
+        cache_files = list(tmp_path.rglob("*.pt"))
+        assert len(cache_files) > 0
+
+
+# ── Issue #21: LocalBackend with HuggingFace + hooks ────────────────────────
+
+class TestLocalBackendHooks:
+    """Verify LocalBackend uses AutoModelForCausalLM and register_forward_hook."""
+
+    def test_model_is_hf_pretrained(self, tiny_model):
+        """Model should be a HuggingFace PreTrainedModel."""
+        from transformers import PreTrainedModel
+        backend = LocalBackend(tiny_model, device="cpu")
+        assert isinstance(backend.model, PreTrainedModel)
+
+    def test_decoder_layers_found(self, tiny_model):
+        """_get_decoder_layers finds layers for tiny-random-llama."""
+        backend = LocalBackend(tiny_model, device="cpu")
+        layers = _get_decoder_layers(backend.model)
+        assert len(layers) > 0
+
+    def test_hooks_cleaned_up(self, tiny_model):
+        """After extraction, no hooks remain on the model."""
+        backend = LocalBackend(tiny_model, device="cpu")
+        # Force model load
+        model = backend.model
+        decoder_layers = _get_decoder_layers(model)
+
+        # Count hooks before extraction
+        hooks_before = sum(
+            len(layer._forward_hooks) for layer in decoder_layers
+        )
+
+        # Run extraction
+        backend.extract_batch(["test prompt"], [0])
+
+        # Hooks should be cleaned up
+        hooks_after = sum(
+            len(layer._forward_hooks) for layer in decoder_layers
+        )
+        assert hooks_after == hooks_before
+
+    def test_extract_single_layer(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cpu")
+        acts, mask = backend.extract_batch(["Hello"], [0])
+        assert acts.ndim == 3
+        assert acts.shape[0] == 1
+
+    def test_extract_multiple_layers_concatenates(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cpu")
+        acts_one, _ = backend.extract_batch(["Hello"], [0])
+        acts_two, _ = backend.extract_batch(["Hello"], [0, 1])
+        assert acts_two.shape[-1] == 2 * acts_one.shape[-1]
+
+    def test_logits_extraction(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cpu")
+        acts, mask, logits = backend.extract_batch_with_logits(["Hello"], [0])
+        assert logits.ndim == 3  # (batch, seq_len, vocab_size)
+
+    def test_full_pipeline_local(self, tiny_model):
+        """Full fit/predict/score pipeline with local backend."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            pooling="last_token",
+            classifier="logistic_regression",
+            device="cpu",
+            backend="local",
+            random_state=42,
+        )
+        positive = ["walk", "fetch", "bark", "wag", "good boy"]
+        negative = ["purr", "scratch", "litter", "meow"]
+        probe.fit(positive, negative)
+
+        preds = probe.predict(["arf!", "hiss"])
+        assert preds.shape == (2,)
+
+        probs = probe.predict_proba(["arf!", "hiss"])
+        assert probs.shape == (2, 2)
+
+        acc = probe.score(["arf!", "hiss"], [1, 0])
+        assert 0.0 <= acc <= 1.0
+
+    def test_unrecognized_architecture_raises(self):
+        """_get_decoder_layers raises for unknown architectures."""
+        class FakeModel:
+            pass
+        with pytest.raises(ValueError, match="Could not find decoder layers"):
+            _get_decoder_layers(FakeModel())
+
+    def test_local_remote_incompatible(self, tiny_model):
+        with pytest.raises(ValueError, match="does not support remote"):
+            resolve_backend("local", tiny_model, "cpu", remote=True)
+
+
+# ── Issue #22: Device/dtype configuration ────────────────────────────────────
+
+class TestDeviceConfiguration:
+    """Verify device parameter works for LocalBackend."""
+
+    def test_cpu_device(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cpu")
+        device = next(backend.model.parameters()).device
+        assert device.type == "cpu"
+
+    def test_probe_cpu_device(self, tiny_model):
+        probe = LinearProbe(
+            model=tiny_model, layers=-1, device="cpu", backend="local",
+        )
+        backend = probe._extractor._backend
+        assert isinstance(backend, LocalBackend)
+        device = next(backend.model.parameters()).device
+        assert device.type == "cpu"
+
+
+class TestDtypeConfiguration:
+    """Verify dtype parameter works for LocalBackend."""
+
+    def test_default_dtype_float32(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cpu")
+        param_dtype = next(backend.model.parameters()).dtype
+        assert param_dtype == torch.float32
+
+    def test_explicit_float32(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cpu", dtype=torch.float32)
+        param_dtype = next(backend.model.parameters()).dtype
+        assert param_dtype == torch.float32
+
+    def test_bfloat16_dtype(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cpu", dtype=torch.bfloat16)
+        param_dtype = next(backend.model.parameters()).dtype
+        assert param_dtype == torch.bfloat16
+
+    def test_float16_dtype(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cpu", dtype=torch.float16)
+        param_dtype = next(backend.model.parameters()).dtype
+        assert param_dtype == torch.float16
+
+    def test_dtype_through_resolve_backend(self, tiny_model):
+        backend = resolve_backend(
+            "local", tiny_model, "cpu", dtype=torch.bfloat16
+        )
+        assert isinstance(backend, LocalBackend)
+        assert backend.dtype == torch.bfloat16
+
+    def test_dtype_ignored_for_nnsight(self, tiny_model):
+        """dtype param should not cause errors for nnsight backend."""
+        backend = resolve_backend(
+            "nnsight", tiny_model, "cpu", dtype=torch.bfloat16
+        )
+        assert isinstance(backend, NnsightBackend)
+
+    def test_dtype_through_probe_string(self, tiny_model):
+        """LinearProbe accepts dtype as string."""
+        probe = LinearProbe(
+            model=tiny_model, layers=-1, device="cpu",
+            backend="local", dtype="bfloat16",
+        )
+        backend = probe._extractor._backend
+        assert isinstance(backend, LocalBackend)
+        assert backend.dtype == torch.bfloat16
+
+    def test_invalid_dtype_string(self, tiny_model):
+        with pytest.raises(ValueError, match="Unknown dtype"):
+            LinearProbe(
+                model=tiny_model, layers=-1, device="cpu",
+                backend="local", dtype="invalid",
+            )
+
+    def test_bfloat16_extraction_works(self, tiny_model):
+        """Activations can be extracted with bfloat16 model."""
+        backend = LocalBackend(tiny_model, device="cpu", dtype=torch.bfloat16)
+        acts, mask = backend.extract_batch(["Hello"], [0])
+        assert acts.ndim == 3
+        # Activations should be float (detached from bfloat16 model)
+        assert acts.dtype == torch.bfloat16
+
+    def test_bfloat16_full_pipeline(self, tiny_model):
+        """Full pipeline works with bfloat16 dtype."""
+        probe = LinearProbe(
+            model=tiny_model, layers=-1, pooling="last_token",
+            device="cpu", backend="local", dtype="bfloat16",
+            random_state=42,
+        )
+        probe.fit(
+            ["walk", "fetch", "bark", "wag", "good boy"],
+            ["purr", "scratch", "litter", "meow"],
+        )
+        preds = probe.predict(["arf!", "hiss"])
+        assert preds.shape == (2,)
+
+    def test_save_load_preserves_dtype(self, tiny_model, tmp_path):
+        """Save/load roundtrip preserves dtype setting."""
+        probe = LinearProbe(
+            model=tiny_model, layers=-1, device="cpu",
+            backend="local", dtype="bfloat16", random_state=42,
+        )
+        probe.fit(["positive"], ["negative"])
+
+        path = str(tmp_path / "probe.pkl")
+        probe.save(path)
+
+        loaded = LinearProbe.load(path)
+        assert loaded.dtype == "bfloat16"
+        assert loaded.backend == "local"


### PR DESCRIPTION
## Summary

- Adds configurable `dtype` parameter to `LocalBackend` (closes the one gap from PR #18 — previously hardcoded to `float32`)
- Adds 39 acceptance-criteria tests covering issues #19-#22, verifying the pluggable backend implementation

### dtype support
- `LocalBackend` accepts `dtype` param: `torch.float32`, `torch.float16`, `torch.bfloat16`
- `LinearProbe` accepts dtype as a string: `dtype="bfloat16"`
- Threaded through `resolve_backend()` → `LocalBackend` → `_get_local_model()`
- dtype is part of model cache key so different configs don't collide
- Save/load roundtrip preserves dtype setting

### Acceptance tests (`test_backend_acceptance.py`)
- **Issue #19**: ABC contract, abstract methods, all consumption sites use backend
- **Issue #20**: NnsightBackend wraps extraction, caching is backend-agnostic
- **Issue #21**: LocalBackend uses HF + hooks, hook cleanup, multi-arch, full pipeline
- **Issue #22**: Device config, dtype config (float32/float16/bfloat16), string resolution, save/load

## Test plan

- [x] All 261 existing tests pass (no regressions)
- [x] 39 new acceptance tests pass
- [x] ruff lint clean

Closes #19, closes #20, closes #21, closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)