### PR TITLE
Add CUDA/MPS device tests and clean up orphaned tags

### DIFF
--- a/tests/test_backend_acceptance.py
+++ b/tests/test_backend_acceptance.py
@@ -258,6 +258,29 @@ class TestDeviceConfiguration:
         device = next(backend.model.parameters()).device
         assert device.type == "cpu"
 
+    @pytest.mark.skipif(
+        not torch.cuda.is_available()
+        or not torch.cuda.get_device_capability()[0] >= 7,
+        reason="Compatible CUDA device not available",
+    )
+    def test_cuda_device(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="cuda")
+        device = next(backend.model.parameters()).device
+        assert device.type == "cuda"
+        acts, mask = backend.extract_batch(["Hello"], [0])
+        assert acts.device.type == "cuda"
+
+    @pytest.mark.skipif(
+        not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()),
+        reason="MPS not available",
+    )
+    def test_mps_device(self, tiny_model):
+        backend = LocalBackend(tiny_model, device="mps")
+        device = next(backend.model.parameters()).device
+        assert device.type == "mps"
+        acts, mask = backend.extract_batch(["Hello"], [0])
+        assert acts.device.type == "mps"
+
 
 class TestDtypeConfiguration:
     """Verify dtype parameter works for LocalBackend."""


### PR DESCRIPTION
## Summary

- Adds `pytest.mark.skipif`-guarded CUDA and MPS device tests for issue #22 acceptance criteria
- Cleans up orphaned v0.4.4 and v0.4.5 tags from failed release runs

Also serves as a test of the fixed release pipeline.

## Test plan

- [x] CUDA test skips on incompatible GPU (sm_61 < sm_70)
- [x] MPS test skips on non-Apple hardware
- [x] Both tests will run when compatible hardware is available
- [x] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)