### PR TITLE
Fix release workflow: pull before version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Sync with latest main
+        run: git pull --rebase origin main
+
       - name: Bump patch version
         id: bump
         run: |
@@ -37,7 +40,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --rebase origin main
           git add pyproject.toml
           git commit -m "Bump version to ${{ steps.bump.outputs.version }}"
           git push


### PR DESCRIPTION
## Summary

- Moves `git pull --rebase origin main` to its own step *before* the version bump
- Previously it ran after `pyproject.toml` was already modified, causing `cannot pull with rebase: You have unstaged changes`

## Test plan

- [x] This PR's merge will itself test the fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)