### PR TITLE
Fix BFloat16 activations crashing on .numpy()

### DIFF
--- a/src/lmprobe/baseline.py
+++ b/src/lmprobe/baseline.py
@@ -345,7 +345,7 @@ class BaselineProbe:
         # Load cached prompts
         for i in cached_indices:
             ppl = load_prompt_perplexity(self.model, prompts[i])
-            features[i] = ppl.numpy()
+            features[i] = ppl.float().numpy()
 
         # If all prompts are cached, return early
         if not uncached_prompts:
@@ -402,7 +402,7 @@ class BaselineProbe:
             ppl_tensor = torch.tensor([mean_ppl, min_ppl, max_ppl], dtype=torch.float32)
             save_prompt_perplexity(self.model, prompt, ppl_tensor)
 
-            features[idx] = ppl_tensor.numpy()
+            features[idx] = ppl_tensor.float().numpy()
 
         return features
 

--- a/src/lmprobe/probe.py
+++ b/src/lmprobe/probe.py
@@ -876,7 +876,7 @@ class LinearProbe:
                     self._inference_pooling,
                     attention_mask,
                 )
-                return reduced.numpy()
+                return reduced.float().numpy()
             else:
                 # Return per-token probabilities
                 return probs
@@ -1093,7 +1093,7 @@ class LinearProbe:
     def _to_numpy(X) -> np.ndarray:
         """Convert input to numpy array, handling torch tensors."""
         if isinstance(X, torch.Tensor):
-            return X.detach().cpu().numpy()
+            return X.detach().cpu().float().numpy()
         return np.asarray(X)
 
     def fit_from_activations(

--- a/src/lmprobe/unified_cache.py
+++ b/src/lmprobe/unified_cache.py
@@ -491,6 +491,6 @@ class UnifiedCache:
         features = []
         for prompt in prompts:
             ppl = load_prompt_perplexity(self.model_name, prompt)
-            features.append(ppl.numpy())
+            features.append(ppl.float().numpy())
 
         return np.array(features)


### PR DESCRIPTION
## Summary
- Adds `.float()` before `.numpy()` at 5 locations that were missing the cast, fixing `TypeError: Got unsupported ScalarType BFloat16` when models use `dtype=torch.bfloat16`
- Affected files: `probe.py`, `baseline.py`, `unified_cache.py`

Fixes #30

## Test plan
- [x] All 273 existing tests pass
- [ ] Verify with a bfloat16 model (e.g., BitNet) that the affected code paths no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)