### PR TITLE
Fix: Add missing dtype parameter to UnifiedCache

### DIFF
--- a/src/lmprobe/unified_cache.py
+++ b/src/lmprobe/unified_cache.py
@@ -110,6 +110,9 @@ class UnifiedCache:
         - "mean": Mean of all non-padding tokens
     backend : str, default="local"
         Extraction backend: "local" (default) or "nnsight".
+    dtype : str or None, default=None
+        Model dtype as a string: "float32", "float16", or "bfloat16".
+        If None, defaults to float32 for local backend.
 
     Examples
     --------
@@ -135,6 +138,7 @@ class UnifiedCache:
         cache_pooled: bool = False,
         pooling: str = "last_token",
         backend: str = "local",
+        dtype: str | None = None,
     ):
         self.model_name = model
         self.layers_spec = layers
@@ -145,6 +149,7 @@ class UnifiedCache:
         self.cache_pooled = cache_pooled
         self.pooling = pooling
         self.backend_name = backend
+        self.dtype = dtype
 
         # Validate pooling strategy
         if cache_pooled and pooling not in TRAIN_POOLING_STRATEGIES:
@@ -167,10 +172,29 @@ class UnifiedCache:
     def _resolved_backend(self) -> ExtractionBackend:
         """Get the backend, creating if necessary."""
         if self._backend is None:
+            torch_dtype = self._resolve_dtype(self.dtype)
             self._backend = resolve_backend(
-                self.backend_name, self.model_name, self.device, remote=self.remote
+                self.backend_name, self.model_name, self.device,
+                remote=self.remote, dtype=torch_dtype,
             )
         return self._backend
+
+    @staticmethod
+    def _resolve_dtype(dtype: str | None) -> torch.dtype | None:
+        """Resolve a dtype string to a torch.dtype, or None."""
+        if dtype is None:
+            return None
+        _dtype_map = {
+            "float32": torch.float32,
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+        }
+        if dtype not in _dtype_map:
+            raise ValueError(
+                f"Unknown dtype: {dtype!r}. "
+                f"Available: {list(_dtype_map.keys())}"
+            )
+        return _dtype_map[dtype]
 
     @property
     def model(self):

--- a/tests/test_unified_cache.py
+++ b/tests/test_unified_cache.py
@@ -233,6 +233,49 @@ class TestUnifiedCache:
         assert stats2.activations_extracted == 1
 
 
+    def test_dtype_parameter_passed_to_backend(self, tiny_model, tmp_path, monkeypatch):
+        """dtype parameter is stored and passed through to resolve_backend."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            compute_perplexity=False,
+            device="cpu",
+            remote=False,
+            dtype="float32",
+        )
+
+        assert cache.dtype == "float32"
+
+        # Trigger backend creation and verify it works
+        prompts = ["dtype test prompt"]
+        stats = cache.warmup(prompts)
+        assert stats.activations_extracted == 1
+
+    def test_dtype_none_default(self, tiny_model):
+        """dtype defaults to None when not specified."""
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            device="cpu",
+        )
+        assert cache.dtype is None
+
+    def test_dtype_invalid_raises(self, tiny_model):
+        """Invalid dtype string raises ValueError on backend creation."""
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            device="cpu",
+            dtype="invalid_dtype",
+        )
+        import pytest
+        with pytest.raises(ValueError, match="Unknown dtype"):
+            # Access _resolved_backend to trigger dtype resolution
+            _ = cache._resolved_backend
+
+
 class TestWarmupStats:
     """Tests for WarmupStats dataclass."""
 


### PR DESCRIPTION
## Summary
- Adds `dtype: str | None = None` parameter to `UnifiedCache.__init__`, resolving it to `torch.dtype` and passing it through to `resolve_backend`
- Adds `_resolve_dtype` static method (mirrors the logic in `probe.py`) to convert string dtype specs like `"bfloat16"` to `torch.bfloat16`
- Adds three tests: dtype passthrough, default None behavior, and invalid dtype error handling

Fixes #34

## Test plan
- [x] `test_dtype_parameter_passed_to_backend` — verifies dtype is stored and backend works with explicit dtype
- [x] `test_dtype_none_default` — verifies dtype defaults to None
- [x] `test_dtype_invalid_raises` — verifies invalid dtype string raises ValueError

🤖 Generated with [Claude Code](https://claude.com/claude-code)