### PR TITLE
Add warmup() method to LinearProbe

### DIFF
--- a/src/lmprobe/probe.py
+++ b/src/lmprobe/probe.py
@@ -382,6 +382,29 @@ class LinearProbe:
             # Return attention_mask for later use
             return pooled.detach().cpu().float().numpy(), attention_mask
 
+    def warmup(
+        self,
+        prompts: list[str],
+        remote: bool | None = None,
+    ) -> None:
+        """Extract and cache activations without training a classifier.
+
+        Use this to pre-populate the activation cache for a set of prompts.
+        This is useful when you want to separate the (expensive) activation
+        extraction step from the (cheap) classifier training step, or when
+        you plan to train multiple probes on the same prompts.
+
+        Parameters
+        ----------
+        prompts : list[str]
+            Text prompts to extract and cache activations for.
+        remote : bool | None
+            Override the instance-level remote setting.
+        """
+        self._check_model()
+        use_remote = self._get_remote(remote)
+        self._cached_extractor.extract(prompts, remote=use_remote)
+
     def fit(
         self,
         positive_prompts: list[str],

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,75 @@
+"""Tests for the LinearProbe.warmup() cache warmup API."""
+
+import pytest
+
+from lmprobe import LinearProbe
+
+
+def test_warmup_basic(tiny_model):
+    """warmup() runs without error and populates the cache."""
+    probe = LinearProbe(
+        model=tiny_model,
+        layers=-1,
+        pooling="last_token",
+        device="cpu",
+        remote=False,
+        random_state=42,
+    )
+
+    # Should not raise
+    probe.warmup(["Hello world", "Another prompt"])
+
+
+def test_warmup_then_fit(tiny_model):
+    """Warming up before fit() should work (fit uses cached activations)."""
+    all_prompts = [
+        "Who wants to go for a walk?",
+        "Fetch the ball!",
+        "Purring, stalking, pouncing.",
+        "Uses a litterbox.",
+    ]
+
+    probe = LinearProbe(
+        model=tiny_model,
+        layers=-1,
+        pooling="last_token",
+        device="cpu",
+        remote=False,
+        random_state=42,
+    )
+
+    # Warmup all prompts first
+    probe.warmup(all_prompts)
+
+    # Then fit (should use cached activations)
+    probe.fit(all_prompts[:2], all_prompts[2:])
+
+    predictions = probe.predict(["test input"])
+    assert predictions.shape == (1,)
+
+
+def test_warmup_requires_model():
+    """warmup() should raise ValueError when no model is set."""
+    probe = LinearProbe(
+        model=None,
+        layers=-1,
+        random_state=42,
+    )
+
+    with pytest.raises(ValueError, match="No model specified"):
+        probe.warmup(["test prompt"])
+
+
+def test_warmup_returns_none(tiny_model):
+    """warmup() should return None."""
+    probe = LinearProbe(
+        model=tiny_model,
+        layers=-1,
+        pooling="last_token",
+        device="cpu",
+        remote=False,
+        random_state=42,
+    )
+
+    result = probe.warmup(["Hello world"])
+    assert result is None


### PR DESCRIPTION
## Summary

- Adds a `warmup()` instance method to `LinearProbe` that extracts and caches activations without training a classifier
- Enables users to separate the expensive activation extraction step from the cheap classifier training step
- Useful when training multiple probes on the same set of prompts

## Usage

```python
probe = LinearProbe(model=model_id, layers="all", ...)
probe.warmup(all_texts)           # extract & cache only
probe.fit(positive, negative)     # trains classifier using cached activations
```

## Implementation

The method is straightforward: it calls `self._cached_extractor.extract()` which handles all caching logic, then discards the returned activations. It validates that a model is configured via `_check_model()` and supports the `remote` override parameter.

## Test plan

- [x] `test_warmup_basic` - warmup runs without error
- [x] `test_warmup_then_fit` - warmup followed by fit/predict works end-to-end
- [x] `test_warmup_requires_model` - raises ValueError when no model is set
- [x] `test_warmup_returns_none` - returns None (no side-effect return value)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)