### PR TITLE
Fix 4 model card issues (#57, #58, #59, #61)

### DIFF
--- a/src/lmprobe/hub.py
+++ b/src/lmprobe/hub.py
@@ -344,12 +344,40 @@ def _build_training_info(
     return info
 
 
+def _format_layers(probe_cfg: dict) -> str:
+    """Format layers for display in the model card.
+
+    Uses the original spec (e.g., "all", "middle") when available,
+    with resolved count. Falls back to the raw list for short lists.
+    """
+    layers = probe_cfg.get("layers")
+    spec = probe_cfg.get("layers_spec_original")
+
+    # If the original spec is a named string like "all", "middle", "fast_auto"
+    if isinstance(spec, str) and layers is not None and isinstance(layers, list):
+        first = min(layers)
+        last = max(layers)
+        n = len(layers)
+        return f"{spec} ({first}\u2013{last}, {n} layers)"
+
+    # Short list or single layer — just show it directly
+    if isinstance(layers, list) and len(layers) > 10:
+        first = min(layers)
+        last = max(layers)
+        n = len(layers)
+        return f"[{first}\u2013{last}] ({n} layers)"
+
+    return str(layers)
+
+
 def _render_model_card(
     config: dict,
     training_info: dict,
+    repo_id: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
     license: str = "mit",
+    limitations: str | None = None,
 ) -> str:
     """Generate a HuggingFace model card README.md.
 
@@ -359,12 +387,16 @@ def _render_model_card(
         probe_config.json contents.
     training_info : dict
         training_info.json contents.
+    repo_id : str | None
+        Repository ID for the usage example.
     description : str | None
         Human-readable description of what the probe detects.
     tags : list[str] | None
         Additional tags for discoverability.
     license : str
         License identifier.
+    limitations : str | None
+        Limitations and intended use text. If None, the section is omitted.
 
     Returns
     -------
@@ -428,7 +460,8 @@ def _render_model_card(
     body_lines.append("```python")
     body_lines.append("from lmprobe import LinearProbe")
     body_lines.append("")
-    body_lines.append('probe = LinearProbe.from_hub("REPO_ID", trust_classifier=True)')
+    usage_repo = repo_id if repo_id else "REPO_ID"
+    body_lines.append(f'probe = LinearProbe.from_hub("{usage_repo}", trust_classifier=True)')
     body_lines.append('predictions = probe.predict(["your text here"])')
     body_lines.append("```")
     body_lines.append("")
@@ -440,7 +473,7 @@ def _render_model_card(
     body_lines.append(f"- **Base model**: `{base_model}`")
     if config["base_model"].get("revision"):
         body_lines.append(f"- **Model revision**: `{config['base_model']['revision']}`")
-    body_lines.append(f"- **Layers**: {probe_cfg['layers']}")
+    body_lines.append(f"- **Layers**: {_format_layers(probe_cfg)}")
     body_lines.append(f"- **Pooling**: {probe_cfg['pooling']}")
     body_lines.append(f"- **Classifier**: {probe_cfg['classifier_type']}")
     body_lines.append(f"- **Task**: {probe_cfg['task']}")
@@ -480,6 +513,20 @@ def _render_model_card(
             body_lines.append(f"- **Negative hash**: `{training_data['negative_hash']}`")
         body_lines.append("")
 
+    # Evaluation data hash (issue #61)
+    if evaluation:
+        eval_hash = evaluation.get("eval_hash")
+        eval_size = evaluation.get("eval_set_size")
+        if eval_hash or eval_size:
+            if not training_data:
+                body_lines.append("## Evaluation Data")
+                body_lines.append("")
+            if eval_size:
+                body_lines.append(f"- **Evaluation samples**: {eval_size}")
+            if eval_hash:
+                body_lines.append(f"- **Evaluation hash**: `{eval_hash}`")
+            body_lines.append("")
+
     # Reproducibility
     env = training_info.get("training_environment", {})
     body_lines.append("## Reproducibility")
@@ -491,11 +538,12 @@ def _render_model_card(
     body_lines.append(f"- **transformers**: {env.get('transformers_version', 'unknown')}")
     body_lines.append("")
 
-    # Limitations
-    body_lines.append("## Limitations and Intended Use")
-    body_lines.append("")
-    body_lines.append("*Please fill in limitations and intended use for this probe.*")
-    body_lines.append("")
+    # Limitations (only if provided)
+    if limitations:
+        body_lines.append("## Limitations and Intended Use")
+        body_lines.append("")
+        body_lines.append(limitations)
+        body_lines.append("")
 
     return "\n".join(yaml_lines) + "\n".join(body_lines) + "\n"
 
@@ -512,6 +560,7 @@ def push_to_hub(
     private: bool = False,
     license: str = "mit",
     commit_message: str = "Upload lmprobe probe",
+    limitations: str | None = None,
 ) -> str:
     """Push a fitted probe to the HuggingFace Hub.
 
@@ -539,6 +588,9 @@ def push_to_hub(
         License identifier.
     commit_message : str
         Git commit message for the upload.
+    limitations : str | None
+        Limitations and intended use text for the model card.
+        If None, the section is omitted.
 
     Returns
     -------
@@ -583,9 +635,11 @@ def push_to_hub(
         # Render model card
         card = _render_model_card(
             config, training_info,
+            repo_id=repo_id,
             description=description,
             tags=tags,
             license=license,
+            limitations=limitations,
         )
         with open(tmpdir / "README.md", "w") as f:
             f.write(card)

--- a/src/lmprobe/probe.py
+++ b/src/lmprobe/probe.py
@@ -1207,6 +1207,7 @@ class LinearProbe:
         private: bool = False,
         license: str = "mit",
         commit_message: str = "Upload lmprobe probe",
+        limitations: str | None = None,
     ) -> str:
         """Push this fitted probe to the HuggingFace Hub.
 
@@ -1232,6 +1233,9 @@ class LinearProbe:
             License identifier.
         commit_message : str
             Git commit message for the upload.
+        limitations : str | None
+            Limitations and intended use text for the model card.
+            If None, the section is omitted.
 
         Returns
         -------
@@ -1252,6 +1256,7 @@ class LinearProbe:
             private=private,
             license=license,
             commit_message=commit_message,
+            limitations=limitations,
         )
 
     @classmethod

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -296,6 +296,91 @@ class TestRenderModelCard:
         assert "0.9800" in card
 
 
+    def test_model_card_uses_repo_id_in_usage(self, fitted_probe):
+        """Issue #57: usage example should show actual repo_id, not placeholder."""
+        from lmprobe.hub import _build_probe_config, _build_training_info, _render_model_card
+
+        config = _build_probe_config(fitted_probe)
+        config["probe"]["serialization_format"] = "skops"
+        info = _build_training_info(fitted_probe)
+        card = _render_model_card(
+            config, info, repo_id="latent-lab/my-probe"
+        )
+
+        assert 'from_hub("latent-lab/my-probe"' in card
+        assert "REPO_ID" not in card
+
+    def test_model_card_fallback_repo_id(self, fitted_probe):
+        """When repo_id is not provided, falls back to REPO_ID placeholder."""
+        from lmprobe.hub import _build_probe_config, _build_training_info, _render_model_card
+
+        config = _build_probe_config(fitted_probe)
+        config["probe"]["serialization_format"] = "skops"
+        info = _build_training_info(fitted_probe)
+        card = _render_model_card(config, info)
+
+        assert "REPO_ID" in card
+
+    def test_model_card_omits_limitations_by_default(self, fitted_probe):
+        """Issue #58: no placeholder limitations text when not provided."""
+        from lmprobe.hub import _build_probe_config, _build_training_info, _render_model_card
+
+        config = _build_probe_config(fitted_probe)
+        config["probe"]["serialization_format"] = "skops"
+        info = _build_training_info(fitted_probe)
+        card = _render_model_card(config, info)
+
+        assert "Limitations and Intended Use" not in card
+        assert "Please fill in" not in card
+
+    def test_model_card_with_limitations(self, fitted_probe):
+        """Issue #58: limitations text renders when provided."""
+        from lmprobe.hub import _build_probe_config, _build_training_info, _render_model_card
+
+        config = _build_probe_config(fitted_probe)
+        config["probe"]["serialization_format"] = "skops"
+        info = _build_training_info(fitted_probe)
+        card = _render_model_card(
+            config, info, limitations="Not suitable for production use."
+        )
+
+        assert "## Limitations and Intended Use" in card
+        assert "Not suitable for production use." in card
+
+    def test_model_card_compact_layers_for_named_spec(self, fitted_probe):
+        """Issue #59: named layer specs show compact format."""
+        from lmprobe.hub import _build_probe_config, _build_training_info, _render_model_card
+
+        config = _build_probe_config(fitted_probe)
+        config["probe"]["serialization_format"] = "skops"
+        # Simulate "all" spec with many layers
+        config["probe"]["layers_spec_original"] = "all"
+        config["probe"]["layers"] = list(range(30))
+        info = _build_training_info(fitted_probe)
+        card = _render_model_card(config, info)
+
+        assert "all (0\u201329, 30 layers)" in card
+        # Should NOT contain the full list
+        assert "[0, 1, 2, 3," not in card
+
+    def test_model_card_eval_hash(self, fitted_probe):
+        """Issue #61: eval hash and size shown in model card."""
+        from lmprobe.hub import _build_probe_config, _build_training_info, _render_model_card
+
+        config = _build_probe_config(fitted_probe)
+        config["probe"]["serialization_format"] = "skops"
+        metrics = {
+            "accuracy": 0.95,
+            "n_eval": 300,
+            "eval_hash": "sha256:abc123",
+        }
+        info = _build_training_info(fitted_probe, metrics=metrics)
+        card = _render_model_card(config, info)
+
+        assert "**Evaluation samples**: 300" in card
+        assert "**Evaluation hash**: `sha256:abc123`" in card
+
+
 class TestSerializationRoundtrip:
     """Test classifier serialization and deserialization."""
 


### PR DESCRIPTION
## Summary

- **#57**: Usage example now shows actual `repo_id` instead of hardcoded `"REPO_ID"` placeholder
- **#58**: `limitations` parameter added to `push_to_hub()`; section omitted entirely when not provided (no more placeholder text)
- **#59**: Named layer specs (e.g., `"all"`, `"middle"`) render compactly as `all (0–29, 30 layers)` instead of dumping the full index list
- **#61**: Evaluation data hash and sample count surfaced in the model card when available

Closes #57, closes #58, closes #59, closes #61

## Test plan

- [x] 6 new tests added covering all 4 fixes
- [x] All 44 hub tests pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)