### PR TITLE
Fast-fail on CUDA compute capability mismatch

### DIFF
--- a/src/lmprobe/_device_utils.py
+++ b/src/lmprobe/_device_utils.py
@@ -1,0 +1,65 @@
+"""Internal utilities for device validation."""
+
+from __future__ import annotations
+
+import torch
+
+
+def check_cuda_compatibility(device: str) -> None:
+    """Check CUDA compute capability before loading a model.
+
+    Raises a clear error if the requested CUDA device has a compute
+    capability that is too low for the installed PyTorch build.
+
+    Parameters
+    ----------
+    device : str
+        Device specification ("auto", "cpu", "cuda", "cuda:0", etc.).
+        Only performs checks when a CUDA device is explicitly requested.
+    """
+    # Only check when user explicitly requests CUDA
+    if not device.startswith("cuda"):
+        return
+
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            f"device='{device}' was requested, but CUDA is not available. "
+            "Use device='cpu' or device='auto'."
+        )
+
+    # Parse device index
+    if ":" in device:
+        try:
+            device_idx = int(device.split(":")[1])
+        except (ValueError, IndexError):
+            return  # Let PyTorch handle malformed device strings
+    else:
+        device_idx = 0
+
+    if device_idx >= torch.cuda.device_count():
+        raise RuntimeError(
+            f"device='{device}' was requested, but only "
+            f"{torch.cuda.device_count()} CUDA device(s) are available."
+        )
+
+    capability = torch.cuda.get_device_capability(device_idx)
+    gpu_name = torch.cuda.get_device_name(device_idx)
+    sm = capability[0] * 10 + capability[1]
+
+    # PyTorch wheels from pip typically require sm_70+ (Volta and newer).
+    # The exact minimum depends on the PyTorch build, but sm_70 is the
+    # most common cutoff for recent PyTorch versions.
+    # We check by attempting a small tensor operation on the device.
+    try:
+        t = torch.tensor([1.0], device=device)
+        _ = t + t
+        del t
+    except RuntimeError as e:
+        if "no kernel image" in str(e).lower():
+            raise RuntimeError(
+                f"GPU '{gpu_name}' (compute capability {capability[0]}.{capability[1]}, sm_{sm}) "
+                f"is not supported by this PyTorch build. "
+                f"Use device='cpu', device='auto', or install a PyTorch version "
+                f"compatible with your GPU."
+            ) from e
+        raise

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -249,6 +249,10 @@ def _get_local_model(
     """
     cache_key = (model_name, device, dtype)
     if cache_key not in _LOCAL_MODEL_CACHE:
+        from lmprobe._device_utils import check_cuda_compatibility
+
+        check_cuda_compatibility(device)
+
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         tokenizer = AutoTokenizer.from_pretrained(model_name)

--- a/src/lmprobe/extraction.py
+++ b/src/lmprobe/extraction.py
@@ -333,6 +333,11 @@ def load_model(
         # See: https://nnsight.net/notebooks/features/remote_execution/
         model = LM(model_name, dispatch=False)
     else:
+        # Fast-fail on CUDA compute capability mismatch
+        from lmprobe._device_utils import check_cuda_compatibility
+
+        check_cuda_compatibility(device)
+
         # Local execution - load weights to specified device
         if device == "auto":
             device_map = "auto"

--- a/tests/test_device_utils.py
+++ b/tests/test_device_utils.py
@@ -1,0 +1,60 @@
+"""Tests for CUDA compute capability early detection."""
+
+from unittest.mock import patch
+
+import pytest
+
+from lmprobe._device_utils import check_cuda_compatibility
+
+
+class TestCheckCudaCompatibility:
+    """Tests for check_cuda_compatibility."""
+
+    def test_cpu_device_skips_check(self):
+        """No error raised for CPU device."""
+        check_cuda_compatibility("cpu")
+
+    def test_auto_device_skips_check(self):
+        """No error raised for auto device."""
+        check_cuda_compatibility("auto")
+
+    @patch("lmprobe._device_utils.torch")
+    def test_cuda_not_available(self, mock_torch):
+        """Clear error when CUDA is requested but not available."""
+        mock_torch.cuda.is_available.return_value = False
+        with pytest.raises(RuntimeError, match="CUDA is not available"):
+            check_cuda_compatibility("cuda")
+
+    @patch("lmprobe._device_utils.torch")
+    def test_cuda_device_index_out_of_range(self, mock_torch):
+        """Clear error when requested device index exceeds available devices."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.device_count.return_value = 1
+        with pytest.raises(RuntimeError, match="only 1 CUDA device"):
+            check_cuda_compatibility("cuda:2")
+
+    @patch("lmprobe._device_utils.torch")
+    def test_incompatible_compute_capability(self, mock_torch):
+        """Clear error on compute capability mismatch (no kernel image)."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.device_count.return_value = 1
+        mock_torch.cuda.get_device_capability.return_value = (6, 1)
+        mock_torch.cuda.get_device_name.return_value = "NVIDIA GeForce GTX 1060"
+        mock_torch.tensor.side_effect = RuntimeError(
+            "no kernel image is available for execution on the device"
+        )
+        with pytest.raises(
+            RuntimeError, match="GTX 1060.*sm_61.*not supported by this PyTorch build"
+        ):
+            check_cuda_compatibility("cuda")
+
+    @patch("lmprobe._device_utils.torch")
+    def test_compatible_cuda_passes(self, mock_torch):
+        """No error when CUDA device is compatible."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.device_count.return_value = 1
+        mock_torch.cuda.get_device_capability.return_value = (8, 0)
+        mock_torch.cuda.get_device_name.return_value = "NVIDIA A100"
+        mock_tensor = mock_torch.tensor.return_value
+        mock_tensor.__add__ = lambda self, other: self
+        check_cuda_compatibility("cuda:0")


### PR DESCRIPTION
## Summary
- Adds early CUDA compute capability check before model loading, so users get a clear error instead of a raw kernel crash deep in the forward pass
- Covers both model-loading backends (`extraction.py` nnsight path, `backends.py` local transformers path)
- Includes 6 unit tests covering: CPU/auto skip, CUDA unavailable, device index OOB, incompatible GPU, and compatible GPU

Closes #64

## Test plan
- [x] All 356 existing tests pass
- [x] 6 new `test_device_utils.py` tests pass
- [ ] Manual verification on a machine with an incompatible GPU (e.g., GTX 1060)

🤖 Generated with [Claude Code](https://claude.com/claude-code)