### PR TITLE
Add S3 cache backend for sharing activations across machines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,15 @@ nnsight = [
 remote = [
     "nnsight>=0.6,<0.6.2",
 ]
+s3 = [
+    "boto3>=1.26",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "ruff>=0.1",
     "black>=23.0",
+    "moto[s3]>=5.0",
 ]
 auto = [
     "skglm>=0.3",

--- a/src/lmprobe/__init__.py
+++ b/src/lmprobe/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "enable_cache_logging",
     "plot_layer_importance",
     "plot_layer_importance_heatmap",
+    "set_cache_backend",
     "set_cache_dtype",
     "set_cache_limit",
     "set_max_threads",
@@ -94,11 +95,15 @@ def __getattr__(name: str):
         from .cache import enable_cache_logging
 
         return enable_cache_logging
-    if name in ("cache_info", "CacheInfo", "ModelCacheInfo", "set_cache_limit", "set_cache_dtype"):
+    if name in (
+        "cache_info", "CacheInfo", "ModelCacheInfo",
+        "set_cache_backend", "set_cache_limit", "set_cache_dtype",
+    ):
         from .cache import (
             CacheInfo,
             ModelCacheInfo,
             cache_info,
+            set_cache_backend,
             set_cache_dtype,
             set_cache_limit,
         )
@@ -107,6 +112,7 @@ def __getattr__(name: str):
             "cache_info": cache_info,
             "CacheInfo": CacheInfo,
             "ModelCacheInfo": ModelCacheInfo,
+            "set_cache_backend": set_cache_backend,
             "set_cache_limit": set_cache_limit,
             "set_cache_dtype": set_cache_dtype,
         }[name]

--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -12,7 +12,7 @@ Keys in safetensors file:
     pooled_{strategy}_layer_{i}      Pooled: (1, hidden_dim)
     perplexity                       Features: (3,)
 
-Legacy format v1 (read-only, for backward compat):
+Legacy format v1 (read-only, for backward compat, local backend only):
     {model_hash}/{prompt_hash}/
       layer_{i}.pt
       attention_mask.pt
@@ -20,12 +20,13 @@ Legacy format v1 (read-only, for backward compat):
       perplexity.pt
 
 Features:
+    - Pluggable cache backends (local filesystem, S3)
     - Disk-full error handling (#44)
     - Pool-then-cache default (#45, applied in UnifiedCache)
     - float16 cache storage (#46) via LMPROBE_CACHE_DTYPE
     - Single safetensors file per prompt (#47)
     - cache_info() reporting (#48)
-    - LRU eviction (#49) via LMPROBE_CACHE_MAX_GB
+    - LRU eviction (#49) via LMPROBE_CACHE_MAX_GB (local backend only)
 """
 
 from __future__ import annotations
@@ -39,6 +40,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import torch
+
+from .cache_backends import CacheBackend, LocalCacheBackend
 
 # =============================================================================
 # Logging
@@ -142,6 +145,84 @@ def set_cache_dtype(dtype: str | None = None) -> None:
 
 
 # =============================================================================
+# Backend management
+# =============================================================================
+
+_backend: CacheBackend | None = None
+
+
+def _parse_backend_uri(uri: str) -> CacheBackend:
+    """Parse a backend URI string into a CacheBackend instance.
+
+    Supported schemes:
+    - ``s3://bucket/prefix`` → S3CacheBackend
+    - Local filesystem path → LocalCacheBackend
+    """
+    if uri.startswith("s3://"):
+        from .cache_backends import S3CacheBackend
+
+        # Parse s3://bucket/prefix
+        rest = uri[5:]  # strip "s3://"
+        parts = rest.split("/", 1)
+        bucket = parts[0]
+        prefix = parts[1] if len(parts) > 1 else ""
+        return S3CacheBackend(bucket=bucket, prefix=prefix)
+    elif uri.startswith("gs://") or uri.startswith("gcs://"):
+        raise ValueError(
+            f"Unsupported cache backend URI scheme: {uri!r}. "
+            "Only 's3://' and local filesystem paths are supported."
+        )
+    else:
+        # Treat as local filesystem path
+        return LocalCacheBackend(Path(uri))
+
+
+def get_backend() -> CacheBackend:
+    """Get the active cache backend, initializing from env vars if needed."""
+    global _backend
+    if _backend is not None:
+        return _backend
+
+    # Check LMPROBE_CACHE_BACKEND env var first
+    env_backend = os.getenv("LMPROBE_CACHE_BACKEND")
+    if env_backend:
+        _backend = _parse_backend_uri(env_backend)
+        return _backend
+
+    # Default: local filesystem backend using LMPROBE_CACHE_DIR
+    _backend = LocalCacheBackend(get_cache_dir())
+    return _backend
+
+
+def set_cache_backend(backend: CacheBackend | str | None) -> None:
+    """Set the cache storage backend.
+
+    Parameters
+    ----------
+    backend : CacheBackend | str | None
+        - A CacheBackend instance
+        - A URI string (e.g. "s3://bucket/prefix" or "/path/to/cache")
+        - None to reset to default (lazy re-initialization)
+    """
+    global _backend
+    if backend is None:
+        _backend = None
+    elif isinstance(backend, str):
+        _backend = _parse_backend_uri(backend)
+    elif isinstance(backend, CacheBackend):
+        _backend = backend
+    else:
+        raise TypeError(
+            f"Expected CacheBackend, str, or None, got {type(backend).__name__}"
+        )
+
+
+def _is_local_backend() -> bool:
+    """Check if the current backend is a local filesystem backend."""
+    return isinstance(get_backend(), LocalCacheBackend)
+
+
+# =============================================================================
 # Helpers
 # =============================================================================
 
@@ -218,6 +299,24 @@ def _parse_pooled_layer_keys(keys: set[str] | list[str], pooling: str) -> set[in
 
 
 # =============================================================================
+# Backend key helpers
+# =============================================================================
+
+
+def _prompt_cache_key(model_name: str, prompt: str) -> str:
+    """Get the backend key for a prompt's safetensors file."""
+    model_hash = _hash_string(model_name)
+    prompt_hash = _hash_string(prompt)
+    return f"{model_hash}/{prompt_hash}.safetensors"
+
+
+def _model_name_key(model_name: str) -> str:
+    """Get the backend key for the model name text file."""
+    model_hash = _hash_string(model_name)
+    return f"{model_hash}/_model_name.txt"
+
+
+# =============================================================================
 # Safe I/O (#44 disk-full handling, #46 dtype, #47 safetensors)
 # =============================================================================
 
@@ -230,6 +329,121 @@ def _prepare_tensor(tensor: torch.Tensor) -> torch.Tensor:
     return t
 
 
+def _save_tensors_to_backend(key: str, tensors: dict[str, torch.Tensor]) -> None:
+    """Save tensors to the backend as safetensors bytes."""
+    from safetensors.torch import save
+
+    if _CACHE_MAX_BYTES == -1:
+        return  # Caching disabled
+
+    backend = get_backend()
+    data = save(tensors)
+
+    try:
+        backend.write_bytes(key, data)
+    except OSError as e:
+        err = str(e)
+        if "No space left" in err or "iostream error" in err or "enforce fail" in err:
+            raise OSError(
+                f"Disk full: could not write cache entry {key}. "
+                f"Free up disk space or set LMPROBE_CACHE_MAX_GB to limit cache size."
+            ) from e
+        raise
+
+    # Run LRU eviction after successful write (local backend only)
+    _maybe_evict()
+
+
+def _load_tensors_from_backend(
+    key: str, tensor_keys: list[str] | None = None
+) -> dict[str, torch.Tensor]:
+    """Load tensors from the backend.
+
+    For LocalCacheBackend, uses safe_open for memory-mapped selective loading.
+    For other backends, loads the full file from bytes.
+    """
+    backend = get_backend()
+
+    if isinstance(backend, LocalCacheBackend):
+        # Use safe_open for memory-mapped access on local files
+        from safetensors import safe_open
+
+        path = str(backend._path(key))
+        result = {}
+        with safe_open(path, framework="pt") as f:
+            available = set(f.keys())
+            if tensor_keys is None:
+                for k in available:
+                    result[k] = f.get_tensor(k)
+            else:
+                for k in tensor_keys:
+                    if k not in available:
+                        raise KeyError(
+                            f"Corrupted or incomplete cache entry {key}: "
+                            f"missing key {k!r}. Available keys: {sorted(available)}. "
+                            f"Delete this entry and re-run to rebuild the cache."
+                        )
+                    result[k] = f.get_tensor(k)
+        return result
+    else:
+        # Load full bytes for non-local backends
+        from safetensors.torch import load
+
+        data = backend.read_bytes(key)
+        all_tensors = load(data)
+        if tensor_keys is None:
+            return all_tensors
+        result = {}
+        for k in tensor_keys:
+            if k not in all_tensors:
+                raise KeyError(
+                    f"Corrupted or incomplete cache entry {key}: "
+                    f"missing key {k!r}. Available keys: {sorted(all_tensors.keys())}. "
+                    f"Delete this entry and re-run to rebuild the cache."
+                )
+            result[k] = all_tensors[k]
+        return result
+
+
+def _get_tensor_keys_from_backend(key: str) -> set[str]:
+    """Get tensor key names from a backend entry without loading data."""
+    backend = get_backend()
+
+    if isinstance(backend, LocalCacheBackend):
+        from safetensors import safe_open
+
+        path = str(backend._path(key))
+        with safe_open(path, framework="pt") as f:
+            return set(f.keys())
+    else:
+        from safetensors.torch import load
+
+        data = backend.read_bytes(key)
+        return set(load(data).keys())
+
+
+def _merge_save_backend(key: str, new_tensors: dict[str, torch.Tensor]) -> None:
+    """Load existing entry, merge with new tensors, and save."""
+    backend = get_backend()
+
+    if isinstance(backend, LocalCacheBackend):
+        # For local backend, use the original _merge_save path which
+        # provides atomic writes via temp file + rename
+        path = backend._path(key)
+        existing = _load_sf_all(path) if path.exists() else {}
+        existing.update(new_tensors)
+        _safe_save_file(existing, path)
+    else:
+        # For non-local backends (S3 etc.), use bytes-level I/O
+        if backend.exists(key):
+            existing = _load_tensors_from_backend(key)
+        else:
+            existing = {}
+        existing.update(new_tensors)
+        _save_tensors_to_backend(key, existing)
+
+
+# Keep legacy functions for backward compatibility (used by tests and v1 paths)
 def _safe_save_file(tensors: dict[str, torch.Tensor], path: Path) -> None:
     """Atomically save tensors to safetensors with disk-full error handling (#44).
 
@@ -340,13 +554,10 @@ def get_prompt_cache_path(model_name: str, prompt: str) -> Path:
 
 def _register_model(model_name: str) -> None:
     """Record model hash -> name mapping for cache_info()."""
-    base = get_cache_dir()
-    model_hash = _hash_string(model_name)
-    model_dir = base / model_hash
-    model_dir.mkdir(parents=True, exist_ok=True)
-    name_file = model_dir / "_model_name.txt"
-    if not name_file.exists():
-        name_file.write_text(model_name)
+    backend = get_backend()
+    key = _model_name_key(model_name)
+    if not backend.exists(key):
+        backend.write_text(key, model_name)
 
 
 def _read_model_name(model_dir: Path) -> str | None:
@@ -367,13 +578,28 @@ def get_prompt_cached_layers(cache_dir: Path) -> set[int]:
 
     Checks v2 safetensors format first, then v1 .pt format.
     """
-    # v2: check safetensors file (sibling of the directory path)
-    sf_path = cache_dir.with_suffix(".safetensors")
-    if sf_path.exists():
-        keys = _load_sf_keys(sf_path)
-        return _parse_raw_layer_keys(keys)
+    backend = get_backend()
 
-    # v1: check .pt files in directory
+    # v2: check via backend
+    # Derive the key from the cache_dir path
+    sf_path = cache_dir.with_suffix(".safetensors")
+    if isinstance(backend, LocalCacheBackend):
+        # For local backend, check if safetensors file exists via Path
+        if sf_path.exists():
+            keys = _load_sf_keys(sf_path)
+            return _parse_raw_layer_keys(keys)
+    else:
+        # For non-local, compute key from model/prompt hashes
+        try:
+            rel = sf_path.relative_to(get_cache_dir())
+            key = str(rel)
+            if backend.exists(key):
+                tensor_keys = _get_tensor_keys_from_backend(key)
+                return _parse_raw_layer_keys(tensor_keys)
+        except ValueError:
+            pass
+
+    # v1: check .pt files in directory (local only)
     if not cache_dir.exists():
         return set()
     cached = set()
@@ -389,19 +615,24 @@ def is_prompt_fully_cached(
     model_name: str, prompt: str, required_layers: set[int]
 ) -> bool:
     """Check if a prompt has all required raw layers cached."""
-    # v2
-    sf_path = get_prompt_cache_path(model_name, prompt)
-    if sf_path.exists():
-        keys = _load_sf_keys(sf_path)
-        cached = _parse_raw_layer_keys(keys)
-        has_mask = _ATTENTION_MASK_KEY in keys
+    backend = get_backend()
+    key = _prompt_cache_key(model_name, prompt)
+
+    # v2: check via backend
+    if backend.exists(key):
+        tensor_keys = _get_tensor_keys_from_backend(key)
+        cached = _parse_raw_layer_keys(tensor_keys)
+        has_mask = _ATTENTION_MASK_KEY in tensor_keys
         return required_layers.issubset(cached) and has_mask
 
-    # v1
-    cache_dir = get_prompt_cache_dir(model_name, prompt)
-    cached = get_prompt_cached_layers(cache_dir)
-    has_mask = (cache_dir / "attention_mask.pt").exists()
-    return required_layers.issubset(cached) and has_mask
+    # v1 fallback (local only)
+    if isinstance(backend, LocalCacheBackend):
+        cache_dir = get_prompt_cache_dir(model_name, prompt)
+        cached = get_prompt_cached_layers(cache_dir)
+        has_mask = (cache_dir / "attention_mask.pt").exists()
+        return required_layers.issubset(cached) and has_mask
+
+    return False
 
 
 def load_prompt_activations(
@@ -411,25 +642,30 @@ def load_prompt_activations(
 
     Returns (activations, attention_mask). Checks v2 then v1.
     """
-    sf_path = get_prompt_cache_path(model_name, prompt)
-    if sf_path.exists():
+    backend = get_backend()
+    key = _prompt_cache_key(model_name, prompt)
+
+    if backend.exists(key):
         # Touch for LRU
-        os.utime(sf_path)
+        backend.touch(key)
         keys_to_load = [_raw_layer_key(li) for li in layers] + [_ATTENTION_MASK_KEY]
-        tensors = _load_sf_tensors(sf_path, keys_to_load)
+        tensors = _load_tensors_from_backend(key, keys_to_load)
         layer_acts = [tensors[_raw_layer_key(li)] for li in layers]
         activations = torch.cat(layer_acts, dim=-1)
         return activations, tensors[_ATTENTION_MASK_KEY]
 
-    # v1 fallback
-    cache_dir = get_prompt_cache_dir(model_name, prompt)
-    layer_acts = []
-    for layer in layers:
-        acts = torch.load(cache_dir / f"layer_{layer}.pt", weights_only=True)
-        layer_acts.append(acts)
-    activations = torch.cat(layer_acts, dim=-1)
-    mask = torch.load(cache_dir / "attention_mask.pt", weights_only=True)
-    return activations, mask
+    # v1 fallback (local only)
+    if isinstance(backend, LocalCacheBackend):
+        cache_dir = get_prompt_cache_dir(model_name, prompt)
+        layer_acts = []
+        for layer in layers:
+            acts = torch.load(cache_dir / f"layer_{layer}.pt", weights_only=True)
+            layer_acts.append(acts)
+        activations = torch.cat(layer_acts, dim=-1)
+        mask = torch.load(cache_dir / "attention_mask.pt", weights_only=True)
+        return activations, mask
+
+    raise FileNotFoundError(f"No cached activations found for prompt: {prompt!r}")
 
 
 def save_prompt_activations(
@@ -441,7 +677,7 @@ def save_prompt_activations(
 ) -> None:
     """Save raw activations for a single prompt (v2 safetensors format)."""
     _register_model(model_name)
-    sf_path = get_prompt_cache_path(model_name, prompt)
+    key = _prompt_cache_key(model_name, prompt)
 
     n_layers = len(layers)
     hidden_dim = activations.shape[-1] // n_layers
@@ -453,33 +689,50 @@ def save_prompt_activations(
         new_tensors[_raw_layer_key(layer)] = _prepare_tensor(activations[..., start:end])
     new_tensors[_ATTENTION_MASK_KEY] = attention_mask.detach().cpu().contiguous()
 
-    _merge_save(sf_path, new_tensors)
+    _merge_save_backend(key, new_tensors)
 
-    # Clean up v1 directory if it exists (migrate on write)
-    old_dir = get_prompt_cache_dir(model_name, prompt)
-    if old_dir.is_dir():
-        shutil.rmtree(old_dir)
+    # Clean up v1 directory if it exists (migrate on write, local only)
+    if isinstance(get_backend(), LocalCacheBackend):
+        old_dir = get_prompt_cache_dir(model_name, prompt)
+        if old_dir.is_dir():
+            shutil.rmtree(old_dir)
 
 
 def is_prompt_perplexity_cached(model_name: str, prompt: str) -> bool:
     """Check if perplexity features are cached for a prompt."""
-    sf_path = get_prompt_cache_path(model_name, prompt)
-    if sf_path.exists():
-        return _PERPLEXITY_KEY in _load_sf_keys(sf_path)
-    # v1
-    cache_dir = get_prompt_cache_dir(model_name, prompt)
-    return (cache_dir / "perplexity.pt").exists()
+    backend = get_backend()
+    key = _prompt_cache_key(model_name, prompt)
+
+    if backend.exists(key):
+        tensor_keys = _get_tensor_keys_from_backend(key)
+        return _PERPLEXITY_KEY in tensor_keys
+
+    # v1 (local only)
+    if isinstance(backend, LocalCacheBackend):
+        cache_dir = get_prompt_cache_dir(model_name, prompt)
+        return (cache_dir / "perplexity.pt").exists()
+
+    return False
 
 
 def load_prompt_perplexity(model_name: str, prompt: str) -> torch.Tensor:
     """Load cached perplexity features (3,) for a single prompt."""
-    sf_path = get_prompt_cache_path(model_name, prompt)
-    if sf_path.exists():
-        os.utime(sf_path)
-        return _load_sf_tensor(sf_path, _PERPLEXITY_KEY)
-    # v1
-    cache_dir = get_prompt_cache_dir(model_name, prompt)
-    return torch.load(cache_dir / "perplexity.pt", weights_only=True)
+    backend = get_backend()
+    key = _prompt_cache_key(model_name, prompt)
+
+    if backend.exists(key):
+        backend.touch(key)
+        tensors = _load_tensors_from_backend(key, [_PERPLEXITY_KEY])
+        return tensors[_PERPLEXITY_KEY]
+
+    # v1 (local only)
+    if isinstance(backend, LocalCacheBackend):
+        cache_dir = get_prompt_cache_dir(model_name, prompt)
+        return torch.load(cache_dir / "perplexity.pt", weights_only=True)
+
+    raise FileNotFoundError(
+        f"No cached perplexity found for prompt: {prompt!r}"
+    )
 
 
 def save_prompt_perplexity(
@@ -487,9 +740,9 @@ def save_prompt_perplexity(
 ) -> None:
     """Save perplexity features for a single prompt."""
     _register_model(model_name)
-    sf_path = get_prompt_cache_path(model_name, prompt)
+    key = _prompt_cache_key(model_name, prompt)
     new_tensors = {_PERPLEXITY_KEY: _prepare_tensor(perplexity_features)}
-    _merge_save(sf_path, new_tensors)
+    _merge_save_backend(key, new_tensors)
 
 
 # =============================================================================
@@ -509,46 +762,58 @@ def is_prompt_pooled_cached(
     pooling: str,
 ) -> bool:
     """Check if pooled activations are cached for a prompt."""
+    backend = get_backend()
+    key = _prompt_cache_key(model_name, prompt)
+
     # v2
-    sf_path = get_prompt_cache_path(model_name, prompt)
-    if sf_path.exists():
-        keys = _load_sf_keys(sf_path)
-        cached = _parse_pooled_layer_keys(keys, pooling)
+    if backend.exists(key):
+        tensor_keys = _get_tensor_keys_from_backend(key)
+        cached = _parse_pooled_layer_keys(tensor_keys, pooling)
         return required_layers.issubset(cached)
 
-    # v1
-    cache_dir = get_prompt_cache_dir(model_name, prompt)
-    pooled_dir = cache_dir / get_pooled_cache_key(pooling)
-    if not pooled_dir.exists():
-        return False
-    cached = set()
-    for f in pooled_dir.glob("layer_*.pt"):
-        try:
-            cached.add(int(f.stem.split("_")[1]))
-        except (IndexError, ValueError):
-            continue
-    return required_layers.issubset(cached)
+    # v1 (local only)
+    if isinstance(backend, LocalCacheBackend):
+        cache_dir = get_prompt_cache_dir(model_name, prompt)
+        pooled_dir = cache_dir / get_pooled_cache_key(pooling)
+        if not pooled_dir.exists():
+            return False
+        cached = set()
+        for f in pooled_dir.glob("layer_*.pt"):
+            try:
+                cached.add(int(f.stem.split("_")[1]))
+            except (IndexError, ValueError):
+                continue
+        return required_layers.issubset(cached)
+
+    return False
 
 
 def load_prompt_pooled_activations(
     model_name: str, prompt: str, layers: list[int], pooling: str
 ) -> torch.Tensor:
     """Load pooled activations for a single prompt. Shape: (1, n_layers * hidden_dim)."""
-    sf_path = get_prompt_cache_path(model_name, prompt)
-    if sf_path.exists():
-        os.utime(sf_path)
-        keys = [_pooled_layer_key(pooling, li) for li in layers]
-        tensors = _load_sf_tensors(sf_path, keys)
-        return torch.cat([tensors[k] for k in keys], dim=-1)
+    backend = get_backend()
+    key = _prompt_cache_key(model_name, prompt)
 
-    # v1
-    cache_dir = get_prompt_cache_dir(model_name, prompt)
-    pooled_dir = cache_dir / get_pooled_cache_key(pooling)
-    layer_acts = []
-    for layer in layers:
-        acts = torch.load(pooled_dir / f"layer_{layer}.pt", weights_only=True)
-        layer_acts.append(acts)
-    return torch.cat(layer_acts, dim=-1)
+    if backend.exists(key):
+        backend.touch(key)
+        tensor_keys = [_pooled_layer_key(pooling, li) for li in layers]
+        tensors = _load_tensors_from_backend(key, tensor_keys)
+        return torch.cat([tensors[k] for k in tensor_keys], dim=-1)
+
+    # v1 (local only)
+    if isinstance(backend, LocalCacheBackend):
+        cache_dir = get_prompt_cache_dir(model_name, prompt)
+        pooled_dir = cache_dir / get_pooled_cache_key(pooling)
+        layer_acts = []
+        for layer in layers:
+            acts = torch.load(pooled_dir / f"layer_{layer}.pt", weights_only=True)
+            layer_acts.append(acts)
+        return torch.cat(layer_acts, dim=-1)
+
+    raise FileNotFoundError(
+        f"No cached pooled activations found for prompt: {prompt!r}"
+    )
 
 
 def save_prompt_pooled_activations(
@@ -560,7 +825,7 @@ def save_prompt_pooled_activations(
 ) -> None:
     """Save pooled activations for a single prompt (v2 safetensors)."""
     _register_model(model_name)
-    sf_path = get_prompt_cache_path(model_name, prompt)
+    key = _prompt_cache_key(model_name, prompt)
 
     n_layers = len(layers)
     hidden_dim = pooled_activations.shape[-1] // n_layers
@@ -573,13 +838,14 @@ def save_prompt_pooled_activations(
             pooled_activations[..., start:end]
         )
 
-    _merge_save(sf_path, new_tensors)
+    _merge_save_backend(key, new_tensors)
 
-    # Clean up v1 pooled directory if exists
-    old_dir = get_prompt_cache_dir(model_name, prompt)
-    pooled_dir = old_dir / get_pooled_cache_key(pooling)
-    if pooled_dir.is_dir():
-        shutil.rmtree(pooled_dir)
+    # Clean up v1 pooled directory if exists (local only)
+    if isinstance(get_backend(), LocalCacheBackend):
+        old_dir = get_prompt_cache_dir(model_name, prompt)
+        pooled_dir = old_dir / get_pooled_cache_key(pooling)
+        if pooled_dir.is_dir():
+            shutil.rmtree(pooled_dir)
 
 
 # =============================================================================
@@ -617,7 +883,7 @@ class ModelCacheInfo:
 class CacheInfo:
     """Cache usage report."""
 
-    cache_dir: Path
+    cache_dir: Path | str
     total_size_bytes: int
     models: list[ModelCacheInfo] = field(default_factory=list)
     oldest_mtime: float | None = None
@@ -664,7 +930,17 @@ def cache_info(model: str | None = None) -> CacheInfo:
     CacheInfo
         Structured cache usage report.
     """
-    base = get_cache_dir()
+    backend = get_backend()
+
+    if isinstance(backend, LocalCacheBackend):
+        return _cache_info_local(backend, model)
+    else:
+        return _cache_info_backend(backend, model)
+
+
+def _cache_info_local(backend: LocalCacheBackend, model: str | None = None) -> CacheInfo:
+    """Cache info implementation for local filesystem backend."""
+    base = backend.base_dir
     total_size = 0
     models = []
     oldest_mtime = None
@@ -758,8 +1034,98 @@ def cache_info(model: str | None = None) -> CacheInfo:
     )
 
 
+def _cache_info_backend(backend: CacheBackend, model: str | None = None) -> CacheInfo:
+    """Cache info implementation for non-local backends (e.g. S3)."""
+    from safetensors.torch import load
+
+    target_hash = _hash_string(model) if model else None
+    entries = backend.collect_entries()
+
+    # Group entries by model hash
+    model_entries: dict[str, list[tuple[str, int, float]]] = {}
+    for entry_key, size, mtime in entries:
+        parts = entry_key.split("/")
+        if len(parts) < 2:
+            continue
+        model_hash = parts[0]
+        if target_hash and model_hash != target_hash:
+            continue
+        model_entries.setdefault(model_hash, []).append((entry_key, size, mtime))
+
+    total_size = 0
+    models = []
+    oldest_mtime = None
+    newest_mtime = None
+
+    for model_hash, m_entries in sorted(model_entries.items()):
+        # Try to read model name
+        name_key = f"{model_hash}/_model_name.txt"
+        model_name = None
+        if backend.exists(name_key):
+            model_name = backend.read_text(name_key).strip()
+
+        model_size = 0
+        num_prompts = 0
+        all_layers: set[int] = set()
+        has_pooled = False
+        has_perplexity = False
+
+        for entry_key, size, mtime in m_entries:
+            model_size += size
+            num_prompts += 1
+
+            if oldest_mtime is None or mtime < oldest_mtime:
+                oldest_mtime = mtime
+            if newest_mtime is None or mtime > newest_mtime:
+                newest_mtime = mtime
+
+            # Try to read tensor keys
+            if entry_key.endswith(".safetensors"):
+                try:
+                    data = backend.read_bytes(entry_key)
+                    tensor_keys = set(load(data).keys())
+                    all_layers |= _parse_raw_layer_keys(tensor_keys)
+                    if any(k.startswith("pooled_") for k in tensor_keys):
+                        has_pooled = True
+                    if _PERPLEXITY_KEY in tensor_keys:
+                        has_perplexity = True
+                except Exception:
+                    pass
+
+        if num_prompts > 0 or model_size > 0:
+            total_size += model_size
+            models.append(
+                ModelCacheInfo(
+                    model_name=model_name,
+                    model_hash=model_hash,
+                    size_bytes=model_size,
+                    num_prompts=num_prompts,
+                    num_layers=len(all_layers),
+                    has_pooled=has_pooled,
+                    has_perplexity=has_perplexity,
+                )
+            )
+
+    # Determine cache_dir label
+    from .cache_backends import S3CacheBackend
+
+    if isinstance(backend, S3CacheBackend):
+        cache_dir_label = f"s3://{backend.bucket}/{backend.prefix}"
+    else:
+        cache_dir_label = str(getattr(backend, "base_dir", "unknown"))
+
+    return CacheInfo(
+        cache_dir=cache_dir_label,
+        total_size_bytes=total_size,
+        models=models,
+        oldest_mtime=oldest_mtime,
+        newest_mtime=newest_mtime,
+        cache_limit_bytes=None,  # No eviction on non-local backends
+    )
+
+
 # =============================================================================
-# LRU Eviction (#49)
+# LRU Eviction (#49) — local backend only
 # =============================================================================
 
 
@@ -794,8 +1160,16 @@ def _collect_cache_entries() -> list[tuple[Path, int, float]]:
 
 
 def _maybe_evict() -> None:
-    """Evict least-recently-used cache entries if over the size limit."""
+    """Evict least-recently-used cache entries if over the size limit.
+
+    This is a no-op on non-local backends (S3 etc.) — S3 is designed
+    for accumulating large datasets, not ephemeral caching.
+    """
     if _CACHE_MAX_BYTES is None or _CACHE_MAX_BYTES <= 0:
+        return
+
+    # Only evict on local backends
+    if not _is_local_backend():
         return
 
     entries = _collect_cache_entries()
@@ -916,19 +1290,35 @@ def clear_cache() -> int:
 
     Returns the number of cache entries deleted.
     """
-    cache_dir = get_cache_dir()
-    count = 0
-    for model_dir in cache_dir.iterdir():
-        if not model_dir.is_dir():
-            continue
-        # Count v2 safetensors files
-        count += sum(1 for _ in model_dir.glob("*.safetensors"))
-        # Count v1 directories
-        count += sum(
-            1 for d in model_dir.iterdir() if d.is_dir() and not d.name.startswith("_")
-        )
-        shutil.rmtree(model_dir)
-    return count
+    backend = get_backend()
+
+    if isinstance(backend, LocalCacheBackend):
+        cache_dir = backend.base_dir
+        count = 0
+        for model_dir in cache_dir.iterdir():
+            if not model_dir.is_dir():
+                continue
+            # Count v2 safetensors files
+            count += sum(1 for _ in model_dir.glob("*.safetensors"))
+            # Count v1 directories
+            count += sum(
+                1 for d in model_dir.iterdir() if d.is_dir() and not d.name.startswith("_")
+            )
+            shutil.rmtree(model_dir)
+        return count
+    else:
+        # Non-local backend: list all entries and delete by model hash
+        entries = backend.collect_entries()
+        model_hashes = set()
+        for entry_key, _, _ in entries:
+            parts = entry_key.split("/")
+            if parts:
+                model_hashes.add(parts[0])
+
+        count = 0
+        for model_hash in model_hashes:
+            count += backend.delete_tree(f"{model_hash}/")
+        return count
 
 
 def compute_cache_key(
@@ -998,15 +1388,16 @@ class CachedExtractor:
         # Handle cache invalidation
         if invalidate_cache:
             logger.info("[CACHE] Cache invalidation requested")
+            backend = get_backend()
             for prompt in prompts:
-                # Delete v2 file
-                sf_path = get_prompt_cache_path(model_name, prompt)
-                if sf_path.exists():
-                    sf_path.unlink()
-                # Delete v1 directory
-                cache_dir = get_prompt_cache_dir(model_name, prompt)
-                if cache_dir.exists():
-                    shutil.rmtree(cache_dir)
+                key = _prompt_cache_key(model_name, prompt)
+                if backend.exists(key):
+                    backend.delete(key)
+                # Delete v1 directory (local only)
+                if isinstance(backend, LocalCacheBackend):
+                    cache_dir = get_prompt_cache_dir(model_name, prompt)
+                    if cache_dir.exists():
+                        shutil.rmtree(cache_dir)
 
         # Check which prompts need extraction
         cached_prompts = []

--- a/src/lmprobe/cache_backends.py
+++ b/src/lmprobe/cache_backends.py
@@ -1,0 +1,339 @@
+"""Pluggable cache storage backends for lmprobe.
+
+This module defines the CacheBackend interface and provides two
+concrete implementations:
+
+- LocalCacheBackend: Wraps filesystem I/O (default)
+- S3CacheBackend: Uses boto3 for S3 storage (optional dependency)
+
+Both backends operate on string keys (e.g. "a1b2c3/hash.safetensors"),
+not Path objects, so the same cache logic works across storage types.
+"""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class CacheBackend(ABC):
+    """Abstract base class for cache storage backends.
+
+    All backends operate on string keys rather than filesystem paths.
+    Keys use forward-slash separators (e.g. "model_hash/prompt.safetensors").
+    """
+
+    @abstractmethod
+    def exists(self, key: str) -> bool:
+        """Check if an entry exists."""
+        ...
+
+    @abstractmethod
+    def read_bytes(self, key: str) -> bytes:
+        """Read raw bytes for a key."""
+        ...
+
+    @abstractmethod
+    def write_bytes(self, key: str, data: bytes) -> None:
+        """Write raw bytes for a key."""
+        ...
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Remove a single entry. No error if missing."""
+        ...
+
+    @abstractmethod
+    def list_keys(self, prefix: str = "") -> list[str]:
+        """List keys under a prefix."""
+        ...
+
+    @abstractmethod
+    def size(self, key: str) -> int:
+        """Get size in bytes of an entry."""
+        ...
+
+    @abstractmethod
+    def mtime(self, key: str) -> float:
+        """Get last-modified time as a Unix timestamp."""
+        ...
+
+    @abstractmethod
+    def touch(self, key: str) -> None:
+        """Update the last-modified time (for LRU tracking)."""
+        ...
+
+    @abstractmethod
+    def read_text(self, key: str) -> str:
+        """Read a text entry."""
+        ...
+
+    @abstractmethod
+    def write_text(self, key: str, text: str) -> None:
+        """Write a text entry."""
+        ...
+
+    @abstractmethod
+    def collect_entries(self) -> list[tuple[str, int, float]]:
+        """Return all cache entries as (key, size_bytes, mtime).
+
+        Used for LRU eviction and cache_info().
+        """
+        ...
+
+    @abstractmethod
+    def delete_tree(self, prefix: str) -> int:
+        """Bulk delete all keys under a prefix.
+
+        Returns the number of entries deleted.
+        """
+        ...
+
+
+class LocalCacheBackend(CacheBackend):
+    """Cache backend backed by the local filesystem.
+
+    Parameters
+    ----------
+    base_dir : Path | str
+        Root directory for cache storage.
+    """
+
+    def __init__(self, base_dir: Path | str):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, key: str) -> Path:
+        return self.base_dir / key
+
+    def exists(self, key: str) -> bool:
+        return self._path(key).exists()
+
+    def read_bytes(self, key: str) -> bytes:
+        return self._path(key).read_bytes()
+
+    def write_bytes(self, key: str, data: bytes) -> None:
+        path = self._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(".tmp")
+        try:
+            tmp_path.write_bytes(data)
+            tmp_path.rename(path)
+        except OSError:
+            if tmp_path.exists():
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
+            raise
+
+    def delete(self, key: str) -> None:
+        path = self._path(key)
+        try:
+            if path.is_dir():
+                import shutil
+
+                shutil.rmtree(path)
+            elif path.exists():
+                path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def list_keys(self, prefix: str = "") -> list[str]:
+        search_dir = self._path(prefix) if prefix else self.base_dir
+        if not search_dir.exists():
+            return []
+        keys = []
+        for item in search_dir.rglob("*"):
+            if item.is_file():
+                keys.append(str(item.relative_to(self.base_dir)))
+        return keys
+
+    def size(self, key: str) -> int:
+        return self._path(key).stat().st_size
+
+    def mtime(self, key: str) -> float:
+        return self._path(key).stat().st_mtime
+
+    def touch(self, key: str) -> None:
+        path = self._path(key)
+        if path.exists():
+            os.utime(path)
+
+    def read_text(self, key: str) -> str:
+        return self._path(key).read_text()
+
+    def write_text(self, key: str, text: str) -> None:
+        path = self._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    def collect_entries(self) -> list[tuple[str, int, float]]:
+        """Collect safetensors files and v1 prompt directories."""
+        entries = []
+        if not self.base_dir.exists():
+            return entries
+
+        for model_dir in self.base_dir.iterdir():
+            if not model_dir.is_dir() or model_dir.name.startswith("."):
+                continue
+
+            # v2 safetensors files
+            for sf_file in model_dir.glob("*.safetensors"):
+                stat = sf_file.stat()
+                key = str(sf_file.relative_to(self.base_dir))
+                entries.append((key, stat.st_size, stat.st_mtime))
+
+            # v1 directories
+            for prompt_dir in model_dir.iterdir():
+                if not prompt_dir.is_dir() or prompt_dir.name.startswith("_"):
+                    continue
+                dir_size = sum(
+                    f.stat().st_size for f in prompt_dir.rglob("*") if f.is_file()
+                )
+                key = str(prompt_dir.relative_to(self.base_dir))
+                entries.append((key, dir_size, prompt_dir.stat().st_mtime))
+
+        return entries
+
+    def delete_tree(self, prefix: str) -> int:
+        """Delete all entries under a model directory prefix."""
+        import shutil
+
+        path = self._path(prefix)
+        if not path.exists():
+            return 0
+
+        count = 0
+        if path.is_dir():
+            # Count entries before deletion
+            count += sum(1 for _ in path.glob("*.safetensors"))
+            count += sum(
+                1 for d in path.iterdir() if d.is_dir() and not d.name.startswith("_")
+            )
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+            count = 1
+        return count
+
+
+class S3CacheBackend(CacheBackend):
+    """Cache backend using Amazon S3.
+
+    Requires ``boto3`` (install with ``pip install lmprobe[s3]``).
+
+    LRU eviction is disabled — S3 is designed for accumulating
+    large activation datasets, not ephemeral caching. Use S3
+    Lifecycle Rules if you need automatic cleanup.
+
+    Parameters
+    ----------
+    bucket : str
+        S3 bucket name.
+    prefix : str
+        Key prefix within the bucket (e.g. "lmprobe-cache/").
+    """
+
+    def __init__(self, bucket: str, prefix: str = ""):
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError(
+                "boto3 is required for S3 cache backend. "
+                "Install it with: pip install lmprobe[s3]"
+            )
+        self.bucket = bucket
+        self.prefix = prefix.rstrip("/")
+        if self.prefix:
+            self.prefix += "/"
+        self._s3 = boto3.client("s3")
+
+    def _full_key(self, key: str) -> str:
+        return f"{self.prefix}{key}"
+
+    def exists(self, key: str) -> bool:
+        from botocore.exceptions import ClientError
+
+        try:
+            self._s3.head_object(Bucket=self.bucket, Key=self._full_key(key))
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                return False
+            raise
+
+    def read_bytes(self, key: str) -> bytes:
+        resp = self._s3.get_object(Bucket=self.bucket, Key=self._full_key(key))
+        return resp["Body"].read()
+
+    def write_bytes(self, key: str, data: bytes) -> None:
+        self._s3.put_object(Bucket=self.bucket, Key=self._full_key(key), Body=data)
+
+    def delete(self, key: str) -> None:
+        self._s3.delete_object(Bucket=self.bucket, Key=self._full_key(key))
+
+    def list_keys(self, prefix: str = "") -> list[str]:
+        full_prefix = self._full_key(prefix)
+        keys = []
+        paginator = self._s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=full_prefix):
+            for obj in page.get("Contents", []):
+                # Strip our prefix to return relative keys
+                rel_key = obj["Key"][len(self.prefix):]
+                keys.append(rel_key)
+        return keys
+
+    def size(self, key: str) -> int:
+        resp = self._s3.head_object(Bucket=self.bucket, Key=self._full_key(key))
+        return resp["ContentLength"]
+
+    def mtime(self, key: str) -> float:
+        resp = self._s3.head_object(Bucket=self.bucket, Key=self._full_key(key))
+        return resp["LastModified"].timestamp()
+
+    def touch(self, key: str) -> None:
+        # No-op on S3: no writable mtime, and LRU doesn't apply.
+        pass
+
+    def read_text(self, key: str) -> str:
+        return self.read_bytes(key).decode("utf-8")
+
+    def write_text(self, key: str, text: str) -> None:
+        self.write_bytes(key, text.encode("utf-8"))
+
+    def collect_entries(self) -> list[tuple[str, int, float]]:
+        """List all cache entries with size and mtime.
+
+        Note: On large caches this requires paginated LIST + HEAD per object
+        and can be slow.
+        """
+        entries = []
+        paginator = self._s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=self.prefix):
+            for obj in page.get("Contents", []):
+                rel_key = obj["Key"][len(self.prefix):]
+                # Skip metadata files
+                if rel_key.endswith("/_model_name.txt"):
+                    continue
+                entries.append((
+                    rel_key,
+                    obj["Size"],
+                    obj["LastModified"].timestamp(),
+                ))
+        return entries
+
+    def delete_tree(self, prefix: str) -> int:
+        """Delete all objects under a prefix."""
+        keys_to_delete = self.list_keys(prefix)
+        count = 0
+        # S3 delete_objects handles up to 1000 at a time
+        for i in range(0, len(keys_to_delete), 1000):
+            batch = keys_to_delete[i : i + 1000]
+            objects = [{"Key": self._full_key(k)} for k in batch]
+            self._s3.delete_objects(
+                Bucket=self.bucket, Delete={"Objects": objects}
+            )
+            count += len(batch)
+        return count

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,18 @@ def tiny_model():
     that the pipeline works end-to-end, but predictions are meaningless.
     """
     return TEST_MODEL
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_backend():
+    """Reset the cache backend global between tests.
+
+    This ensures that tests using LMPROBE_CACHE_DIR via monkeypatch
+    get a fresh LocalCacheBackend pointing to the correct directory.
+    """
+    import lmprobe.cache as cache_mod
+
+    old = cache_mod._backend
+    cache_mod._backend = None
+    yield
+    cache_mod._backend = old

--- a/tests/test_cache_backends.py
+++ b/tests/test_cache_backends.py
@@ -1,0 +1,126 @@
+"""Tests for cache backend implementations."""
+
+import time
+
+import pytest
+
+from lmprobe.cache_backends import CacheBackend, LocalCacheBackend
+
+
+class TestLocalCacheBackend:
+    """Tests for LocalCacheBackend (filesystem)."""
+
+    @pytest.fixture
+    def backend(self, tmp_path):
+        return LocalCacheBackend(tmp_path)
+
+    def test_implements_abc(self, backend):
+        assert isinstance(backend, CacheBackend)
+
+    def test_exists_false_when_missing(self, backend):
+        assert not backend.exists("nonexistent/key.bin")
+
+    def test_write_and_read_bytes(self, backend):
+        backend.write_bytes("model/file.bin", b"hello bytes")
+        assert backend.exists("model/file.bin")
+        assert backend.read_bytes("model/file.bin") == b"hello bytes"
+
+    def test_write_and_read_text(self, backend):
+        backend.write_text("model/_model_name.txt", "my-model")
+        assert backend.read_text("model/_model_name.txt") == "my-model"
+
+    def test_delete(self, backend):
+        backend.write_bytes("model/file.bin", b"data")
+        assert backend.exists("model/file.bin")
+        backend.delete("model/file.bin")
+        assert not backend.exists("model/file.bin")
+
+    def test_delete_nonexistent_is_noop(self, backend):
+        backend.delete("does/not/exist.bin")  # should not raise
+
+    def test_list_keys(self, backend):
+        backend.write_bytes("model1/a.bin", b"data")
+        backend.write_bytes("model1/b.bin", b"data")
+        backend.write_bytes("model2/c.bin", b"data")
+
+        keys = backend.list_keys("model1")
+        assert sorted(keys) == ["model1/a.bin", "model1/b.bin"]
+
+    def test_list_keys_empty_prefix(self, backend):
+        backend.write_bytes("model1/a.bin", b"data")
+        backend.write_bytes("model2/b.bin", b"data")
+        keys = backend.list_keys()
+        assert len(keys) == 2
+
+    def test_list_keys_nonexistent_prefix(self, backend):
+        assert backend.list_keys("nonexistent") == []
+
+    def test_size(self, backend):
+        data = b"x" * 100
+        backend.write_bytes("model/file.bin", data)
+        assert backend.size("model/file.bin") == 100
+
+    def test_mtime(self, backend):
+        before = time.time()
+        backend.write_bytes("model/file.bin", b"data")
+        after = time.time()
+        mt = backend.mtime("model/file.bin")
+        assert before - 1 <= mt <= after + 1  # allow small tolerance
+
+    def test_touch(self, backend):
+        backend.write_bytes("model/file.bin", b"data")
+        original_mtime = backend.mtime("model/file.bin")
+        time.sleep(0.05)
+        backend.touch("model/file.bin")
+        new_mtime = backend.mtime("model/file.bin")
+        assert new_mtime >= original_mtime
+
+    def test_collect_entries_safetensors(self, backend):
+        backend.write_bytes("abc123/prompt1.safetensors", b"data1")
+        backend.write_bytes("abc123/prompt2.safetensors", b"data22")
+
+        entries = backend.collect_entries()
+        assert len(entries) == 2
+        keys = {e[0] for e in entries}
+        assert "abc123/prompt1.safetensors" in keys
+        assert "abc123/prompt2.safetensors" in keys
+        # Each entry is (key, size, mtime)
+        for key, size, mtime in entries:
+            assert isinstance(size, int)
+            assert isinstance(mtime, float)
+
+    def test_collect_entries_skips_metadata(self, backend):
+        """_model_name.txt should not appear in collect_entries for v2 files."""
+        backend.write_text("abc123/_model_name.txt", "my-model")
+        backend.write_bytes("abc123/prompt1.safetensors", b"data")
+        entries = backend.collect_entries()
+        # Only the safetensors file, not the text file
+        assert len(entries) == 1
+        assert entries[0][0] == "abc123/prompt1.safetensors"
+
+    def test_delete_tree(self, backend):
+        backend.write_bytes("abc123/prompt1.safetensors", b"data")
+        backend.write_bytes("abc123/prompt2.safetensors", b"data")
+        backend.write_text("abc123/_model_name.txt", "model")
+
+        count = backend.delete_tree("abc123")
+        assert count == 2  # two safetensors files (not the _model_name.txt)
+        assert not backend.exists("abc123/prompt1.safetensors")
+        assert not backend.exists("abc123/_model_name.txt")
+
+    def test_delete_tree_nonexistent(self, backend):
+        assert backend.delete_tree("nonexistent") == 0
+
+    def test_write_bytes_creates_parent_dirs(self, backend):
+        backend.write_bytes("deep/nested/dir/file.bin", b"data")
+        assert backend.read_bytes("deep/nested/dir/file.bin") == b"data"
+
+    def test_write_bytes_atomic(self, backend):
+        """No .tmp files left after successful write."""
+        backend.write_bytes("model/file.bin", b"data")
+        import os
+
+        parent = backend._path("model")
+        files = os.listdir(parent)
+        assert "file.tmp" not in files
+        assert "file.bin" in files

--- a/tests/test_cache_s3.py
+++ b/tests/test_cache_s3.py
@@ -1,0 +1,444 @@
+"""Tests for S3CacheBackend and backend configuration."""
+
+import pytest
+
+from lmprobe.cache_backends import CacheBackend, LocalCacheBackend
+
+# Skip all tests if moto is not installed
+moto = pytest.importorskip("moto")
+boto3 = pytest.importorskip("boto3")
+
+from moto import mock_aws  # noqa: E402
+
+from lmprobe.cache_backends import S3CacheBackend  # noqa: E402
+
+TEST_BUCKET = "test-cache-bucket"
+TEST_PREFIX = "lmprobe-cache"
+
+
+@pytest.fixture
+def s3_backend():
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=TEST_BUCKET)
+        yield S3CacheBackend(TEST_BUCKET, TEST_PREFIX)
+
+
+class TestS3CacheBackend:
+    """Tests for S3CacheBackend with moto."""
+
+    def test_implements_abc(self, s3_backend):
+        assert isinstance(s3_backend, CacheBackend)
+
+    def test_exists_false_when_missing(self, s3_backend):
+        assert not s3_backend.exists("nonexistent/key.bin")
+
+    def test_write_and_read_bytes(self, s3_backend):
+        s3_backend.write_bytes("model/file.bin", b"hello s3")
+        assert s3_backend.exists("model/file.bin")
+        assert s3_backend.read_bytes("model/file.bin") == b"hello s3"
+
+    def test_write_and_read_text(self, s3_backend):
+        s3_backend.write_text("model/_model_name.txt", "my-model")
+        assert s3_backend.read_text("model/_model_name.txt") == "my-model"
+
+    def test_delete(self, s3_backend):
+        s3_backend.write_bytes("model/file.bin", b"data")
+        assert s3_backend.exists("model/file.bin")
+        s3_backend.delete("model/file.bin")
+        assert not s3_backend.exists("model/file.bin")
+
+    def test_delete_nonexistent_is_noop(self, s3_backend):
+        s3_backend.delete("does/not/exist.bin")  # should not raise
+
+    def test_list_keys(self, s3_backend):
+        s3_backend.write_bytes("model1/a.bin", b"data")
+        s3_backend.write_bytes("model1/b.bin", b"data")
+        s3_backend.write_bytes("model2/c.bin", b"data")
+
+        keys = s3_backend.list_keys("model1/")
+        assert sorted(keys) == ["model1/a.bin", "model1/b.bin"]
+
+    def test_list_keys_empty_prefix(self, s3_backend):
+        s3_backend.write_bytes("model1/a.bin", b"data")
+        s3_backend.write_bytes("model2/b.bin", b"data")
+        keys = s3_backend.list_keys()
+        assert len(keys) == 2
+
+    def test_size(self, s3_backend):
+        data = b"x" * 100
+        s3_backend.write_bytes("model/file.bin", data)
+        assert s3_backend.size("model/file.bin") == 100
+
+    def test_mtime(self, s3_backend):
+        import time
+
+        before = time.time()
+        s3_backend.write_bytes("model/file.bin", b"data")
+        after = time.time()
+        mt = s3_backend.mtime("model/file.bin")
+        # moto timestamps are approximate
+        assert mt >= before - 5
+        assert mt <= after + 5
+
+    def test_touch_is_noop(self, s3_backend):
+        """touch() is a no-op on S3 (no writable mtime, LRU doesn't apply)."""
+        s3_backend.write_bytes("model/file.bin", b"data")
+        s3_backend.touch("model/file.bin")  # should not raise
+
+    def test_collect_entries(self, s3_backend):
+        s3_backend.write_bytes("abc123/prompt1.safetensors", b"data1")
+        s3_backend.write_bytes("abc123/prompt2.safetensors", b"data22")
+
+        entries = s3_backend.collect_entries()
+        assert len(entries) == 2
+        keys = {e[0] for e in entries}
+        assert "abc123/prompt1.safetensors" in keys
+
+    def test_collect_entries_skips_model_name(self, s3_backend):
+        s3_backend.write_text("abc123/_model_name.txt", "my-model")
+        s3_backend.write_bytes("abc123/prompt1.safetensors", b"data")
+        entries = s3_backend.collect_entries()
+        assert len(entries) == 1
+
+    def test_delete_tree(self, s3_backend):
+        s3_backend.write_bytes("abc123/prompt1.safetensors", b"data")
+        s3_backend.write_bytes("abc123/prompt2.safetensors", b"data")
+        s3_backend.write_text("abc123/_model_name.txt", "model")
+
+        count = s3_backend.delete_tree("abc123/")
+        assert count == 3  # all objects under prefix
+        assert not s3_backend.exists("abc123/prompt1.safetensors")
+
+    def test_prefix_handling(self):
+        """Keys are correctly prefixed."""
+        with mock_aws():
+            boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="test")
+            backend = S3CacheBackend("test", "my/prefix")
+            backend.write_bytes("key.bin", b"data")
+            # The full S3 key should include the prefix
+            assert backend._full_key("key.bin") == "my/prefix/key.bin"
+            assert backend.read_bytes("key.bin") == b"data"
+
+    def test_prefix_without_trailing_slash(self):
+        """Prefix normalization handles trailing slash."""
+        with mock_aws():
+            boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="test")
+            b1 = S3CacheBackend("test", "prefix")
+            b2 = S3CacheBackend("test", "prefix/")
+            assert b1.prefix == b2.prefix
+
+    def test_empty_prefix(self):
+        """Empty prefix works (keys go at bucket root)."""
+        with mock_aws():
+            boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="test")
+            backend = S3CacheBackend("test", "")
+            backend.write_bytes("file.bin", b"data")
+            assert backend.read_bytes("file.bin") == b"data"
+
+
+class TestS3CacheBackendImportError:
+    """Test clear error when boto3 is missing."""
+
+    def test_import_error_message(self, monkeypatch):
+        """S3CacheBackend gives a clear error when boto3 is not installed."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "boto3":
+                raise ImportError("No module named 'boto3'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+
+        with pytest.raises(ImportError, match="boto3 is required"):
+            S3CacheBackend("bucket", "prefix")
+
+
+class TestBackendConfiguration:
+    """Tests for set_cache_backend(), get_backend(), _parse_backend_uri()."""
+
+    def test_parse_s3_uri(self):
+        from lmprobe.cache import _parse_backend_uri
+
+        backend = _parse_backend_uri("s3://my-bucket/my-prefix/")
+        assert isinstance(backend, S3CacheBackend)
+        assert backend.bucket == "my-bucket"
+        assert backend.prefix == "my-prefix/"
+
+    def test_parse_s3_uri_no_prefix(self):
+        from lmprobe.cache import _parse_backend_uri
+
+        backend = _parse_backend_uri("s3://my-bucket")
+        assert isinstance(backend, S3CacheBackend)
+        assert backend.bucket == "my-bucket"
+        assert backend.prefix == ""
+
+    def test_parse_s3_uri_trailing_slash(self):
+        from lmprobe.cache import _parse_backend_uri
+
+        backend = _parse_backend_uri("s3://my-bucket/prefix")
+        assert backend.bucket == "my-bucket"
+        assert backend.prefix == "prefix/"
+
+    def test_parse_local_path(self, tmp_path):
+        from lmprobe.cache import _parse_backend_uri
+
+        backend = _parse_backend_uri(str(tmp_path))
+        assert isinstance(backend, LocalCacheBackend)
+        assert backend.base_dir == tmp_path
+
+    def test_parse_unknown_scheme_raises(self):
+        from lmprobe.cache import _parse_backend_uri
+
+        with pytest.raises(ValueError, match="Unsupported"):
+            _parse_backend_uri("gcs://bucket/prefix")
+
+    def test_set_cache_backend_string(self, tmp_path, monkeypatch):
+        import lmprobe.cache as cache_mod
+
+        old = cache_mod._backend
+        try:
+            from lmprobe.cache import get_backend, set_cache_backend
+
+            set_cache_backend(str(tmp_path))
+            backend = get_backend()
+            assert isinstance(backend, LocalCacheBackend)
+            assert backend.base_dir == tmp_path
+        finally:
+            cache_mod._backend = old
+
+    def test_set_cache_backend_instance(self, tmp_path, monkeypatch):
+        import lmprobe.cache as cache_mod
+
+        old = cache_mod._backend
+        try:
+            from lmprobe.cache import get_backend, set_cache_backend
+
+            backend_instance = LocalCacheBackend(tmp_path)
+            set_cache_backend(backend_instance)
+            assert get_backend() is backend_instance
+        finally:
+            cache_mod._backend = old
+
+    def test_set_cache_backend_none_resets(self, monkeypatch):
+        import lmprobe.cache as cache_mod
+
+        old = cache_mod._backend
+        try:
+            from lmprobe.cache import set_cache_backend
+
+            set_cache_backend(None)
+            assert cache_mod._backend is None
+        finally:
+            cache_mod._backend = old
+
+    def test_get_backend_default_is_local(self, tmp_path, monkeypatch):
+        import lmprobe.cache as cache_mod
+
+        old = cache_mod._backend
+        try:
+            cache_mod._backend = None
+            monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+            from lmprobe.cache import get_backend
+
+            backend = get_backend()
+            assert isinstance(backend, LocalCacheBackend)
+        finally:
+            cache_mod._backend = old
+
+    def test_env_var_backend(self, monkeypatch):
+        """LMPROBE_CACHE_BACKEND env var configures the backend."""
+        import lmprobe.cache as cache_mod
+
+        old = cache_mod._backend
+        try:
+            cache_mod._backend = None
+            monkeypatch.setenv("LMPROBE_CACHE_BACKEND", "s3://env-bucket/env-prefix")
+            from lmprobe.cache import get_backend
+
+            backend = get_backend()
+            assert isinstance(backend, S3CacheBackend)
+            assert backend.bucket == "env-bucket"
+        finally:
+            cache_mod._backend = old
+
+
+class TestS3Integration:
+    """Integration tests: exercise cache.py public functions with S3 backend."""
+
+    @pytest.fixture(autouse=True)
+    def setup_s3_backend(self, monkeypatch):
+        """Set up mock S3 backend for all tests in this class."""
+        import lmprobe.cache as cache_mod
+
+        self._old_backend = cache_mod._backend
+        with mock_aws():
+            boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=TEST_BUCKET)
+            backend = S3CacheBackend(TEST_BUCKET, TEST_PREFIX)
+            cache_mod._backend = backend
+            yield
+        cache_mod._backend = self._old_backend
+
+    def test_save_and_load_prompt_activations(self):
+        import torch
+
+        from lmprobe.cache import (
+            is_prompt_fully_cached,
+            load_prompt_activations,
+            save_prompt_activations,
+        )
+
+        model = "test-model"
+        prompt = "hello world"
+        layers = [0, 1]
+        acts = torch.randn(1, 5, 128)
+        mask = torch.ones(1, 5, dtype=torch.long)
+
+        save_prompt_activations(model, prompt, layers, acts, mask)
+        assert is_prompt_fully_cached(model, prompt, {0, 1})
+
+        loaded_acts, loaded_mask = load_prompt_activations(model, prompt, layers)
+        assert torch.allclose(acts, loaded_acts)
+        assert torch.equal(mask, loaded_mask)
+
+    def test_save_and_load_pooled_activations(self):
+        import torch
+
+        from lmprobe.cache import (
+            is_prompt_pooled_cached,
+            load_prompt_pooled_activations,
+            save_prompt_pooled_activations,
+        )
+
+        model = "test-model"
+        prompt = "test"
+        layers = [0, 1]
+        pooling = "last_token"
+        pooled = torch.randn(1, 128)
+
+        save_prompt_pooled_activations(model, prompt, layers, pooled, pooling)
+        assert is_prompt_pooled_cached(model, prompt, {0, 1}, pooling)
+
+        loaded = load_prompt_pooled_activations(model, prompt, layers, pooling)
+        assert torch.allclose(pooled, loaded)
+
+    def test_save_and_load_perplexity(self):
+        import torch
+
+        from lmprobe.cache import (
+            is_prompt_perplexity_cached,
+            load_prompt_perplexity,
+            save_prompt_perplexity,
+        )
+
+        model = "test-model"
+        prompt = "test"
+        ppl = torch.tensor([1.5, 2.0, 3.0])
+
+        save_prompt_perplexity(model, prompt, ppl)
+        assert is_prompt_perplexity_cached(model, prompt)
+
+        loaded = load_prompt_perplexity(model, prompt)
+        assert torch.allclose(ppl, loaded)
+
+    def test_cache_info_with_s3(self):
+        import torch
+
+        from lmprobe.cache import cache_info, save_prompt_activations
+
+        save_prompt_activations(
+            "test-model", "p1", [0],
+            torch.randn(1, 5, 64),
+            torch.ones(1, 5, dtype=torch.long),
+        )
+        save_prompt_activations(
+            "test-model", "p2", [0],
+            torch.randn(1, 5, 64),
+            torch.ones(1, 5, dtype=torch.long),
+        )
+
+        info = cache_info()
+        assert info.total_size_bytes > 0
+        assert len(info.models) == 1
+        assert info.models[0].num_prompts == 2
+
+    def test_clear_cache_with_s3(self):
+        import torch
+
+        from lmprobe.cache import clear_cache, save_prompt_activations
+
+        save_prompt_activations(
+            "test-model", "p1", [0],
+            torch.randn(1, 5, 64),
+            torch.ones(1, 5, dtype=torch.long),
+        )
+        count = clear_cache()
+        assert count >= 1
+
+    def test_eviction_is_noop_on_s3(self):
+        """LRU eviction should not run on S3 backend."""
+        import torch
+
+        import lmprobe.cache as cache_mod
+        from lmprobe.cache import save_prompt_activations
+
+        old_limit = cache_mod._CACHE_MAX_BYTES
+        try:
+            # Set a very small cache limit
+            cache_mod._CACHE_MAX_BYTES = 1  # 1 byte
+
+            # This should still work — eviction is no-op on S3
+            save_prompt_activations(
+                "test-model", "p1", [0],
+                torch.randn(1, 5, 64),
+                torch.ones(1, 5, dtype=torch.long),
+            )
+            # File should still exist (not evicted)
+            from lmprobe.cache import is_prompt_fully_cached
+
+            assert is_prompt_fully_cached("test-model", "p1", {0})
+        finally:
+            cache_mod._CACHE_MAX_BYTES = old_limit
+
+    def test_register_model(self):
+        from lmprobe.cache import _register_model, get_backend
+
+        _register_model("org/my-model")
+        from lmprobe.cache import _hash_string
+
+        model_hash = _hash_string("org/my-model")
+        backend = get_backend()
+        name_key = f"{model_hash}/_model_name.txt"
+        assert backend.exists(name_key)
+        assert backend.read_text(name_key) == "org/my-model"
+
+    def test_incremental_layer_save(self):
+        import torch
+
+        from lmprobe.cache import (
+            is_prompt_fully_cached,
+            load_prompt_activations,
+            save_prompt_activations,
+        )
+
+        model = "test-model"
+        prompt = "test prompt"
+
+        # Save layer 0
+        acts0 = torch.randn(1, 5, 64)
+        mask = torch.ones(1, 5, dtype=torch.long)
+        save_prompt_activations(model, prompt, [0], acts0, mask)
+
+        # Save layer 1 (should merge)
+        acts1 = torch.randn(1, 5, 64)
+        save_prompt_activations(model, prompt, [1], acts1, mask)
+
+        assert is_prompt_fully_cached(model, prompt, {0, 1})
+
+        loaded0, _ = load_prompt_activations(model, prompt, [0])
+        assert torch.allclose(acts0, loaded0)
+
+        loaded1, _ = load_prompt_activations(model, prompt, [1])
+        assert torch.allclose(acts1, loaded1)


### PR DESCRIPTION
## Summary

- Adds a pluggable `CacheBackend` ABC with `LocalCacheBackend` (filesystem, default) and `S3CacheBackend` (boto3, optional `pip install lmprobe[s3]`)
- Users call `set_cache_backend("s3://bucket/prefix")` or set `LMPROBE_CACHE_BACKEND` env var — all existing `fit()`/`predict()` calls automatically use S3 with zero API changes
- LRU eviction is disabled on S3 by design (S3 is for accumulating large activation datasets, not ephemeral caching)
- v1 `.pt` legacy format only supported on local backend; S3 users start fresh on v2 safetensors

## Test plan

- [x] All 37 existing `test_cache.py` tests pass (no regressions)
- [x] 18 `test_cache_backends.py` tests for `LocalCacheBackend`
- [x] 36 `test_cache_s3.py` tests: S3 backend with moto, URI parsing, env var config, S3 integration (save/load activations, pooled, perplexity, cache_info, clear_cache, eviction no-op)
- [x] North star `test_readme_example.py` passes
- [x] Full suite: 410 passed, 0 failed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)