### PR TITLE
Fix warmup() OOM on 100% cache hit

### DIFF
--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -1366,7 +1366,8 @@ class CachedExtractor:
         remote: bool = False,
         invalidate_cache: bool = False,
         max_retries: int | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cache_only: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
         """Extract activations, using per-prompt cache when available."""
         model_name = self.extractor.model_name
         layer_indices = sorted(self.extractor.layer_indices)
@@ -1514,6 +1515,14 @@ class CachedExtractor:
                 f"{cached_now}/{len(prompts)} prompts are now cached. "
                 f"Re-run to retry the remaining prompts (cached results will be reused)."
             )
+
+        # If cache_only, skip matrix assembly (used by warmup())
+        if cache_only:
+            logger.info(
+                f"[CACHE] cache_only=True — skipping matrix assembly "
+                f"({n_cached} cached + {n_missing} extracted)"
+            )
+            return None
 
         # Load all prompts from cache in original order
         all_activations = []

--- a/src/lmprobe/probe.py
+++ b/src/lmprobe/probe.py
@@ -588,7 +588,8 @@ class LinearProbe:
         use_remote = self._get_remote(remote)
         effective_retries = max_retries if max_retries is not None else self.max_retries
         self._cached_extractor.extract(
-            prompts, remote=use_remote, max_retries=effective_retries
+            prompts, remote=use_remote, max_retries=effective_retries,
+            cache_only=True,
         )
 
     def fit(


### PR DESCRIPTION
## Summary
- Add `cache_only` flag to `CachedExtractor.extract()` that skips the load-pad-concatenate matrix assembly step
- `warmup()` now passes `cache_only=True` since it only needs to populate the cache, not return the feature tensor
- Fixes OOM on large models (e.g. 405B, 126 layers, 1980 prompts) where assembling the padded matrix required more RAM than available

Closes #72

## Test plan
- [x] North star test passes (`test_readme_example.py`)
- [ ] CI passes
- [ ] Verify on large model that `warmup()` no longer OOMs on 100% cache hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)