### PR TITLE
Add classifier_kwargs, preprocessing pipeline, and sweep mode

### DIFF
--- a/src/lmprobe/classifiers.py
+++ b/src/lmprobe/classifiers.py
@@ -42,7 +42,11 @@ CLASSIFICATION_CLASSIFIERS = BUILTIN_CLASSIFIERS - {"ridge_regression"}
 REGRESSION_CLASSIFIERS = frozenset({"ridge_regression"})
 
 
-def build_classifier(name: str, random_state: int | None = None) -> BaseEstimator:
+def build_classifier(
+    name: str,
+    random_state: int | None = None,
+    classifier_kwargs: dict | None = None,
+) -> BaseEstimator:
     """Build a classifier by name with the given random_state.
 
     Parameters
@@ -59,6 +63,10 @@ def build_classifier(name: str, random_state: int | None = None) -> BaseEstimato
         - "lda": Linear Discriminant Analysis (covariance-corrected mass mean)
     random_state : int | None
         Random seed for reproducibility. Propagated from LinearProbe.
+    classifier_kwargs : dict | None
+        Additional keyword arguments passed to the sklearn classifier constructor.
+        These override the defaults (e.g., ``{"C": 0.01, "solver": "liblinear"}``
+        for logistic regression).
 
     Returns
     -------
@@ -70,39 +78,38 @@ def build_classifier(name: str, random_state: int | None = None) -> BaseEstimato
     ValueError
         If the classifier name is not recognized.
     """
+    extra = classifier_kwargs or {}
+
     if name == "logistic_regression":
-        return LogisticRegression(
-            max_iter=1000,
-            solver="lbfgs",
-            random_state=random_state,
-        )
+        defaults = dict(max_iter=1000, solver="lbfgs", random_state=random_state)
+        defaults.update(extra)
+        return LogisticRegression(**defaults)
     elif name == "logistic_regression_cv":
-        return LogisticRegressionCV(
-            cv=5,
-            max_iter=1000,
-            random_state=random_state,
-        )
+        defaults = dict(cv=5, max_iter=1000, random_state=random_state)
+        defaults.update(extra)
+        return LogisticRegressionCV(**defaults)
     elif name == "ridge":
-        return RidgeClassifier(random_state=random_state)
+        defaults = dict(random_state=random_state)
+        defaults.update(extra)
+        return RidgeClassifier(**defaults)
     elif name == "ridge_regression":
-        return Ridge(alpha=1.0)
+        defaults = dict(alpha=1.0)
+        defaults.update(extra)
+        return Ridge(**defaults)
     elif name == "svm":
-        return SVC(
-            kernel="linear",
-            probability=True,
-            random_state=random_state,
-        )
+        defaults = dict(kernel="linear", probability=True, random_state=random_state)
+        defaults.update(extra)
+        return SVC(**defaults)
     elif name == "sgd":
-        return SGDClassifier(
-            loss="log_loss",
-            random_state=random_state,
-        )
+        defaults = dict(loss="log_loss", random_state=random_state)
+        defaults.update(extra)
+        return SGDClassifier(**defaults)
     elif name == "mass_mean":
         return MassMeanClassifier()
     elif name == "lda":
         from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 
-        return LinearDiscriminantAnalysis()
+        return LinearDiscriminantAnalysis(**extra)
     else:
         raise ValueError(
             f"Unknown classifier: {name!r}. "
@@ -148,6 +155,7 @@ def validate_classifier(clf: BaseEstimator) -> None:
 def resolve_classifier(
     classifier: str | BaseEstimator,
     random_state: int | None = None,
+    classifier_kwargs: dict | None = None,
 ) -> BaseEstimator:
     """Resolve a classifier specification to an estimator instance.
 
@@ -159,6 +167,9 @@ def resolve_classifier(
     random_state : int | None
         Random seed. Only used for built-in classifiers (strings).
         Custom estimators must set their own random_state.
+    classifier_kwargs : dict | None
+        Additional keyword arguments for built-in classifiers.
+        Ignored when a custom estimator instance is provided.
 
     Returns
     -------
@@ -166,7 +177,10 @@ def resolve_classifier(
         The resolved classifier instance.
     """
     if isinstance(classifier, str):
-        clf = build_classifier(classifier, random_state=random_state)
+        clf = build_classifier(
+            classifier, random_state=random_state,
+            classifier_kwargs=classifier_kwargs,
+        )
     else:
         clf = classifier
 

--- a/src/lmprobe/probe.py
+++ b/src/lmprobe/probe.py
@@ -32,6 +32,48 @@ if TYPE_CHECKING:
 
     from .scaling import PerLayerScaler
 
+def _parse_sweep_spec(spec: str) -> tuple[bool, int | list[int] | str]:
+    """Parse a sweep layer specification.
+
+    Parameters
+    ----------
+    spec : str
+        One of: "sweep", "sweep:10", "sweep:55-65"
+
+    Returns
+    -------
+    tuple[bool, int | list[int] | str]
+        (is_sweep, resolved_layers) where resolved_layers is the layer
+        spec to pass to sweep_layers. "sweep" -> "all",
+        "sweep:10" -> step size, "sweep:55-65" -> range.
+    """
+    if not isinstance(spec, str) or not spec.startswith("sweep"):
+        return False, spec
+
+    if spec == "sweep":
+        return True, "all"
+
+    # Must be "sweep:..." format
+    if not spec.startswith("sweep:"):
+        return False, spec
+
+    suffix = spec[len("sweep:"):]
+
+    if "-" in suffix:
+        # Range: "sweep:55-65"
+        parts = suffix.split("-")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid sweep range: {spec!r}. Expected 'sweep:START-END'."
+            )
+        start, end = int(parts[0]), int(parts[1])
+        return True, list(range(start, end + 1))
+
+    # Step size: "sweep:10"
+    step = int(suffix)
+    return True, step
+
+
 _DTYPE_MAP = {
     "float32": torch.float32,
     "float16": torch.float16,
@@ -234,6 +276,9 @@ class LinearProbe:
         - "all": All layers
         - "auto": Automatic layer selection via Group Lasso
         - "fast_auto": Fast automatic layer selection via coefficient importance
+        - "sweep": Train independent probe per layer (memory-safe)
+        - "sweep:N": Sweep every Nth layer (coarse sweep)
+        - "sweep:START-END": Sweep a range of layers (fine sweep)
     pooling : str, default="last_token"
         Token pooling strategy for both training and inference.
         Options: "last_token", "first_token", "mean", "all"
@@ -283,6 +328,21 @@ class LinearProbe:
     dtype : str | None, default=None
         Model dtype for local backend: "float32", "float16", or "bfloat16".
         Defaults to "float32" if None. Ignored for nnsight backend.
+    classifier_kwargs : dict | None, default=None
+        Additional keyword arguments passed to the sklearn classifier constructor.
+        Overrides defaults for built-in classifiers. Example:
+        ``{"C": 0.01, "solver": "liblinear", "max_iter": 5000}``
+        for logistic regression.
+    preprocessing : str | list[str] | None, default=None
+        Preprocessing pipeline applied after layer scaling but before the
+        classifier. Steps are separated by ``"+"`` when given as a string:
+        - ``"standard"``: StandardScaler
+        - ``"pca"`` or ``"pca:N"``: PCA with N components
+        - ``"standard+pca"``: StandardScaler then PCA
+        Use ``pca_components`` to set N when using ``"pca"`` without ``:N``.
+    pca_components : int | None, default=None
+        Number of PCA components when ``preprocessing`` includes ``"pca"``
+        without an explicit component count.
 
     Attributes
     ----------
@@ -340,6 +400,9 @@ class LinearProbe:
         backend: str = "local",
         dtype: str | None = None,
         max_retries: int | None = None,
+        classifier_kwargs: dict | None = None,
+        preprocessing: str | list[str] | None = None,
+        pca_components: int | None = None,
     ):
         self.model = model
         self.layers = layers
@@ -359,6 +422,12 @@ class LinearProbe:
         self.backend = backend
         self.dtype = dtype
         self.max_retries = max_retries
+        self.classifier_kwargs = classifier_kwargs
+        self.preprocessing = preprocessing
+        self.pca_components = pca_components
+
+        # Detect sweep mode before other validations
+        self._sweep_mode, self._sweep_layers_spec = _parse_sweep_spec(layers)
 
         # Validate task
         if task not in ("classification", "regression"):
@@ -386,13 +455,18 @@ class LinearProbe:
         if task == "regression" and classifier == "logistic_regression":
             # Default regression classifier
             self._classifier_template = resolve_classifier(
-                "ridge_regression", random_state
+                "ridge_regression", random_state,
+                classifier_kwargs=classifier_kwargs,
             )
         else:
-            self._classifier_template = resolve_classifier(classifier, random_state)
+            self._classifier_template = resolve_classifier(
+                classifier, random_state,
+                classifier_kwargs=classifier_kwargs,
+            )
 
         # Create extractor (lazy loads model) only if model is provided
-        if model is not None:
+        # Skip for sweep mode — sweep creates its own extractors
+        if model is not None and not self._sweep_mode:
             _torch_dtype = _resolve_dtype(dtype)
             self._extractor = ActivationExtractor(
                 model, device, layers, batch_size,
@@ -411,6 +485,8 @@ class LinearProbe:
         self.candidate_layers_: list[int] | None = None
         self.layer_importances_: np.ndarray | None = None
         self.scaler_: PerLayerScaler | None = None
+        self.preprocessing_pipeline_: object | None = None
+        self.sweep_result_: LayerSweepResult | None = None
 
         # Training data cache (for push_to_hub)
         self._training_positive_: list[str] | None = None
@@ -451,6 +527,55 @@ class LinearProbe:
             f"Invalid normalize_layers value: {self.normalize_layers!r}. "
             f"Expected True, False, 'per_neuron', or 'per_layer'."
         )
+
+    def _build_preprocessing_pipeline(self):
+        """Build a sklearn Pipeline from the preprocessing specification.
+
+        Returns
+        -------
+        sklearn.pipeline.Pipeline | None
+            A fitted preprocessing pipeline, or None if no preprocessing.
+        """
+        from sklearn.decomposition import PCA
+        from sklearn.pipeline import Pipeline
+        from sklearn.preprocessing import StandardScaler
+
+        spec = self.preprocessing
+        if spec is None:
+            return None
+
+        # Normalize to list of step strings
+        if isinstance(spec, str):
+            steps_spec = [s.strip() for s in spec.split("+")]
+        else:
+            steps_spec = list(spec)
+
+        steps = []
+        for s in steps_spec:
+            if s == "standard_scaler" or s == "standard":
+                steps.append(("scaler", StandardScaler()))
+            elif s.startswith("pca"):
+                # "pca", "pca:200"
+                if ":" in s:
+                    n = int(s.split(":")[1])
+                else:
+                    n = self.pca_components
+                if n is None:
+                    raise ValueError(
+                        "PCA requested but no component count specified. "
+                        "Use preprocessing='standard+pca:200' or set pca_components=200."
+                    )
+                steps.append(("pca", PCA(n_components=n)))
+            else:
+                raise ValueError(
+                    f"Unknown preprocessing step: {s!r}. "
+                    f"Available: 'standard', 'standard_scaler', 'pca', 'pca:<N>'."
+                )
+
+        if not steps:
+            return None
+
+        return Pipeline(steps)
 
     def _try_load_from_pooled_cache(
         self,
@@ -669,6 +794,12 @@ class LinearProbe:
             self._training_prompts_ = None
             self._training_labels_ = None
 
+        # Check if sweep mode
+        if self._sweep_mode:
+            return self._fit_sweep(
+                positive_prompts, negative_prompts, remote,
+            )
+
         # Check if auto layer selection is needed
         if self.layers == "auto":
             return self._fit_auto_layers(prompts, labels, remote, invalidate_cache)
@@ -709,6 +840,11 @@ class LinearProbe:
 
             self.scaler_ = StandardScaler()
             X = self.scaler_.fit_transform(X)
+
+        # Apply user-specified preprocessing (StandardScaler, PCA, etc.)
+        self.preprocessing_pipeline_ = self._build_preprocessing_pipeline()
+        if self.preprocessing_pipeline_ is not None:
+            X = self.preprocessing_pipeline_.fit_transform(X)
 
         # Clone and fit classifier
         self.classifier_ = clone(self._classifier_template)
@@ -969,6 +1105,69 @@ class LinearProbe:
 
         return self
 
+    def _fit_sweep(
+        self,
+        positive_prompts: list[str],
+        negative_prompts: list[str],
+        remote: bool | None,
+    ) -> LinearProbe:
+        """Fit using sweep mode: train an independent probe per layer.
+
+        Resolves the sweep spec to layer indices, delegates to sweep_layers(),
+        and sets the best layer's probe as the active classifier.
+        """
+        from .extraction import get_num_layers_from_config, resolve_layers
+
+        self._check_model()
+
+        num_layers = get_num_layers_from_config(self.model)
+        spec = self._sweep_layers_spec
+
+        if isinstance(spec, int):
+            # Step size: "sweep:10" → every 10th layer
+            sweep_layers_list = list(range(0, num_layers, spec))
+        elif isinstance(spec, list):
+            # Explicit layer list (from range parse)
+            sweep_layers_list = [idx for idx in spec if 0 <= idx < num_layers]
+        elif isinstance(spec, str):
+            # "all", "middle", etc.
+            sweep_layers_list = resolve_layers(spec, num_layers)
+        else:
+            sweep_layers_list = resolve_layers("all", num_layers)
+
+        # Delegate to sweep_layers classmethod
+        self.sweep_result_ = type(self).sweep_layers(
+            model=self.model,
+            positive_prompts=positive_prompts,
+            negative_prompts=negative_prompts,
+            layers=sweep_layers_list,
+            pooling=self.pooling,
+            classifier=self.classifier,
+            device=self.device,
+            remote=self._get_remote(remote),
+            random_state=self.random_state,
+            batch_size=self.batch_size,
+            backend=self.backend,
+            dtype=self.dtype,
+            normalize_layers=self.normalize_layers,
+            classifier_kwargs=self.classifier_kwargs,
+            preprocessing=self.preprocessing,
+            pca_components=self.pca_components,
+        )
+
+        # Use the first layer's probe as a default active probe
+        # (user can pick the best after evaluate())
+        first_layer = self.sweep_result_.layers[0]
+        best_probe = self.sweep_result_[first_layer]
+        self.classifier_ = best_probe.classifier_
+        self.classes_ = best_probe.classes_
+        self.scaler_ = best_probe.scaler_
+        self.preprocessing_pipeline_ = best_probe.preprocessing_pipeline_
+        self._extractor = best_probe._extractor
+        self._cached_extractor = best_probe._cached_extractor
+
+        return self
+
     def _check_fitted(self) -> None:
         """Check that the probe has been fitted."""
         if self.classifier_ is None:
@@ -1029,6 +1228,9 @@ class LinearProbe:
                 # Apply scaling if fitted
                 if self.scaler_ is not None:
                     X_flat = self.scaler_.transform(X_flat)
+                # Apply preprocessing if fitted
+                if self.preprocessing_pipeline_ is not None:
+                    X_flat = self.preprocessing_pipeline_.transform(X_flat)
 
                 preds_flat = self.classifier_.predict(X_flat)
                 preds = preds_flat.reshape(batch_size, seq_len)
@@ -1042,6 +1244,9 @@ class LinearProbe:
                 # Apply scaling if fitted
                 if self.scaler_ is not None:
                     X = self.scaler_.transform(X)
+                # Apply preprocessing if fitted
+                if self.preprocessing_pipeline_ is not None:
+                    X = self.preprocessing_pipeline_.transform(X)
                 return self.classifier_.predict(X)
 
     def predict_proba(
@@ -1092,6 +1297,9 @@ class LinearProbe:
             # Apply scaling if fitted
             if self.scaler_ is not None:
                 X_flat = self.scaler_.transform(X_flat)
+            # Apply preprocessing if fitted
+            if self.preprocessing_pipeline_ is not None:
+                X_flat = self.preprocessing_pipeline_.transform(X_flat)
 
             # Classify all tokens
             probs_flat = self.classifier_.predict_proba(X_flat)
@@ -1117,6 +1325,9 @@ class LinearProbe:
             # Apply scaling if fitted
             if self.scaler_ is not None:
                 X = self.scaler_.transform(X)
+            # Apply preprocessing if fitted
+            if self.preprocessing_pipeline_ is not None:
+                X = self.preprocessing_pipeline_.transform(X)
             return self.classifier_.predict_proba(X)
 
     def score(
@@ -1180,6 +1391,52 @@ class LinearProbe:
 
         self._check_fitted()
         labels = np.asarray(labels)
+
+        # Sweep mode: evaluate each layer and return per-layer + summary
+        if self.sweep_result_ is not None:
+            layer_results = {}
+            scores = self.sweep_result_.score(prompts, labels)
+            for layer_idx, probe in sorted(self.sweep_result_.probes.items()):
+                layer_preds = probe.predict(prompts, remote=remote)
+                layer_metrics: dict = {
+                    "accuracy": float(accuracy_score(labels, layer_preds)),
+                    "f1": float(f1_score(labels, layer_preds, zero_division=0)),
+                    "precision": float(precision_score(labels, layer_preds, zero_division=0)),
+                    "recall": float(recall_score(labels, layer_preds, zero_division=0)),
+                }
+                if hasattr(probe.classifier_, "predict_proba"):
+                    try:
+                        from sklearn.metrics import roc_auc_score
+
+                        proba = probe.predict_proba(prompts, remote=remote)
+                        if proba.ndim == 2 and proba.shape[1] == 2:
+                            layer_metrics["auroc"] = float(roc_auc_score(labels, proba[:, 1]))
+                        else:
+                            layer_metrics["auroc"] = float(roc_auc_score(labels, proba))
+                    except Exception:
+                        pass
+                layer_results[layer_idx] = layer_metrics
+
+            best_layer = max(scores, key=scores.get)
+            results: dict = {
+                "layer_results": layer_results,
+                "best_layer": best_layer,
+                "best_accuracy": scores[best_layer],
+                **layer_results[best_layer],  # top-level metrics from best layer
+            }
+
+            # Update this probe to use the best layer's probe
+            best_probe = self.sweep_result_[best_layer]
+            self.classifier_ = best_probe.classifier_
+            self.classes_ = best_probe.classes_
+            self.scaler_ = best_probe.scaler_
+            self.preprocessing_pipeline_ = best_probe.preprocessing_pipeline_
+            self._extractor = best_probe._extractor
+            self._cached_extractor = best_probe._cached_extractor
+
+            self._evaluation_results_ = results
+            return results
+
         predictions = self.predict(prompts, remote=remote)
 
         results: dict = {
@@ -1722,6 +1979,9 @@ class LinearProbe:
         backend: str = "local",
         dtype: str | None = None,
         normalize_layers: bool | str = True,
+        classifier_kwargs: dict | None = None,
+        preprocessing: str | list[str] | None = None,
+        pca_components: int | None = None,
     ) -> LayerSweepResult:
         """Train a probe at every layer and return per-layer results.
 
@@ -1799,6 +2059,7 @@ class LinearProbe:
             backend=backend,
             dtype=dtype,
             normalize_layers=False,  # No scaling needed for warmup
+            classifier_kwargs=classifier_kwargs,
         )
 
         all_prompts = list(positive_prompts) + list(negative_prompts)
@@ -1823,6 +2084,9 @@ class LinearProbe:
                 backend=backend,
                 dtype=dtype,
                 normalize_layers=normalize_layers,
+                classifier_kwargs=classifier_kwargs,
+                preprocessing=preprocessing,
+                pca_components=pca_components,
             )
             probe.fit(positive_prompts, negative_prompts, remote=remote)
             probes[layer_idx] = probe

--- a/tests/test_classifier_kwargs.py
+++ b/tests/test_classifier_kwargs.py
@@ -1,0 +1,107 @@
+"""Tests for classifier_kwargs parameter (Issue #75)."""
+
+from lmprobe import LinearProbe
+
+
+class TestClassifierKwargs:
+    """Tests for exposing classifier hyperparameters via classifier_kwargs."""
+
+    def test_logistic_regression_custom_c(self, tiny_model):
+        """classifier_kwargs overrides default C for logistic regression."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            classifier="logistic_regression",
+            classifier_kwargs={"C": 0.01},
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        # Check the template classifier has the right C
+        assert probe._classifier_template.C == 0.01
+
+    def test_logistic_regression_custom_solver(self, tiny_model):
+        """classifier_kwargs overrides solver."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            classifier="logistic_regression",
+            classifier_kwargs={"solver": "liblinear", "max_iter": 5000},
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        assert probe._classifier_template.solver == "liblinear"
+        assert probe._classifier_template.max_iter == 5000
+
+    def test_svm_custom_c(self, tiny_model):
+        """classifier_kwargs works with SVM."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            classifier="svm",
+            classifier_kwargs={"C": 0.1},
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        assert probe._classifier_template.C == 0.1
+
+    def test_ridge_custom_alpha(self, tiny_model):
+        """classifier_kwargs works with ridge regression."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            classifier="ridge_regression",
+            task="regression",
+            classifier_kwargs={"alpha": 10.0},
+            device="cpu",
+            remote=False,
+        )
+        assert probe._classifier_template.alpha == 10.0
+
+    def test_fit_predict_with_kwargs(self, tiny_model):
+        """Full fit/predict roundtrip with custom classifier_kwargs."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            classifier="logistic_regression",
+            classifier_kwargs={"C": 0.01, "solver": "liblinear"},
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        predictions = probe.predict(["test"])
+        assert predictions.shape == (1,)
+
+    def test_kwargs_ignored_for_custom_estimator(self, tiny_model):
+        """classifier_kwargs is ignored when a custom estimator is passed."""
+        from sklearn.linear_model import LogisticRegression
+
+        custom_clf = LogisticRegression(C=0.5, random_state=42)
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            classifier=custom_clf,
+            classifier_kwargs={"C": 999},  # Should be ignored
+            device="cpu",
+            remote=False,
+        )
+        # Custom estimator should be used as-is
+        assert probe._classifier_template.C == 0.5
+
+    def test_sweep_layers_passes_kwargs(self, tiny_model):
+        """sweep_layers forwards classifier_kwargs to each probe."""
+        result = LinearProbe.sweep_layers(
+            model=tiny_model,
+            positive_prompts=["good", "great"],
+            negative_prompts=["bad", "terrible"],
+            layers=0,
+            classifier_kwargs={"C": 0.01},
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe = result[0]
+        assert probe._classifier_template.C == 0.01

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,154 @@
+"""Tests for preprocessing pipeline parameter (Issue #74)."""
+
+from lmprobe import LinearProbe
+
+
+class TestPreprocessing:
+    """Tests for the preprocessing pipeline feature."""
+
+    def test_standard_scaler_string(self, tiny_model):
+        """preprocessing='standard' applies StandardScaler."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            preprocessing="standard",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great", "nice"], ["bad", "terrible", "awful"])
+        assert probe.preprocessing_pipeline_ is not None
+        assert len(probe.preprocessing_pipeline_.steps) == 1
+        assert probe.preprocessing_pipeline_.steps[0][0] == "scaler"
+
+    def test_standard_plus_pca(self, tiny_model):
+        """preprocessing='standard+pca:4' applies StandardScaler then PCA."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            preprocessing="standard+pca:4",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(
+            ["good", "great", "nice", "wonderful", "excellent"],
+            ["bad", "terrible", "awful", "horrible", "dreadful"],
+        )
+        assert probe.preprocessing_pipeline_ is not None
+        assert len(probe.preprocessing_pipeline_.steps) == 2
+        assert probe.preprocessing_pipeline_.steps[0][0] == "scaler"
+        assert probe.preprocessing_pipeline_.steps[1][0] == "pca"
+
+    def test_pca_with_pca_components_param(self, tiny_model):
+        """pca_components param sets PCA n_components when not specified inline."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            preprocessing="standard+pca",
+            pca_components=4,
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(
+            ["good", "great", "nice", "wonderful", "excellent"],
+            ["bad", "terrible", "awful", "horrible", "dreadful"],
+        )
+        assert probe.preprocessing_pipeline_ is not None
+        pca_step = probe.preprocessing_pipeline_.named_steps["pca"]
+        assert pca_step.n_components == 4
+
+    def test_fit_predict_with_preprocessing(self, tiny_model):
+        """Full roundtrip with preprocessing works correctly."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            preprocessing="standard+pca:4",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(
+            ["good", "great", "nice", "wonderful", "excellent"],
+            ["bad", "terrible", "awful", "horrible", "dreadful"],
+        )
+        predictions = probe.predict(["test input"])
+        assert predictions.shape == (1,)
+
+        probabilities = probe.predict_proba(["test input"])
+        assert probabilities.shape == (1, 2)
+
+    def test_no_preprocessing_by_default(self, tiny_model):
+        """No preprocessing pipeline when preprocessing=None."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        assert probe.preprocessing_pipeline_ is None
+
+    def test_preprocessing_as_list(self, tiny_model):
+        """preprocessing accepts list of step strings."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            preprocessing=["standard_scaler", "pca:4"],
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(
+            ["good", "great", "nice", "wonderful", "excellent"],
+            ["bad", "terrible", "awful", "horrible", "dreadful"],
+        )
+        assert probe.preprocessing_pipeline_ is not None
+        assert len(probe.preprocessing_pipeline_.steps) == 2
+
+    def test_invalid_preprocessing_step(self, tiny_model):
+        """Unknown preprocessing step raises ValueError."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Unknown preprocessing step"):
+            probe = LinearProbe(
+                model=tiny_model,
+                layers=-1,
+                preprocessing="unknown_step",
+                device="cpu",
+                remote=False,
+            )
+            probe.fit(["good"], ["bad"])
+
+    def test_pca_without_components_raises(self, tiny_model):
+        """PCA without component count raises ValueError."""
+        import pytest
+
+        with pytest.raises(ValueError, match="PCA requested but no component count"):
+            probe = LinearProbe(
+                model=tiny_model,
+                layers=-1,
+                preprocessing="pca",
+                device="cpu",
+                remote=False,
+            )
+            probe.fit(["good"], ["bad"])
+
+    def test_score_with_preprocessing(self, tiny_model):
+        """score() works correctly with preprocessing."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers=-1,
+            preprocessing="standard+pca:4",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(
+            ["good", "great", "nice", "wonderful", "excellent"],
+            ["bad", "terrible", "awful", "horrible", "dreadful"],
+        )
+        accuracy = probe.score(["test one", "test two"], [1, 0])
+        assert 0.0 <= accuracy <= 1.0

--- a/tests/test_sweep_mode.py
+++ b/tests/test_sweep_mode.py
@@ -1,0 +1,141 @@
+"""Tests for layers='sweep' mode (Issue #76)."""
+
+from lmprobe import LayerSweepResult, LinearProbe
+
+
+class TestSweepMode:
+    """Tests for the sweep layer specification in LinearProbe."""
+
+    def test_sweep_all_layers(self, tiny_model):
+        """layers='sweep' trains a probe per layer."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers="sweep",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        assert probe.sweep_result_ is not None
+        assert isinstance(probe.sweep_result_, LayerSweepResult)
+        assert len(probe.sweep_result_) > 1
+
+    def test_sweep_step(self, tiny_model):
+        """layers='sweep:8' sweeps every 8th layer."""
+        from lmprobe.extraction import get_num_layers_from_config
+
+        num_layers = get_num_layers_from_config(tiny_model)
+
+        probe = LinearProbe(
+            model=tiny_model,
+            layers="sweep:8",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        assert probe.sweep_result_ is not None
+
+        expected_layers = list(range(0, num_layers, 8))
+        assert probe.sweep_result_.layers == expected_layers
+
+    def test_sweep_range(self, tiny_model):
+        """layers='sweep:0-1' sweeps layers 0 through 1."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers="sweep:0-1",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        assert probe.sweep_result_ is not None
+        assert probe.sweep_result_.layers == [0, 1]
+
+    def test_sweep_predict_works(self, tiny_model):
+        """predict() works after sweep fit (uses first layer by default)."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers="sweep:0-1",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        predictions = probe.predict(["test input"])
+        assert predictions.shape == (1,)
+
+    def test_sweep_evaluate_returns_per_layer(self, tiny_model):
+        """evaluate() returns per-layer results in sweep mode."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers="sweep:0-2",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        results = probe.evaluate(["test one", "test two"], [1, 0])
+
+        assert "layer_results" in results
+        assert "best_layer" in results
+        assert "best_accuracy" in results
+        assert isinstance(results["best_layer"], int)
+        assert 0.0 <= results["best_accuracy"] <= 1.0
+
+        # Per-layer results should have metrics
+        for layer_idx, layer_metrics in results["layer_results"].items():
+            assert "accuracy" in layer_metrics
+            assert "f1" in layer_metrics
+
+    def test_sweep_evaluate_updates_to_best(self, tiny_model):
+        """After evaluate(), probe uses the best layer for predictions."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers="sweep:0-2",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        results = probe.evaluate(["test one", "test two"], [1, 0])
+
+        # After evaluate, probe should use best layer
+        best_layer = results["best_layer"]
+        best_probe = probe.sweep_result_[best_layer]
+
+        # Predictions should now come from best layer's classifier
+        assert probe.classifier_ is best_probe.classifier_
+
+    def test_sweep_with_classifier_kwargs(self, tiny_model):
+        """Sweep mode works with classifier_kwargs."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers="sweep:0-1",
+            classifier_kwargs={"C": 0.01},
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(["good", "great"], ["bad", "terrible"])
+        # Each sub-probe should have the custom C
+        for layer, sub_probe in probe.sweep_result_.probes.items():
+            assert sub_probe._classifier_template.C == 0.01
+
+    def test_sweep_with_preprocessing(self, tiny_model):
+        """Sweep mode works with preprocessing pipeline."""
+        probe = LinearProbe(
+            model=tiny_model,
+            layers="sweep:0-1",
+            preprocessing="standard+pca:4",
+            device="cpu",
+            remote=False,
+            random_state=42,
+        )
+        probe.fit(
+            ["good", "great", "nice", "wonderful", "excellent"],
+            ["bad", "terrible", "awful", "horrible", "dreadful"],
+        )
+        # Each sub-probe should have preprocessing
+        for layer, sub_probe in probe.sweep_result_.probes.items():
+            assert sub_probe.preprocessing_pipeline_ is not None


### PR DESCRIPTION
## Summary
- **`classifier_kwargs`** (#75): Pass hyperparameters like `C`, `solver`, `max_iter` directly to built-in classifiers without creating custom estimator instances. Works across all built-in classifiers and `sweep_layers`.
- **`preprocessing`** (#74): Apply `StandardScaler` + `PCA` pipeline before the classifier via `preprocessing="standard+pca:200"` or `preprocessing=["standard_scaler", "pca:200"]`. Automatically applied during `predict()` and `predict_proba()`.
- **`layers="sweep"`** (#76): Train an independent probe per layer using memory-safe single-layer extraction. Supports `"sweep"` (all layers), `"sweep:N"` (every Nth layer), and `"sweep:START-END"` (range). `evaluate()` returns per-layer metrics with `best_layer` and `best_accuracy`, then auto-selects the best layer for subsequent predictions.

Closes #74, closes #75, closes #76.

## Test plan
- [x] 7 tests for `classifier_kwargs` (custom C/solver/max_iter, SVM, ridge, roundtrip, sweep passthrough)
- [x] 9 tests for `preprocessing` (StandardScaler, PCA, list syntax, error cases, roundtrip)
- [x] 8 tests for sweep mode (all layers, step, range, predict, evaluate per-layer, best selection, kwargs/preprocessing passthrough)
- [x] All 392 existing tests pass (1 pre-existing remote test failure unrelated to this PR)
- [x] North star test passes
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)