### PR TITLE
Cache raw logits for baseline/ceiling analysis

### DIFF
--- a/src/lmprobe/__init__.py
+++ b/src/lmprobe/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "BaselineResult",
     "BaselineResults",
     "CacheInfo",
+    "CachedLogits",
     "LayerSweepResult",
     "LinearProbe",
     "Probe",
@@ -117,10 +118,14 @@ def __getattr__(name: str):
             "set_cache_limit": set_cache_limit,
             "set_cache_dtype": set_cache_dtype,
         }[name]
-    if name in ("UnifiedCache", "WarmupStats"):
-        from .unified_cache import UnifiedCache, WarmupStats
+    if name in ("UnifiedCache", "WarmupStats", "CachedLogits"):
+        from .unified_cache import CachedLogits, UnifiedCache, WarmupStats
 
-        return {"UnifiedCache": UnifiedCache, "WarmupStats": WarmupStats}[name]
+        return {
+            "UnifiedCache": UnifiedCache,
+            "WarmupStats": WarmupStats,
+            "CachedLogits": CachedLogits,
+        }[name]
     if name == "ProbeCard":
         from .hub import ProbeCard
 

--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -271,6 +271,9 @@ def _pooled_layer_key(pooling: str, layer: int) -> str:
 
 _ATTENTION_MASK_KEY = "attention_mask"
 _PERPLEXITY_KEY = "perplexity"
+_LOGITS_KEY = "logits"
+_LOGITS_TOP_K_VALUES_KEY = "logits_top_k_values"
+_LOGITS_TOP_K_INDICES_KEY = "logits_top_k_indices"
 
 
 def _parse_raw_layer_keys(keys: set[str] | list[str]) -> set[int]:
@@ -762,6 +765,135 @@ def save_prompt_perplexity(
     key = _prompt_cache_key(model_name, prompt)
     new_tensors = {_PERPLEXITY_KEY: _prepare_tensor(perplexity_features)}
     _merge_save_backend(key, new_tensors)
+
+
+# =============================================================================
+# Logit Cache Functions
+# =============================================================================
+
+
+def is_prompt_logits_cached(
+    model_name: str, prompt: str, top_k: int | None = None
+) -> bool:
+    """Check if logits are cached for a prompt.
+
+    Parameters
+    ----------
+    model_name : str
+        HuggingFace model ID.
+    prompt : str
+        The prompt text.
+    top_k : int | None
+        If None, checks for full logits. If int, checks for top-k logits.
+    """
+    backend = get_backend()
+    key = _prompt_cache_key(model_name, prompt)
+
+    if backend.exists(key):
+        tensor_keys = _get_tensor_keys_from_backend(key)
+        if top_k is not None:
+            return (
+                _LOGITS_TOP_K_VALUES_KEY in tensor_keys
+                and _LOGITS_TOP_K_INDICES_KEY in tensor_keys
+            )
+        return _LOGITS_KEY in tensor_keys
+
+    return False
+
+
+def save_prompt_logits(
+    model_name: str,
+    prompt: str,
+    logits: torch.Tensor,
+    attention_mask: torch.Tensor,
+    top_k: int | None = None,
+    positions: str = "last",
+) -> None:
+    """Save logits for a single prompt.
+
+    Parameters
+    ----------
+    model_name : str
+        HuggingFace model ID.
+    prompt : str
+        The prompt text.
+    logits : torch.Tensor
+        Raw logits with shape (1, seq_len, vocab_size).
+    attention_mask : torch.Tensor
+        Attention mask with shape (1, seq_len).
+    top_k : int | None
+        If set, store only top-k values and indices instead of full logits.
+    positions : str
+        Which token positions to store: "last" (default) or "all".
+    """
+    _register_model(model_name)
+    key = _prompt_cache_key(model_name, prompt)
+
+    # Select positions
+    if positions == "last":
+        # Find last non-padding position
+        mask = attention_mask[0]  # (seq_len,)
+        last_pos = mask.sum().long().item() - 1
+        selected_logits = logits[:, last_pos : last_pos + 1, :]  # (1, 1, vocab_size)
+    elif positions == "all":
+        selected_logits = logits  # (1, seq_len, vocab_size)
+    else:
+        raise ValueError(
+            f"Invalid positions: {positions!r}. Must be 'last' or 'all'."
+        )
+
+    if top_k is not None:
+        # Store only top-k values and indices
+        values, indices = torch.topk(selected_logits, top_k, dim=-1)
+        new_tensors = {
+            _LOGITS_TOP_K_VALUES_KEY: _prepare_tensor(values),
+            _LOGITS_TOP_K_INDICES_KEY: _prepare_tensor(indices.to(torch.int32)),
+        }
+    else:
+        new_tensors = {_LOGITS_KEY: _prepare_tensor(selected_logits)}
+
+    _merge_save_backend(key, new_tensors)
+
+
+def load_prompt_logits(
+    model_name: str, prompt: str, top_k: int | None = None
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Load cached logits for a single prompt.
+
+    Parameters
+    ----------
+    model_name : str
+        HuggingFace model ID.
+    prompt : str
+        The prompt text.
+    top_k : int | None
+        If None, loads full logits. If int, loads top-k values and indices.
+
+    Returns
+    -------
+    tuple[torch.Tensor, torch.Tensor | None]
+        If top_k is None: (logits, None) where logits has shape (1, positions, vocab_size).
+        If top_k is set: (values, indices) where values has shape (1, positions, K)
+        and indices has shape (1, positions, K) with dtype int32.
+    """
+    backend = get_backend()
+    key = _prompt_cache_key(model_name, prompt)
+
+    if not backend.exists(key):
+        raise FileNotFoundError(
+            f"No cached logits found for prompt: {prompt!r}"
+        )
+
+    backend.touch(key)
+
+    if top_k is not None:
+        tensors = _load_tensors_from_backend(
+            key, [_LOGITS_TOP_K_VALUES_KEY, _LOGITS_TOP_K_INDICES_KEY]
+        )
+        return tensors[_LOGITS_TOP_K_VALUES_KEY], tensors[_LOGITS_TOP_K_INDICES_KEY]
+    else:
+        tensors = _load_tensors_from_backend(key, [_LOGITS_KEY])
+        return tensors[_LOGITS_KEY], None
 
 
 # =============================================================================

--- a/src/lmprobe/unified_cache.py
+++ b/src/lmprobe/unified_cache.py
@@ -20,12 +20,15 @@ from .cache import (
     get_prompt_cached_pooled_layers,
     get_prompt_cached_raw_layers,
     is_prompt_fully_cached,
+    is_prompt_logits_cached,
     is_prompt_perplexity_cached,
     is_prompt_pooled_cached,
     load_prompt_activations,
+    load_prompt_logits,
     load_prompt_perplexity,
     load_prompt_pooled_activations,
     save_prompt_activations,
+    save_prompt_logits,
     save_prompt_perplexity,
     save_prompt_pooled_activations,
 )
@@ -53,6 +56,8 @@ class WarmupStats:
     perplexity_cached: int
     perplexity_extracted: int
     elapsed_seconds: float
+    logits_cached: int = 0
+    logits_extracted: int = 0
 
     @property
     def cache_hit_rate(self) -> float:
@@ -62,13 +67,44 @@ class WarmupStats:
         return self.activations_cached / self.total_prompts
 
     def __repr__(self) -> str:
-        return (
-            f"WarmupStats(total={self.total_prompts}, "
+        parts = [
+            f"WarmupStats(total={self.total_prompts}",
             f"activations={self.activations_cached} cached "
-            f"+ {self.activations_extracted} extracted, "
-            f"perplexity={self.perplexity_cached} cached + {self.perplexity_extracted} extracted, "
-            f"time={self.elapsed_seconds:.1f}s)"
-        )
+            f"+ {self.activations_extracted} extracted",
+            f"perplexity={self.perplexity_cached} cached "
+            f"+ {self.perplexity_extracted} extracted",
+        ]
+        if self.logits_cached or self.logits_extracted:
+            parts.append(
+                f"logits={self.logits_cached} cached "
+                f"+ {self.logits_extracted} extracted"
+            )
+        parts.append(f"time={self.elapsed_seconds:.1f}s)")
+        return ", ".join(parts)
+
+
+@dataclass
+class CachedLogits:
+    """Cached logits from language model extraction.
+
+    Attributes
+    ----------
+    values : torch.Tensor
+        Logit values. Shape (batch, positions, vocab_size) for full logits,
+        or (batch, positions, K) for top-k logits.
+    indices : torch.Tensor | None
+        Top-k token indices with shape (batch, positions, K) and dtype int32.
+        None when full logits are stored.
+    top_k : int | None
+        K value if top-k logits, None for full logits.
+    positions : str
+        Which token positions are stored: "last" or "all".
+    """
+
+    values: torch.Tensor
+    indices: torch.Tensor | None
+    top_k: int | None
+    positions: str
 
 
 class UnifiedCache:
@@ -144,6 +180,9 @@ class UnifiedCache:
         pooling: str = "last_token",
         backend: str = "local",
         dtype: str | None = None,
+        cache_logits: bool = False,
+        logit_top_k: int | None = None,
+        logit_positions: str = "last",
     ):
         self.model_name = model
         self.layers_spec = layers
@@ -155,6 +194,9 @@ class UnifiedCache:
         self.pooling = pooling
         self.backend_name = backend
         self.dtype = dtype
+        self.cache_logits = cache_logits
+        self.logit_top_k = logit_top_k
+        self.logit_positions = logit_positions
 
         # Validate pooling strategy
         if cache_pooled and pooling not in TRAIN_POOLING_STRATEGIES:
@@ -166,6 +208,12 @@ class UnifiedCache:
             raise ValueError(
                 "pooling='all' is not valid with cache_pooled=True. "
                 "Use 'last_token', 'first_token', or 'mean'."
+            )
+
+        if logit_positions not in ("last", "all"):
+            raise ValueError(
+                f"Invalid logit_positions: {logit_positions!r}. "
+                f"Must be 'last' or 'all'."
             )
 
         # Create backend (lazy-loads model)
@@ -216,7 +264,7 @@ class UnifiedCache:
 
     def _check_cache_status(
         self, prompts: list[str]
-    ) -> tuple[list[str], list[str]]:
+    ) -> tuple[list[str], list[str], list[str]]:
         """Check which prompts need extraction.
 
         Returns
@@ -224,11 +272,13 @@ class UnifiedCache:
         tuple
             - prompts needing activation extraction
             - prompts needing perplexity extraction (if compute_perplexity=True)
+            - prompts needing logit extraction (if cache_logits=True)
         """
         required_layers = set(self.layer_indices)
 
         need_activations = []
         need_perplexity = []
+        need_logits = []
         partial_cache_count = 0
         partial_cache_found_layers: set[int] | None = None
 
@@ -246,6 +296,14 @@ class UnifiedCache:
             ppl_cached = (
                 is_prompt_perplexity_cached(self.model_name, prompt)
                 if self.compute_perplexity
+                else True
+            )
+
+            logits_cached = (
+                is_prompt_logits_cached(
+                    self.model_name, prompt, self.logit_top_k
+                )
+                if self.cache_logits
                 else True
             )
 
@@ -268,6 +326,9 @@ class UnifiedCache:
             if not ppl_cached:
                 need_perplexity.append(prompt)
 
+            if not logits_cached:
+                need_logits.append(prompt)
+
         if partial_cache_count > 0:
             missing = sorted(required_layers - (partial_cache_found_layers or set()))
             found = sorted(partial_cache_found_layers or set())
@@ -281,7 +342,7 @@ class UnifiedCache:
                 stacklevel=2,
             )
 
-        return need_activations, need_perplexity
+        return need_activations, need_perplexity, need_logits
 
     def warmup(
         self,
@@ -316,19 +377,24 @@ class UnifiedCache:
         layer_indices = sorted(self.layer_indices)
 
         # Check cache status
-        need_activations, need_perplexity = self._check_cache_status(prompts)
+        need_activations, need_perplexity, need_logits = self._check_cache_status(
+            prompts
+        )
 
         # Compute which prompts need unified extraction
         # (prompts that need BOTH or where we can get both cheaply)
         need_activations_set = set(need_activations)
         need_perplexity_set = set(need_perplexity)
-        need_unified = need_activations_set | need_perplexity_set
+        need_logits_set = set(need_logits)
+        need_unified = need_activations_set | need_perplexity_set | need_logits_set
         need_unified_list = [p for p in prompts if p in need_unified]
 
         activations_cached = len(prompts) - len(need_activations)
         perplexity_cached = len(prompts) - len(need_perplexity)
+        logits_cached = len(prompts) - len(need_logits) if self.cache_logits else 0
         activations_extracted = 0
         perplexity_extracted = 0
+        logits_extracted = 0
 
         logger.info(
             f"[UNIFIED] Checking cache for {len(prompts)} prompts, "
@@ -342,6 +408,11 @@ class UnifiedCache:
             logger.info(
                 f"[UNIFIED] Perplexity: {perplexity_cached} cached, "
                 f"{len(need_perplexity)} need extraction"
+            )
+        if self.cache_logits:
+            logger.info(
+                f"[UNIFIED] Logits: {logits_cached} cached, "
+                f"{len(need_logits)} need extraction"
             )
 
         if need_unified_list:
@@ -422,6 +493,18 @@ class UnifiedCache:
                             )
                             perplexity_extracted += 1
 
+                        # Save logits if needed
+                        if self.cache_logits and prompt in need_logits_set:
+                            save_prompt_logits(
+                                self.model_name,
+                                prompt,
+                                batch_logits[j : j + 1],
+                                batch_mask[j : j + 1],
+                                self.logit_top_k,
+                                self.logit_positions,
+                            )
+                            logits_extracted += 1
+
         elapsed = time.time() - start_time
 
         stats = WarmupStats(
@@ -430,12 +513,15 @@ class UnifiedCache:
             activations_extracted=activations_extracted,
             perplexity_cached=perplexity_cached,
             perplexity_extracted=perplexity_extracted,
+            logits_cached=logits_cached,
+            logits_extracted=logits_extracted,
             elapsed_seconds=elapsed,
         )
 
         logger.info(
             f"[UNIFIED] Complete: {activations_extracted} activations + "
-            f"{perplexity_extracted} perplexity extracted in {elapsed:.1f}s"
+            f"{perplexity_extracted} perplexity + "
+            f"{logits_extracted} logits extracted in {elapsed:.1f}s"
         )
 
         return stats
@@ -552,3 +638,49 @@ class UnifiedCache:
             features.append(ppl.float().numpy())
 
         return np.array(features)
+
+    def get_logits(
+        self,
+        prompts: list[str],
+        remote: bool | None = None,
+    ) -> CachedLogits:
+        """Get cached logits for prompts (from cache or via extraction).
+
+        Parameters
+        ----------
+        prompts : list[str]
+            Text prompts.
+        remote : bool | None
+            Override the instance-level remote setting.
+
+        Returns
+        -------
+        CachedLogits
+            Cached logits with values and optional indices tensors.
+        """
+        if not self.cache_logits:
+            raise ValueError(
+                "UnifiedCache was created with cache_logits=False. "
+                "Create a new instance with cache_logits=True."
+            )
+
+        # Ensure cache is warm
+        self.warmup(prompts, remote=remote)
+
+        # Load from cache
+        all_values = []
+        all_indices = []
+        for prompt in prompts:
+            values, indices = load_prompt_logits(
+                self.model_name, prompt, self.logit_top_k
+            )
+            all_values.append(values)
+            if indices is not None:
+                all_indices.append(indices)
+
+        return CachedLogits(
+            values=torch.cat(all_values, dim=0),
+            indices=torch.cat(all_indices, dim=0) if all_indices else None,
+            top_k=self.logit_top_k,
+            positions=self.logit_positions,
+        )

--- a/tests/test_unified_cache.py
+++ b/tests/test_unified_cache.py
@@ -7,10 +7,11 @@ import pytest
 
 from lmprobe.cache import (
     get_prompt_cache_dir,
+    is_prompt_logits_cached,
     is_prompt_perplexity_cached,
     is_prompt_pooled_cached,
 )
-from lmprobe.unified_cache import UnifiedCache, WarmupStats
+from lmprobe.unified_cache import CachedLogits, UnifiedCache, WarmupStats
 
 
 class TestUnifiedCache:
@@ -624,3 +625,156 @@ class TestPooledCache:
         assert activations.ndim == 2  # Pooled
         assert mask is None
         assert ppl.shape == (1, 3)
+
+
+class TestCachedLogits:
+    """Tests for cache_logits feature."""
+
+    def test_cache_logits_full(self, tiny_model, tmp_path, monkeypatch):
+        """Full logits cached and retrieved with correct shape."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            compute_perplexity=False,
+            device="cpu",
+            remote=False,
+            cache_logits=True,
+            logit_positions="all",
+        )
+
+        prompts = ["hello world", "test prompt"]
+        stats = cache.warmup(prompts)
+
+        assert stats.logits_extracted == 2
+        assert stats.logits_cached == 0
+
+        result = cache.get_logits(prompts)
+        assert isinstance(result, CachedLogits)
+        assert result.values.ndim == 3  # (batch, seq_len, vocab_size)
+        assert result.values.shape[0] == 2
+        assert result.indices is None
+        assert result.top_k is None
+        assert result.positions == "all"
+
+    def test_cache_logits_top_k(self, tiny_model, tmp_path, monkeypatch):
+        """Top-K values + indices cached with correct shape."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        K = 10
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            compute_perplexity=False,
+            device="cpu",
+            remote=False,
+            cache_logits=True,
+            logit_top_k=K,
+            logit_positions="last",
+        )
+
+        prompts = ["top k test"]
+        cache.warmup(prompts)
+
+        result = cache.get_logits(prompts)
+        assert result.values.shape == (1, 1, K)  # (batch, 1 position, K)
+        assert result.indices is not None
+        assert result.indices.shape == (1, 1, K)
+        assert result.indices.dtype == np.int32 or str(result.indices.dtype) == "torch.int32"
+        assert result.top_k == K
+
+    def test_cache_logits_last_position(self, tiny_model, tmp_path, monkeypatch):
+        """positions='last' stores only 1 position per prompt."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            compute_perplexity=False,
+            device="cpu",
+            remote=False,
+            cache_logits=True,
+            logit_positions="last",
+        )
+
+        prompts = ["a longer prompt with several tokens for testing"]
+        cache.warmup(prompts)
+
+        result = cache.get_logits(prompts)
+        # Should have only 1 position (last token)
+        assert result.values.shape[1] == 1
+        assert result.positions == "last"
+
+    def test_cache_logits_idempotent(self, tiny_model, tmp_path, monkeypatch):
+        """Second warmup is all cache hits for logits."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            compute_perplexity=False,
+            device="cpu",
+            remote=False,
+            cache_logits=True,
+            logit_positions="last",
+        )
+
+        prompts = ["idempotent logit test"]
+
+        stats1 = cache.warmup(prompts)
+        assert stats1.logits_extracted == 1
+        assert stats1.logits_cached == 0
+
+        stats2 = cache.warmup(prompts)
+        assert stats2.logits_cached == 1
+        assert stats2.logits_extracted == 0
+
+    def test_cache_logits_default_off(self, tiny_model, tmp_path, monkeypatch):
+        """Default cache_logits=False; get_logits() raises ValueError."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            compute_perplexity=False,
+            device="cpu",
+            remote=False,
+        )
+
+        with pytest.raises(ValueError, match="cache_logits=False"):
+            cache.get_logits(["test"])
+
+    def test_cache_logits_with_perplexity(self, tiny_model, tmp_path, monkeypatch):
+        """Both logits and perplexity work together from same forward pass."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        cache = UnifiedCache(
+            model=tiny_model,
+            layers=[0],
+            compute_perplexity=True,
+            device="cpu",
+            remote=False,
+            cache_logits=True,
+            logit_positions="last",
+        )
+
+        prompts = ["combined test prompt"]
+        stats = cache.warmup(prompts)
+
+        assert stats.activations_extracted == 1
+        assert stats.perplexity_extracted == 1
+        assert stats.logits_extracted == 1
+
+        # Both should load from cache
+        ppl = cache.get_perplexity(prompts)
+        logits = cache.get_logits(prompts)
+
+        assert ppl.shape == (1, 3)
+        assert logits.values.ndim == 3
+        assert logits.values.shape[0] == 1
+
+        # Verify cache is populated
+        for prompt in prompts:
+            assert is_prompt_perplexity_cached(tiny_model, prompt)
+            assert is_prompt_logits_cached(tiny_model, prompt)


### PR DESCRIPTION
## Summary

- Add opt-in `cache_logits` flag to `UnifiedCache` that persists raw logits (or top-K logits) from the existing forward pass, eliminating redundant NDIF round-trips for downstream baseline/ceiling analysis
- Support `logit_top_k` for storage-efficient top-K caching and `logit_positions` ("last" or "all") for selecting which token positions to store
- Add `CachedLogits` dataclass and `get_logits()` method following the existing `get_perplexity()` pattern exactly
- Fully additive — `cache_logits=False` default means zero impact on existing users/caches

Closes #88

## Test plan

- [x] 6 new tests covering full logits, top-k, last position, idempotency, default-off error, and combined with perplexity
- [x] All 32 unified cache tests pass (26 existing + 6 new, zero regressions)
- [ ] Manual verification with real model via `UnifiedCache(model=..., cache_logits=True)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)