### PR TITLE
Fix push_dataset OOM with streaming consolidation

### DIFF
--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -656,12 +656,11 @@ def _consolidate_and_shard(
 
                 shard_data.append(loaded)
             except (FileNotFoundError, KeyError, OSError) as e:
-                logger.warning(
-                    f"[SHARING] Failed to load prompt during shard write "
-                    f"(was valid during scan): {e}"
-                )
-                # Append empty dict to preserve alignment with metadata
-                shard_data.append({})
+                raise OSError(
+                    f"Prompt passed metadata scan but failed to load during "
+                    f"shard write (cache may have been modified concurrently): "
+                    f"{e}"
+                ) from e
 
         # Write hidden_layers shard
         if hidden_layers and (hidden_strategy or use_raw):


### PR DESCRIPTION
## Summary

- **Fixes #101** — `push_dataset` OOMs on large datasets because `_consolidate_and_shard` loads all prompts' tensors into memory before writing any shard
- Restructures consolidation into a streaming two-pass approach: metadata-only scan first, then write shards one at a time (load → write → free)
- Peak memory is now bounded by `shard_max_bytes` (default 1 GB) instead of total dataset size

## How it works

1. **Phase 1 (metadata-only):** Validates prompts via `discover_cached()` — no tensor loading
2. **Phase 2:** Shuffles lightweight metadata lists
3. **Phase 3:** Probes one prompt for `hidden_dim`, computes shard boundaries
4. **Phase 4 (streaming):** For each shard, loads only that shard's prompts, writes safetensors, then `del` to free before next shard

## Test plan

- [x] All 55 previously-passing `test_sharing.py` tests still pass
- [x] 9 pre-existing failures confirmed unrelated (same failures on `main`)
- [ ] Manual test with large dataset (405B activations, ~348 GB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)