### PR TITLE
Fix left-padding position selection in logit saving and pooling

### DIFF
--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -1414,9 +1414,9 @@ def save_prompt_logits(
 
     # Select positions
     if positions == "last":
-        # Find last non-padding position
+        # Find last non-padding position (works for both left- and right-padding)
         mask = attention_mask[0]  # (seq_len,)
-        last_pos = mask.sum().long().item() - 1
+        last_pos = mask.nonzero(as_tuple=True)[0][-1].item()
         selected_logits = logits[:, last_pos : last_pos + 1, :]  # (1, 1, vocab_size)
     elif positions == "all":
         selected_logits = logits  # (1, seq_len, vocab_size)
@@ -1474,8 +1474,9 @@ def save_prompt_topk_logits(
 
     # Select positions
     if positions == "last":
+        # Find last non-padding position (works for both left- and right-padding)
         mask = attention_mask[0]  # (seq_len,)
-        last_pos = mask.sum().long().item() - 1
+        last_pos = mask.nonzero(as_tuple=True)[0][-1].item()
         selected_values = values[:, last_pos : last_pos + 1, :]  # (1, 1, K)
         selected_indices = indices[:, last_pos : last_pos + 1, :]  # (1, 1, K)
     elif positions == "all":

--- a/src/lmprobe/pooling.py
+++ b/src/lmprobe/pooling.py
@@ -64,12 +64,13 @@ def pool_last_token(
         return activations[:, -1, :]
 
     # Find the last non-padding position for each sequence
-    # attention_mask is 1 for real tokens, 0 for padding
-    seq_lengths = attention_mask.sum(dim=1)  # (batch,)
-    last_indices = (seq_lengths - 1).long()  # (batch,)
+    # Works for both left-padding and right-padding
+    batch_size = activations.shape[0]
+    last_indices = torch.stack(
+        [attention_mask[i].nonzero(as_tuple=True)[0][-1] for i in range(batch_size)]
+    )
 
     # Gather the last token for each sequence
-    batch_size = activations.shape[0]
     batch_indices = torch.arange(batch_size, device=activations.device)
     return activations[batch_indices, last_indices, :]
 


### PR DESCRIPTION
## Summary
- `save_prompt_logits()`, `save_prompt_topk_logits()`, and `pool_last_token()` used `mask.sum() - 1` to find the last real token position — this is wrong for left-padding tokenizers
- nnsight defaults to `padding_side="left"`, causing 16-27% of cached logits to be corrupt (garbage from padding positions)
- Replaced with `mask.nonzero()[-1]` which finds the actual last `1` in the mask, working for both left- and right-padding

Fixes #105

## Test plan
- [x] All 464 existing tests pass (the 1 failure in `test_remote_caching` is pre-existing)
- [ ] Verify on Llama 3.1 70B via NDIF that short prompts in a batch now select correct logit positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)