### PR TITLE
Fix shard boundary issues (#107, #91)

### DIFF
--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -906,8 +906,8 @@ def _load_raw_from_shard(
             f"but shard has storage={storage!r}"
         )
 
-    shard_idx = entry["shard_index"]
-    tok_off = entry["token_offset"]
+    shard_idx = entry.get("shard_index_hidden", entry.get("shard_index"))
+    tok_off = entry.get("token_offset_hidden", entry.get("token_offset"))
     num_tok = entry["num_tokens"]
 
     shards = t_info["shards"]
@@ -919,7 +919,7 @@ def _load_raw_from_shard(
     layout = t_info.get("layout")
 
     if layout == "per_layer":
-        # v1.1 per-layer layout: each layer in its own file
+        # v1.1+ per-layer layout: each layer in its own file
         layer_slices = []
         for layer in layers:
             per_layer_paths = shards[shard_idx].get("per_layer_paths", {})
@@ -995,7 +995,7 @@ def _load_pooled_from_shard(
 
     storage = t_info.get("storage", "pooled")
     layout = t_info.get("layout")
-    shard_idx = entry["shard_index"]
+    shard_idx = entry.get("shard_index_hidden", entry.get("shard_index"))
 
     shards = t_info["shards"]
     if shard_idx >= len(shards):
@@ -1004,12 +1004,12 @@ def _load_pooled_from_shard(
         )
 
     if layout == "per_layer":
-        # v1.1 per-layer layout
+        # v1.1+ per-layer layout
         per_layer_paths = shards[shard_idx].get("per_layer_paths", {})
         layer_slices = []
 
         if storage == "full_sequence":
-            tok_off = entry["token_offset"]
+            tok_off = entry.get("token_offset_hidden", entry.get("token_offset"))
             num_tok = entry["num_tokens"]
             for layer in layers:
                 layer_path = per_layer_paths.get(
@@ -1029,7 +1029,7 @@ def _load_pooled_from_shard(
                     ]
                     layer_slices.append((layer, last_tok))
         else:
-            row_offset = entry["row_offset"]
+            row_offset = entry.get("row_offset_hidden", entry.get("row_offset"))
             for layer in layers:
                 layer_path = per_layer_paths.get(
                     layer
@@ -1113,8 +1113,8 @@ def _load_logits_from_shard(
     if t_info is None:
         raise FileNotFoundError("No logits_topk in shard manifest")
 
-    shard_idx = entry["shard_index"]
-    row_offset = entry["row_offset"]
+    shard_idx = entry.get("shard_index_logits", entry.get("shard_index"))
+    row_offset = entry.get("row_offset_logits", entry.get("row_offset"))
 
     shards = t_info["shards"]
     if shard_idx >= len(shards):

--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -55,7 +55,7 @@ from .cache import (
 
 logger = logging.getLogger(__name__)
 
-FORMAT_VERSION = "1.1"
+FORMAT_VERSION = "1.2"
 DEFAULT_SHARD_BYTES = 1_073_741_824  # 1 GB
 INFO_FILENAME = "lmprobe_info.json"
 PARQUET_PATH = "index/train-00000-of-00001.parquet"
@@ -469,9 +469,9 @@ def _consolidate_and_shard(
 ) -> tuple[Path, dict, list[dict]]:
     """Consolidate cached tensors into sharded safetensors files.
 
-    Layers are co-located within each hidden_layers shard.  All tensor types
-    share the same shard boundaries (same prompt ordering, same num_prompts
-    per shard).
+    Layers are co-located within each hidden_layers shard.  Each tensor type
+    gets independent shard boundaries (v1.2), so small logits data isn't
+    needlessly split across many shards.
 
     Uses streaming consolidation: only one shard's worth of tensors is held
     in memory at a time, so peak memory is bounded by ``shard_max_bytes``
@@ -599,76 +599,81 @@ def _consolidate_and_shard(
         # values (float32) + indices (int64)
         logits_row_bytes = logits_top_k * 4 + logits_top_k * 8
 
+    # Compute independent shard boundaries per tensor type (v1.2)
+    has_hidden = bool(hidden_layers and (hidden_strategy or use_raw))
+    want_logits = bool(has_logits and logits_top_k is not None)
+
     if use_raw:
         # Variable-size rows: bytes depend on per-prompt token count
         per_prompt_bytes = [
-            tok * hidden_dim * 4 * len(hidden_layers)
+            tok * hidden_dim * 4
             for tok in per_prompt_tokens
         ]
-        shard_boundaries = _compute_shard_boundaries_variable(
+        hidden_boundaries = _compute_shard_boundaries_variable(
             per_prompt_bytes, shard_max_bytes,
         )
     else:
-        # Per-layer sharding: row_bytes is per single layer (not all layers)
         hidden_row_bytes = hidden_dim * 4  # float32, single layer
-        max_row_bytes = max(hidden_row_bytes, logits_row_bytes, 1)
-        shard_boundaries = _compute_shard_boundaries(
-            n, max_row_bytes, shard_max_bytes,
+        hidden_boundaries = _compute_shard_boundaries(
+            n, hidden_row_bytes, shard_max_bytes,
+        ) if has_hidden else []
+
+    if want_logits:
+        logits_boundaries = _compute_shard_boundaries(
+            n, max(logits_row_bytes, 1), shard_max_bytes,
         )
+    else:
+        logits_boundaries = []
 
-    # --- Phase 4: Stream shards (load one shard at a time) ---
+    # --- Phase 4: Stream shards per tensor type ---
     tensor_descriptors: dict[str, dict] = {}
-    offset = 0
 
-    for shard_idx, shard_size in enumerate(tqdm(
-        shard_boundaries, desc="Writing shards", unit="shard",
-    )):
-        shard_prompts_text = valid_prompts[offset : offset + shard_size]
-
-        # Assign shard_index and row_offset / token_offset to metadata
+    # --- Hidden pass ---
+    if has_hidden and hidden_boundaries:
+        offset = 0
         token_offset_acc = 0
-        for local_row in range(shard_size):
-            global_row = offset + local_row
-            if global_row < len(prompt_metadata):
-                prompt_metadata[global_row]["shard_index"] = shard_idx
-                prompt_metadata[global_row]["row_offset"] = local_row
-                if use_raw:
-                    prompt_metadata[global_row]["token_offset"] = token_offset_acc
-                    token_offset_acc += per_prompt_tokens[global_row]
+        for shard_idx, shard_size in enumerate(tqdm(
+            hidden_boundaries, desc="Writing hidden shards", unit="shard",
+        )):
+            shard_prompts_text = valid_prompts[offset : offset + shard_size]
 
-        # Load only this shard's tensors from cache
-        shard_data: list[dict] = []
-        for prompt in shard_prompts_text:
-            try:
-                loaded: dict[str, torch.Tensor] = {}
+            # Assign per-type shard metadata
+            for local_row in range(shard_size):
+                global_row = offset + local_row
+                if global_row < len(prompt_metadata):
+                    prompt_metadata[global_row]["shard_index_hidden"] = shard_idx
+                    prompt_metadata[global_row]["row_offset_hidden"] = local_row
+                    # Legacy aliases (point to hidden by default)
+                    prompt_metadata[global_row]["shard_index"] = shard_idx
+                    prompt_metadata[global_row]["row_offset"] = local_row
+                    if use_raw:
+                        prompt_metadata[global_row]["token_offset_hidden"] = token_offset_acc
+                        prompt_metadata[global_row]["token_offset"] = token_offset_acc
+                        token_offset_acc += per_prompt_tokens[global_row]
 
-                if use_raw and hidden_layers:
-                    layer_tensors, _ = _load_hidden_raw_for_prompt(
-                        model_name, prompt, hidden_layers,
-                    )
-                    loaded.update(layer_tensors)
-                elif hidden_strategy and hidden_layers:
-                    layer_tensors = _load_hidden_for_prompt(
-                        model_name, prompt, hidden_layers, hidden_strategy,
-                    )
-                    loaded.update(layer_tensors)
+            # Load and write hidden tensors for this shard
+            shard_data: list[dict] = []
+            for prompt in shard_prompts_text:
+                try:
+                    loaded: dict[str, torch.Tensor] = {}
+                    if use_raw:
+                        layer_tensors, _ = _load_hidden_raw_for_prompt(
+                            model_name, prompt, hidden_layers,
+                        )
+                        loaded.update(layer_tensors)
+                    elif hidden_strategy:
+                        layer_tensors = _load_hidden_for_prompt(
+                            model_name, prompt, hidden_layers, hidden_strategy,
+                        )
+                        loaded.update(layer_tensors)
+                    shard_data.append(loaded)
+                except (FileNotFoundError, KeyError, OSError) as e:
+                    raise OSError(
+                        f"Prompt passed metadata scan but failed to load during "
+                        f"shard write (cache may have been modified concurrently): "
+                        f"{e}"
+                    ) from e
 
-                if has_logits and logits_top_k is not None:
-                    logit_tensors = _load_logits_for_prompt(
-                        model_name, prompt, logits_top_k,
-                    )
-                    loaded.update(logit_tensors)
-
-                shard_data.append(loaded)
-            except (FileNotFoundError, KeyError, OSError) as e:
-                raise OSError(
-                    f"Prompt passed metadata scan but failed to load during "
-                    f"shard write (cache may have been modified concurrently): "
-                    f"{e}"
-                ) from e
-
-        # Write per-layer hidden shard files (v1.1 layout)
-        if hidden_layers and (hidden_strategy or use_raw):
             for layer in hidden_layers:
                 key = f"hidden.layer_{layer}"
                 rows = [p[key] for p in shard_data if key in p]
@@ -681,43 +686,80 @@ def _consolidate_and_shard(
                     save_file(layer_tensor, str(tmpdir / fname))
                     del layer_tensor
 
-        # Write logits_topk shard
-        if has_logits and logits_top_k is not None:
+            del shard_data
+            offset += shard_size
+            if not use_raw:
+                token_offset_acc = 0  # reset per shard only matters for raw
+
+    # --- Logits pass ---
+    if want_logits and logits_boundaries:
+        offset = 0
+        for shard_idx, shard_size in enumerate(tqdm(
+            logits_boundaries, desc="Writing logits shards", unit="shard",
+        )):
+            shard_prompts_text = valid_prompts[offset : offset + shard_size]
+
+            # Assign per-type shard metadata for logits
+            for local_row in range(shard_size):
+                global_row = offset + local_row
+                if global_row < len(prompt_metadata):
+                    prompt_metadata[global_row]["shard_index_logits"] = shard_idx
+                    prompt_metadata[global_row]["row_offset_logits"] = local_row
+                    # If no hidden, legacy columns point to logits
+                    if not has_hidden:
+                        prompt_metadata[global_row]["shard_index"] = shard_idx
+                        prompt_metadata[global_row]["row_offset"] = local_row
+
+            # Load and write logits tensors for this shard
+            shard_data_logits: list[dict] = []
+            for prompt in shard_prompts_text:
+                try:
+                    loaded_l: dict[str, torch.Tensor] = {}
+                    if logits_top_k is not None:
+                        logit_tensors = _load_logits_for_prompt(
+                            model_name, prompt, logits_top_k,
+                        )
+                        loaded_l.update(logit_tensors)
+                    shard_data_logits.append(loaded_l)
+                except (FileNotFoundError, KeyError, OSError) as e:
+                    raise OSError(
+                        f"Prompt passed metadata scan but failed to load during "
+                        f"shard write (cache may have been modified concurrently): "
+                        f"{e}"
+                    ) from e
+
             vals = [
                 p["logits_topk.values"]
-                for p in shard_data
+                for p in shard_data_logits
                 if "logits_topk.values" in p
             ]
             idxs = [
                 p["logits_topk.indices"]
-                for p in shard_data
+                for p in shard_data_logits
                 if "logits_topk.indices" in p
             ]
             if vals and idxs:
-                logits_tensors = {
+                logits_tensors_out = {
                     "logits_topk.values": torch.cat(vals, dim=0),
                     "logits_topk.indices": torch.cat(idxs, dim=0),
                 }
                 fname = f"tensors/logits_topk_{shard_idx:03d}.safetensors"
-                save_file(logits_tensors, str(tmpdir / fname))
-                del logits_tensors
+                save_file(logits_tensors_out, str(tmpdir / fname))
+                del logits_tensors_out
 
-        # Free this shard's data before loading the next
-        del shard_data
-
-        offset += shard_size
+            del shard_data_logits
+            offset += shard_size
 
     # Build tensor descriptors for lmprobe_info.json
-    if hidden_layers and (hidden_strategy or use_raw):
+    if has_hidden and hidden_boundaries:
         hidden_shards = []
         off = 0
-        for si, sz in enumerate(shard_boundaries):
+        for si, sz in enumerate(hidden_boundaries):
             actual = min(sz, n - off)
             shard_desc: dict[str, Any] = {
                 "num_prompts": actual,
             }
             if use_raw:
-                # Total tokens in this shard
                 shard_desc["num_tokens"] = sum(
                     per_prompt_tokens[off : off + actual]
                 )
@@ -741,10 +783,10 @@ def _consolidate_and_shard(
 
         tensor_descriptors["hidden_layers"] = hidden_desc
 
-    if has_logits and logits_top_k is not None:
+    if want_logits and logits_boundaries:
         logits_shards = []
         off = 0
-        for si, sz in enumerate(shard_boundaries):
+        for si, sz in enumerate(logits_boundaries):
             actual = min(sz, n - off)
             logits_shards.append({
                 "file": f"tensors/logits_topk_{si:03d}.safetensors",
@@ -806,11 +848,24 @@ def _write_parquet_index(
         "row_offset": pa.array(row_offsets, type=pa.int32()),
     }
 
+    # Per-type shard columns (v1.2)
+    per_type_keys = {
+        "shard_index_hidden", "row_offset_hidden", "token_offset_hidden",
+        "shard_index_logits", "row_offset_logits",
+    }
+    for ptk in per_type_keys:
+        if any(ptk in p for p in prompt_metadata):
+            vals = [p.get(ptk, 0) for p in prompt_metadata]
+            if "token_offset" in ptk:
+                columns[ptk] = pa.array(vals, type=pa.int64())
+            else:
+                columns[ptk] = pa.array(vals, type=pa.int32())
+
     # token_offset is a fixed column (int64 for large shards) when present
     fixed_keys = {
         "text", "label", "num_tokens", "shard_index", "row_offset",
         "token_offset",
-    }
+    } | per_type_keys
     if any("token_offset" in p for p in prompt_metadata):
         token_offsets = [p.get("token_offset", 0) for p in prompt_metadata]
         columns["token_offset"] = pa.array(token_offsets, type=pa.int64())
@@ -1461,12 +1516,18 @@ def pull_dataset(
     else:
         pull_types = list(tensor_descriptors.keys())
 
-    # Figure out which shards we need
+    # Figure out which shards we need (v1.2: per-type shard indices)
     needed_shards: dict[str, set[int]] = {}
     for i in prompt_indices:
-        shard_idx = index["shard_index"][i]
         for t_type in pull_types:
-            needed_shards.setdefault(t_type, set()).add(shard_idx)
+            if t_type == "logits_topk" and "shard_index_logits" in index:
+                si = index["shard_index_logits"][i]
+            elif t_type == "hidden_layers" and "shard_index_hidden" in index:
+                si = index["shard_index_hidden"][i]
+            else:
+                # Legacy v1.1 fallback: single shard_index for all types
+                si = index["shard_index"][i]
+            needed_shards.setdefault(t_type, set()).add(si)
 
     # Download shard files and record local paths
     # For per-layer layout (v1.1), we download per-layer files
@@ -1567,6 +1628,13 @@ def pull_dataset(
         }
         if "token_offset" in index:
             entry["token_offset"] = index["token_offset"][i]
+        # Per-type fields (v1.2)
+        for col in (
+            "shard_index_hidden", "row_offset_hidden", "token_offset_hidden",
+            "shard_index_logits", "row_offset_logits",
+        ):
+            if col in index:
+                entry[col] = index[col][i]
         shard_index[prompt_hash] = entry
 
     write_shard_registry(model_name, manifest, shard_index)

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -1363,9 +1363,11 @@ class TestRoundtrip:
         table = pq.read_table(str(remote_dir / PARQUET_PATH))
 
         assert table.num_rows == 2
-        assert set(table.column_names) == {
+        expected_cols = {
             "text", "label", "num_tokens", "shard_index", "row_offset",
+            "shard_index_hidden", "row_offset_hidden",
         }
+        assert set(table.column_names) == expected_cols
         assert set(table.column("text").to_pylist()) == set(prompts)
         assert set(table.column("label").to_pylist()) == {0, 1}
 
@@ -2317,3 +2319,305 @@ class TestLayersParam:
         ]
         assert len(tensor_downloads) == 1
         assert "hidden_layer000" in tensor_downloads[0]
+
+
+# =============================================================================
+# v1.2 independent shard boundary tests
+# =============================================================================
+
+
+class TestIndependentShardBoundaries:
+    """Test that hidden and logits get independent shard boundaries (v1.2)."""
+
+    @requires_pyarrow
+    def test_different_shard_counts_per_type(self, tmp_path, monkeypatch):
+        """With small logits and large hidden, logits should use fewer shards."""
+        src_cache = tmp_path / "src_cache"
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(src_cache))
+        cache_mod._backend = None
+
+        prompts = [f"prompt {i}" for i in range(10)]
+        layers = [0, 1]
+        top_k = 5
+        vocab_size = 50
+
+        for prompt in prompts:
+            # Pooled hidden (fairly large per row)
+            for layer in layers:
+                pooled = torch.randn(1, HIDDEN_DIM)
+                save_prompt_pooled_activations(
+                    TEST_MODEL, prompt, [layer], pooled, "last_token",
+                )
+            # Logits (small per row)
+            logits = torch.randn(1, 1, vocab_size)
+            mask = torch.ones(1, 1, dtype=torch.long)
+            save_prompt_logits(
+                TEST_MODEL, prompt, logits, mask,
+                top_k=top_k, positions="last",
+            )
+
+        # Use a tiny shard size so hidden gets multiple shards
+        # hidden_row_bytes = 32 * 4 = 128 bytes per row
+        # logits_row_bytes = 5 * 4 + 5 * 8 = 60 bytes per row
+        # With shard_max_bytes=384, hidden fits 3 rows/shard (4 shards),
+        # logits fits 6 rows/shard (2 shards)
+        tmpdir, tensor_descriptors, prompt_metadata = _consolidate_and_shard(
+            model_name=TEST_MODEL,
+            prompts=prompts,
+            kept_indices=list(range(10)),
+            tensor_types={
+                "raw_layers": [],
+                "pooled": {"last_token": [0, 1]},
+                "has_logits": True,
+                "logits_top_k": top_k,
+                "has_perplexity": False,
+            },
+            labels=None,
+            shard_max_bytes=384,
+            repo_id="user/independent-test",
+        )
+
+        hidden_desc = tensor_descriptors["hidden_layers"]
+        logits_desc = tensor_descriptors["logits_topk"]
+
+        hidden_shard_count = len(hidden_desc["shards"])
+        logits_shard_count = len(logits_desc["shards"])
+
+        # Logits should have fewer shards than hidden
+        assert logits_shard_count < hidden_shard_count, (
+            f"Expected logits ({logits_shard_count} shards) < "
+            f"hidden ({hidden_shard_count} shards)"
+        )
+
+        # Total prompts across all shards should equal 10 for each type
+        assert sum(s["num_prompts"] for s in hidden_desc["shards"]) == 10
+        assert sum(s["num_prompts"] for s in logits_desc["shards"]) == 10
+
+        # Check per-type columns in metadata
+        for pm in prompt_metadata:
+            assert "shard_index_hidden" in pm
+            assert "row_offset_hidden" in pm
+            assert "shard_index_logits" in pm
+            assert "row_offset_logits" in pm
+            # Legacy columns present
+            assert "shard_index" in pm
+            assert "row_offset" in pm
+
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @requires_pyarrow
+    def test_per_type_columns_in_parquet(self, tmp_path, monkeypatch):
+        """Parquet index includes per-type shard columns."""
+        import pyarrow.parquet as pq
+
+        src_cache = tmp_path / "src_cache"
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(src_cache))
+        cache_mod._backend = None
+
+        prompts = ["hello", "world"]
+        for prompt in prompts:
+            pooled = torch.randn(1, HIDDEN_DIM)
+            save_prompt_pooled_activations(
+                TEST_MODEL, prompt, [0], pooled, "last_token",
+            )
+            logits = torch.randn(1, 1, 50)
+            mask = torch.ones(1, 1, dtype=torch.long)
+            save_prompt_logits(
+                TEST_MODEL, prompt, logits, mask,
+                top_k=5, positions="last",
+            )
+
+        remote_dir = tmp_path / "remote"
+        remote_dir.mkdir()
+        mock_api = MagicMock()
+
+        def capture_upload(repo_id, folder_path, **kwargs):
+            for f in Path(folder_path).rglob("*"):
+                if f.is_file():
+                    rel = f.relative_to(folder_path)
+                    dest = remote_dir / rel
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(str(f), str(dest))
+
+        mock_api.upload_large_folder.side_effect = capture_upload
+
+        with (
+            patch("lmprobe.sharing._check_hub_deps"),
+            patch("huggingface_hub.HfApi", return_value=mock_api),
+        ):
+            push_dataset(
+                repo_id="user/pertype-test",
+                model_name=TEST_MODEL,
+                prompts=prompts,
+                labels=[1, 0],
+                exist_ok=True,
+            )
+
+        table = pq.read_table(str(remote_dir / PARQUET_PATH))
+        col_names = set(table.column_names)
+        assert "shard_index_hidden" in col_names
+        assert "row_offset_hidden" in col_names
+        assert "shard_index_logits" in col_names
+        assert "row_offset_logits" in col_names
+        # Legacy columns still present
+        assert "shard_index" in col_names
+        assert "row_offset" in col_names
+
+    def test_format_version_is_1_2(self):
+        """Format version is bumped to 1.2."""
+        assert FORMAT_VERSION == "1.2"
+
+    @requires_pyarrow
+    def test_hidden_only_no_logits_columns(self, tmp_path, monkeypatch):
+        """When only hidden is present, no logits columns appear."""
+        src_cache = tmp_path / "src_cache"
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(src_cache))
+        cache_mod._backend = None
+
+        prompts = ["hello", "world"]
+        for prompt in prompts:
+            pooled = torch.randn(1, HIDDEN_DIM)
+            save_prompt_pooled_activations(
+                TEST_MODEL, prompt, [0], pooled, "last_token",
+            )
+
+        tmpdir, tensor_descriptors, prompt_metadata = _consolidate_and_shard(
+            model_name=TEST_MODEL,
+            prompts=prompts,
+            kept_indices=[0, 1],
+            tensor_types={
+                "raw_layers": [],
+                "pooled": {"last_token": [0]},
+                "has_logits": False,
+                "logits_top_k": None,
+                "has_perplexity": False,
+            },
+            labels=None,
+            shard_max_bytes=1_000_000_000,
+            repo_id="user/hidden-only",
+        )
+
+        assert "hidden_layers" in tensor_descriptors
+        assert "logits_topk" not in tensor_descriptors
+
+        # No logits columns in metadata
+        for pm in prompt_metadata:
+            assert "shard_index_logits" not in pm
+            assert "row_offset_logits" not in pm
+            # Hidden columns present
+            assert "shard_index_hidden" in pm
+
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestRawShardBoundaryFix107:
+    """Test fix for #107: raw per_prompt_bytes should not multiply by layers."""
+
+    def test_raw_shard_count_reasonable(self, tmp_path, monkeypatch):
+        """Raw mode shard count should be based on per-layer size, not all layers."""
+        src_cache = tmp_path / "src_cache"
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(src_cache))
+        cache_mod._backend = None
+
+        prompts = [f"prompt {i}" for i in range(5)]
+        seq_lens = [10, 10, 10, 10, 10]
+        layers = [0, 1, 2, 3]  # 4 layers
+
+        for prompt, sl in zip(prompts, seq_lens):
+            act = torch.randn(1, sl, HIDDEN_DIM * len(layers))
+            mask = torch.ones(1, sl, dtype=torch.long)
+            save_prompt_activations(TEST_MODEL, prompt, layers, act, mask)
+
+        # Per-prompt bytes (single layer): 10 tokens * 32 dim * 4 bytes = 1280
+        # With shard_max_bytes=4000, should fit 3 rows per shard -> 2 shards
+        # Bug #107 would compute 10*32*4*4=5120 per prompt -> only 1 per shard -> 5 shards
+        tmpdir, tensor_descriptors, prompt_metadata = _consolidate_and_shard(
+            model_name=TEST_MODEL,
+            prompts=prompts,
+            kept_indices=list(range(5)),
+            tensor_types={
+                "raw_layers": [0, 1, 2, 3],
+                "pooled": {},
+                "has_logits": False,
+                "logits_top_k": None,
+                "has_perplexity": False,
+            },
+            labels=None,
+            shard_max_bytes=4000,
+            repo_id="user/raw-fix107",
+        )
+
+        hidden_desc = tensor_descriptors["hidden_layers"]
+        shard_count = len(hidden_desc["shards"])
+
+        # With fix: 1280 bytes/prompt, 4000 byte shards -> 3 prompts/shard -> 2 shards
+        # Without fix: 5120 bytes/prompt, 4000 byte shards -> 1 prompt/shard -> 5 shards
+        assert shard_count == 2, (
+            f"Expected 2 shards (per-layer sizing), got {shard_count}"
+        )
+
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestBackwardCompatLegacySingleShardIndex:
+    """Test that v1.1 datasets with single shard_index still work."""
+
+    @requires_pyarrow
+    @patch("lmprobe.sharing._check_hub_deps")
+    def test_pull_v11_single_shard_index(self, mock_deps, tmp_path, cache_dir):
+        """pull_dataset works with v1.1 datasets that only have shard_index."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+        from safetensors.torch import save_file
+
+        remote_dir = tmp_path / "remote"
+        (remote_dir / "tensors").mkdir(parents=True)
+        (remote_dir / "index").mkdir(parents=True)
+
+        prompts = ["prompt 0", "prompt 1"]
+        t0 = torch.randn(2, HIDDEN_DIM)
+        save_file(
+            {"hidden.layer_0": t0},
+            str(remote_dir / "tensors" / "hidden_layer000_shard000.safetensors"),
+        )
+
+        # v1.1 Parquet: only legacy columns (no per-type columns)
+        table = pa.table({
+            "text": pa.array(prompts, type=pa.string()),
+            "label": pa.array([None, None], type=pa.int32()),
+            "num_tokens": pa.array([5, 5], type=pa.int32()),
+            "shard_index": pa.array([0, 0], type=pa.int32()),
+            "row_offset": pa.array([0, 1], type=pa.int32()),
+        })
+        pq.write_table(table, str(remote_dir / PARQUET_PATH))
+
+        lmprobe_info = {
+            "format_version": "1.1",
+            "model": {"name": TEST_MODEL, "revision": None},
+            "num_prompts": 2,
+            "tensors": {
+                "hidden_layers": {
+                    "type": "hidden",
+                    "layers": [0],
+                    "dim": HIDDEN_DIM,
+                    "dtype": "float32",
+                    "layout": "per_layer",
+                    "pooling": "last_token",
+                    "row_bytes": HIDDEN_DIM * 4,
+                    "shards": [{"num_prompts": 2}],
+                }
+            },
+            "provenance": {},
+        }
+        with open(remote_dir / INFO_FILENAME, "w") as f:
+            json.dump(lmprobe_info, f)
+
+        def mock_download(repo_id, filename, **kwargs):
+            return str(remote_dir / filename)
+
+        with patch(
+            "huggingface_hub.hf_hub_download", side_effect=mock_download,
+        ):
+            count = pull_dataset("user/v11-test")
+
+        assert count == 2


### PR DESCRIPTION
## Summary

- **Fix #107 (bug)**: `per_prompt_bytes` for raw storage was multiplied by `len(hidden_layers)`, but v1.1 per-layer sharding means each file is a single layer. This created ~N× too many shards. One-line fix removes the multiplier.
- **Fix #91 (enhancement)**: All tensor types previously shared one set of shard boundaries computed from the largest type. Now hidden and logits get independent boundaries, so tiny logits data (~9 MB) isn't split across 7+ shards matching hidden layers (~3.4 GB). Bumps format version to 1.2.

Key changes:
- Two-pass shard writing (hidden pass + logits pass) with independent boundary lists
- Per-type columns in Parquet index (`shard_index_hidden`, `shard_index_logits`, etc.)
- Legacy `shard_index`/`row_offset` columns preserved for v1.1 backward compatibility
- Cache loaders use `entry.get("shard_index_hidden", entry.get("shard_index"))` fallback pattern

## Test plan

- [x] All 75 existing sharing tests pass
- [x] Full test suite passes (592 passed)
- [x] New test: different shard counts per tensor type verified
- [x] New test: per-type columns present in Parquet output
- [x] New test: raw mode shard count is reasonable with #107 fix
- [x] New test: v1.1 datasets with single shard_index still load correctly
- [x] New test: hidden-only datasets have no logits columns

Closes #107, closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)