### PR TITLE
Fix FileNotFoundError race condition in _collect_cache_entries

### DIFF
--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -1960,7 +1960,10 @@ def _collect_cache_entries() -> list[tuple[Path, int, float]]:
 
         # v2 safetensors files
         for sf_file in model_dir.glob("*.safetensors"):
-            stat = sf_file.stat()
+            try:
+                stat = sf_file.stat()
+            except FileNotFoundError:
+                continue  # File was deleted between listing and stat
             entries.append((sf_file, stat.st_size, stat.st_mtime))
 
         # v1 directories


### PR DESCRIPTION
## Summary

- Wrap `sf_file.stat()` in `try/except FileNotFoundError` in `_collect_cache_entries()` so files deleted between the glob iteration and the `stat()` call are silently skipped instead of crashing the process

## Test plan

- [ ] Verify existing cache tests pass
- [ ] Manual: confirmed the crash no longer occurs when a file is removed during cache entry collection

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)