### PR TITLE
Fix dataset test mocks and make releases opt-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/tests/test_dataset_param.py
+++ b/tests/test_dataset_param.py
@@ -151,9 +151,9 @@ class TestLoadAndPoolFromCache:
         meta = _make_metadata(model_name="test-model")
         probe._dataset_metadata = meta
 
-        # Fake activations: seq_len=3, hidden_dim=4 (2 layers × 2 dim)
-        acts = torch.randn(3, 4)
-        mask = torch.ones(3)
+        # Fake activations: (1, seq_len=3, hidden_dim=4) — batch dim included
+        acts = torch.randn(1, 3, 4)
+        mask = torch.ones(1, 3)
 
         with patch(
             "lmprobe.cache.load_prompt_activations",
@@ -207,7 +207,7 @@ class TestFitPredictDataset:
         seq_len = 3
 
         def fake_load(_model_name, _prompt, _layers):
-            return torch.randn(seq_len, hidden_dim), torch.ones(seq_len)
+            return torch.randn(1, seq_len, hidden_dim), torch.ones(1, seq_len)
 
         with patch(
             "lmprobe.sharing.fetch_dataset_metadata", return_value=meta


### PR DESCRIPTION
## Summary
- **Fix CI failure**: Update test mocks in `test_dataset_param.py` to return 3D tensors `(1, seq_len, hidden_dim)` matching the real `load_prompt_activations` contract. The previous 2D mocks were masked by a `.unsqueeze(0)` that was correctly removed in #109's batch dimension fix.
- **Make releases opt-in**: The auto-release workflow now only triggers when a PR has the `release` label. PRs without it merge normally with no version bump or PyPI publish.

## Test plan
- [ ] CI passes (the two `test_dataset_param` failures should be resolved)
- [ ] Merging this PR without a `release` label should NOT trigger a PyPI release
- [ ] Future PRs with the `release` label still trigger the full release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)