### PR TITLE
Use deterministic staging dir for resumable push_dataset

### DIFF
--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -110,6 +110,8 @@ def _staging_dir_path(
     *,
     shard_max_bytes: int = DEFAULT_SHARD_BYTES,
     labels: list[int | str | None] | None = None,
+    metadata: list[dict] | None = None,
+    tensors: list[str] | None = None,
 ) -> Path:
     """Deterministic staging directory for resumable uploads.
 
@@ -121,7 +123,11 @@ def _staging_dir_path(
 
     key_parts: list[Any] = [repo_id, model_name, prompts, shard_max_bytes]
     if labels is not None:
-        key_parts.append(labels)
+        key_parts.append(["labels", labels])
+    if metadata is not None:
+        key_parts.append(["metadata", metadata])
+    if tensors is not None:
+        key_parts.append(["tensors", sorted(tensors)])
     content = json.dumps(key_parts, sort_keys=True)
     key = hashlib.sha256(content.encode()).hexdigest()[:16]
     return get_cache_dir() / "staging" / key
@@ -1280,6 +1286,7 @@ def push_dataset(
     staging_dir = _staging_dir_path(
         repo_id, model_name, prompts,
         shard_max_bytes=shard_max_bytes, labels=labels,
+        metadata=metadata, tensors=tensors,
     )
     sentinel = staging_dir / _STAGE_SENTINEL
 

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -2672,6 +2672,20 @@ class TestStagingDir:
         path3 = _staging_dir_path("user/repo", "m", ["x"], labels=None)
         assert len({path1, path2, path3}) == 3
 
+    def test_staging_dir_includes_metadata(self, cache_dir):
+        """Different metadata produce different staging path."""
+        path1 = _staging_dir_path("user/repo", "m", ["x"], metadata=[{"k": "a"}])
+        path2 = _staging_dir_path("user/repo", "m", ["x"], metadata=[{"k": "b"}])
+        path3 = _staging_dir_path("user/repo", "m", ["x"], metadata=None)
+        assert len({path1, path2, path3}) == 3
+
+    def test_staging_dir_includes_tensors_filter(self, cache_dir):
+        """Different tensors filter produces different staging path."""
+        path1 = _staging_dir_path("user/repo", "m", ["x"], tensors=["hidden_layers"])
+        path2 = _staging_dir_path("user/repo", "m", ["x"], tensors=["logits_topk"])
+        path3 = _staging_dir_path("user/repo", "m", ["x"], tensors=None)
+        assert len({path1, path2, path3}) == 3
+
     def test_staging_dir_under_cache(self, cache_dir):
         """Staging dir lives under the cache directory."""
         path = _staging_dir_path("user/repo", "m", ["x"])


### PR DESCRIPTION
## Summary
- Adds a deterministic staging directory under `~/.cache/lmprobe/staging/<hash>/` keyed by `(repo_id, model_name, sorted(prompts))` so interrupted `push_dataset` uploads can resume without re-consolidating all shards from scratch
- Uses a `_stage_complete` sentinel file to detect completed staging and skip straight to upload on retry
- Staging directory is cleaned up after successful upload

## Test plan
- [x] `test_staging_dir_deterministic` — same args produce same path
- [x] `test_staging_dir_different_for_different_args` — different args produce different paths
- [x] `test_staging_dir_order_independent` — prompt order doesn't matter (sorted internally)
- [x] `test_staging_dir_under_cache` — path lives under cache dir
- [x] `test_push_dataset_resumes_from_sentinel` — sentinel present → consolidation skipped
- [x] `test_push_dataset_creates_sentinel_after_staging` — sentinel created after consolidation
- [x] `test_staging_dir_cleaned_on_success` — staging dir removed after successful upload
- [x] Full `test_sharing.py` suite passes (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)