### PR TITLE
Add commit_batch_size to push_dataset for unreliable connections

### DIFF
--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -1187,6 +1187,7 @@ def push_dataset(
     license: str = "cc-by-4.0",
     token: str | None = None,
     num_workers: int | None = None,
+    commit_batch_size: int | None = None,
 ) -> str:
     """Push cached activations to a HuggingFace Dataset repo.
 
@@ -1225,6 +1226,12 @@ def push_dataset(
         Number of workers for parallel file uploads.  Passed directly to
         ``upload_large_folder``.  ``None`` (default) uses the
         ``huggingface_hub`` default (currently 16 workers).
+    commit_batch_size : int | None
+        Maximum number of files per commit during upload.  On unreliable
+        connections, setting this to a small value (e.g. ``1``) ensures
+        progress is committed frequently, so interrupted uploads lose
+        less work on restart.  ``None`` (default) uses the
+        ``huggingface_hub`` default scale.
 
     Returns
     -------
@@ -1370,12 +1377,26 @@ def push_dataset(
         "[SHARING] Uploading dataset (%.2f GB) via upload_large_folder",
         total_size / 1e9,
     )
-    api.upload_large_folder(
-        repo_id=repo_id,
-        folder_path=str(tmpdir),
-        repo_type="dataset",
-        num_workers=num_workers,
-    )
+    if commit_batch_size is not None:
+        import huggingface_hub._upload_large_folder as _ulf
+
+        _orig_scale = _ulf.COMMIT_SIZE_SCALE
+        _ulf.COMMIT_SIZE_SCALE = [commit_batch_size]
+        logger.info(
+            "[SHARING] commit_batch_size=%d — overriding COMMIT_SIZE_SCALE",
+            commit_batch_size,
+        )
+
+    try:
+        api.upload_large_folder(
+            repo_id=repo_id,
+            folder_path=str(tmpdir),
+            repo_type="dataset",
+            num_workers=num_workers,
+        )
+    finally:
+        if commit_batch_size is not None:
+            _ulf.COMMIT_SIZE_SCALE = _orig_scale
     url = f"https://huggingface.co/datasets/{repo_id}"
 
     # Cleanup

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -649,6 +649,67 @@ class TestPushDataset:
 
     @patch("lmprobe.sharing._check_hub_deps")
     @patch("lmprobe.sharing._check_pyarrow")
+    @patch("huggingface_hub.HfApi")
+    def test_push_commit_batch_size_overrides_scale(
+        self, MockHfApi, mock_pyarrow, mock_deps, populated_cache,
+    ):
+        """commit_batch_size monkey-patches COMMIT_SIZE_SCALE during upload."""
+        import huggingface_hub._upload_large_folder as _ulf
+
+        original_scale = _ulf.COMMIT_SIZE_SCALE
+
+        captured_scale = []
+
+        def capture_scale(**kwargs):
+            captured_scale.append(list(_ulf.COMMIT_SIZE_SCALE))
+
+        mock_api = MagicMock()
+        MockHfApi.return_value = mock_api
+        mock_api.upload_large_folder.side_effect = capture_scale
+
+        push_dataset(
+            repo_id="user/test-dataset",
+            model_name=TEST_MODEL,
+            prompts=populated_cache,
+            labels=[1, 1, 0],
+            exist_ok=True,
+            commit_batch_size=3,
+        )
+
+        # During upload, scale should have been overridden
+        assert captured_scale == [[3]]
+        # After upload, original scale should be restored
+        assert _ulf.COMMIT_SIZE_SCALE is original_scale
+
+    @patch("lmprobe.sharing._check_hub_deps")
+    @patch("lmprobe.sharing._check_pyarrow")
+    @patch("huggingface_hub.HfApi")
+    def test_push_commit_batch_size_restored_on_error(
+        self, MockHfApi, mock_pyarrow, mock_deps, populated_cache,
+    ):
+        """COMMIT_SIZE_SCALE is restored even if upload raises."""
+        import huggingface_hub._upload_large_folder as _ulf
+
+        original_scale = _ulf.COMMIT_SIZE_SCALE
+
+        mock_api = MagicMock()
+        MockHfApi.return_value = mock_api
+        mock_api.upload_large_folder.side_effect = RuntimeError("connection lost")
+
+        with pytest.raises(RuntimeError, match="connection lost"):
+            push_dataset(
+                repo_id="user/test-dataset",
+                model_name=TEST_MODEL,
+                prompts=populated_cache,
+                labels=[1, 1, 0],
+                exist_ok=True,
+                commit_batch_size=1,
+            )
+
+        assert _ulf.COMMIT_SIZE_SCALE is original_scale
+
+    @patch("lmprobe.sharing._check_hub_deps")
+    @patch("lmprobe.sharing._check_pyarrow")
     def test_push_labels_length_mismatch(
         self, mock_pyarrow, mock_deps, populated_cache,
     ):


### PR DESCRIPTION
## Summary
- Adds `commit_batch_size` parameter to `push_dataset()` that controls how many files are included per commit during upload
- On unreliable connections, setting `commit_batch_size=1` ensures each file is committed immediately, so interrupted uploads lose minimal progress on restart
- Monkey-patches `huggingface_hub._upload_large_folder.COMMIT_SIZE_SCALE` during upload and restores it afterward (even on error)
- Default behavior (`None`) is unchanged

## Usage
```python
push_dataset(
    repo_id="user/my-activations",
    model_name="meta-llama/Llama-3.1-405B-Instruct",
    prompts=prompts,
    num_workers=1,
    commit_batch_size=1,  # commit after every file
)
```

## Test plan
- [x] `test_push_commit_batch_size_overrides_scale` — verifies COMMIT_SIZE_SCALE is set to `[commit_batch_size]` during upload and restored after
- [x] `test_push_commit_batch_size_restored_on_error` — verifies COMMIT_SIZE_SCALE is restored even when upload raises an exception

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)