### PR TITLE
Fix perplexity computation for left-padded models

### DIFF
--- a/src/lmprobe/logit_utils.py
+++ b/src/lmprobe/logit_utils.py
@@ -279,10 +279,10 @@ def compute_perplexity_from_activations(
         acts = acts_list[0].to(device=device, dtype=norm_weight.dtype)
         mask = masks_list[0]
 
-        # Truncate to real (non-padded) length using mask.
+        # Select real (non-padded) positions using mask.
         # Cached activations may be padded from batched extraction.
-        real_len = mask[0].sum().item()
-        acts = acts[:, :real_len, :]
+        # Use boolean indexing to handle both left- and right-padding.
+        acts = acts[:, mask[0].bool(), :]
 
         # Apply norm
         normed = apply_norm(


### PR DESCRIPTION
## Summary
- Fix `compute_perplexity_from_activations` assuming right-padding when selecting real token positions from cached activations
- Use boolean mask indexing (`mask[0].bool()`) instead of slice-based truncation (`[:real_len]`), correctly handling both left- and right-padded models

Closes #126

## Test plan
- [x] All 382 existing tests pass (1 pre-existing unrelated failure in `test_plotting_works_after_compute`)
- [ ] Verify with left-padded Llama 405B activations that perplexity values are now correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)