### PR TITLE
Fix remote execution downloading model weights unnecessarily

### DIFF
--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -134,6 +134,7 @@ class NnsightBackend(ExtractionBackend):
         super().__init__(model_name, device)
         self.remote = remote
         self._model = None
+        self._remote_model = None
 
     @property
     def model(self):
@@ -145,6 +146,25 @@ class NnsightBackend(ExtractionBackend):
                 self.model_name, self.device, remote=self.remote
             )
         return self._model
+
+    def _get_model_for_remote(self):
+        """Get a lightweight model stub for remote execution.
+
+        When the backend was created with remote=False but a call-time
+        remote=True is used, we need a model loaded with dispatch=False
+        (no weights) instead of the full local model.
+        """
+        if self.remote:
+            # Backend was created for remote use — main model is already lightweight
+            return self.model
+        # Backend was created for local use — need a separate remote stub
+        if self._remote_model is None:
+            from .extraction import get_cached_model
+
+            self._remote_model = get_cached_model(
+                self.model_name, self.device, remote=True
+            )
+        return self._remote_model
 
     @property
     def tokenizer(self) -> PreTrainedTokenizerBase:
@@ -159,7 +179,8 @@ class NnsightBackend(ExtractionBackend):
         from .extraction import _extract_batch
 
         remote = kwargs.get("remote", self.remote)
-        return _extract_batch(self.model, prompts, layer_indices, remote=remote)
+        model = self._get_model_for_remote() if remote else self.model
+        return _extract_batch(model, prompts, layer_indices, remote=remote)
 
     def extract_batch_with_logits(
         self,
@@ -171,8 +192,9 @@ class NnsightBackend(ExtractionBackend):
 
         remote = kwargs.get("remote", self.remote)
         logit_top_k = kwargs.get("logit_top_k")
+        model = self._get_model_for_remote() if remote else self.model
         return _extract_batch_with_logits(
-            self.model, prompts, layer_indices, remote=remote,
+            model, prompts, layer_indices, remote=remote,
             logit_top_k=logit_top_k,
         )
 

--- a/src/lmprobe/extraction.py
+++ b/src/lmprobe/extraction.py
@@ -332,6 +332,11 @@ def load_model(
         # This is critical for large models (405B) that would OOM locally.
         # See: https://nnsight.net/notebooks/features/remote_execution/
         model = LM(model_name, dispatch=False)
+        # Prevent nnsight's MetaMixin.interleave from auto-dispatching
+        # (which would download all weights via from_pretrained).
+        # Remote traces don't need local weights — the forward pass
+        # runs on the NDIF server.
+        model.dispatched = True
     else:
         # Fast-fail on CUDA compute capability mismatch
         from lmprobe._device_utils import check_cuda_compatibility
@@ -1014,8 +1019,12 @@ class ActivationExtractor:
             (activations, attention_mask)
         """
         layer_indices = layers if layers is not None else self.layer_indices
+        if remote and hasattr(self._backend, '_get_model_for_remote'):
+            model = self._backend._get_model_for_remote()
+        else:
+            model = self.model
         return extract_activations(
-            self.model,
+            model,
             prompts,
             layer_indices,
             remote=remote,


### PR DESCRIPTION
## Summary
- Fixes #136: NDIF remote extraction no longer downloads all model weight shards
- Sets `model.dispatched = True` after `dispatch=False` loading to prevent nnsight's auto-dispatch from triggering weight download during remote traces
- Adds `_get_model_for_remote()` to `NnsightBackend` so call-time `remote=True` loads a lightweight stub (config + tokenizer only) instead of the full local model

## Details

The issue had two root causes:

1. **Backend remote mismatch**: When `ActivationExtractor(backend="nnsight")` was created without `remote=True`, then `extract_batch_with_logits(remote=True)` was called, the model was loaded with `dispatch=True` (full weight download) because the backend's `self.remote` was `False`.

2. **nnsight auto-dispatch**: Even with `dispatch=False`, nnsight's `MetaMixin.interleave` calls `self.dispatch()` for non-scanning traces — which downloads all weights via `from_pretrained`. This would affect remote traces where weights aren't needed locally.

HuggingFace permission checks still happen via config/tokenizer download, so gated model access is still validated — just without downloading weight shards.

## Test plan
- [x] All 729 existing tests pass
- [x] Verified remote model loads with `meta` device parameters (no weights)
- [x] Verified `_get_model_for_remote()` returns lightweight stub when backend created with `remote=False`
- [ ] Manual test with a large gated model (e.g., Llama-405B) on NDIF

🤖 Generated with [Claude Code](https://claude.com/claude-code)