### PR TITLE
Fix configure_remote() to read NDIF_API_KEY instead of NNSIGHT_API_KEY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ These decisions are **mandatory** and must not be changed without explicit discu
 | Activation caching | Always enabled | Remote/LLM inference is expensive |
 | Package layout | `src/lmprobe/` | Standard Python packaging |
 | nnsight for extraction | Required dependency | Supports remote execution |
-| API key | `NNSIGHT_API_KEY` env var | Standard credential handling |
+| API key | `NDIF_API_KEY` env var | Standard credential handling |
 | Cache location | `~/.cache/lmprobe/` (or `LMPROBE_CACHE_DIR`) | XDG-style default |
 
 ## Code Conventions
@@ -109,7 +109,7 @@ def tiny_model():
 
 **Test requirements:**
 - Tests must run without GPU (CPU-only)
-- Tests must not require `NNSIGHT_API_KEY` (use `remote=False`)
+- Tests must not require `NDIF_API_KEY` (use `remote=False`)
 - Tests should be fast (tiny model has ~few MB weights)
 - Integration tests verify full pipeline: extraction → pooling → classification
 
@@ -120,19 +120,19 @@ def tiny_model():
 The `remote=True` functionality uses nnsight to connect to NDIF (National Deep Inference Fabric), a US national research initiative. Remote testing has not been performed due to:
 
 1. **Geographic restriction**: NDIF restricts access to US-based users only
-2. **API key requirement**: Requires `NNSIGHT_API_KEY` environment variable
+2. **API key requirement**: Requires `NDIF_API_KEY` environment variable
 
 **What needs testing:**
 - `LinearProbe(..., remote=True)` connects successfully
 - `probe.fit(..., remote=True)` extracts activations from remote models
 - `probe.predict(..., remote=False)` override works (train remote, predict local)
 - Large models (e.g., `meta-llama/Llama-3.1-70B-Instruct`) work via remote
-- Error handling when `NNSIGHT_API_KEY` is missing/invalid
+- Error handling when `NDIF_API_KEY` is missing/invalid
 - Cache behavior with remote extractions
 
 **To test when US-based:**
 ```bash
-export NNSIGHT_API_KEY="your-key"
+export NDIF_API_KEY="your-key"
 pytest tests/test_remote.py -v  # (test file to be created)
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install lmprobe[auto]        # Automatic layer selection (Group Lasso)
 For remote execution (large models via nnsight/NDIF):
 
 ```bash
-export NNSIGHT_API_KEY="your-api-key-here"
+export NDIF_API_KEY="your-api-key-here"
 ```
 
 ### Example Usage
@@ -112,7 +112,7 @@ probe = Probe(
     model="meta-llama/Llama-3.1-70B-Instruct",
     layers="middle",
     backend="nnsight",
-    remote=True,  # Requires NNSIGHT_API_KEY
+    remote=True,  # Requires NDIF_API_KEY
 )
 
 probe.fit(positive_prompts, negative_prompts)
@@ -215,7 +215,7 @@ probe = Probe(
 | `classifier` | `str \| sklearn estimator` | `"logistic_regression"` | Classification model |
 | `task` | `str` | `"classification"` | `"classification"` or `"regression"` |
 | `device` | `str` | `"auto"` | `"auto"`, `"cuda:0"`, `"cpu"` |
-| `remote` | `bool` | `False` | Use nnsight remote execution (requires `NNSIGHT_API_KEY`) |
+| `remote` | `bool` | `False` | Use nnsight remote execution (requires `NDIF_API_KEY`) |
 | `random_state` | `int \| None` | `None` | Random seed for reproducibility (propagates to classifier) |
 | `batch_size` | `int` | `8` | Prompts per forward pass during extraction |
 | `backend` | `str` | `"local"` | `"local"` (HuggingFace) or `"nnsight"` |

--- a/docs/design/001-api-philosophy.md
+++ b/docs/design/001-api-philosophy.md
@@ -103,16 +103,16 @@ probe.predict(test, remote=False)
 **Authentication**: Remote execution requires an API key. Set via environment variable:
 
 ```bash
-export NNSIGHT_API_KEY="your-api-key-here"
+export NDIF_API_KEY="your-api-key-here"
 ```
 
 The library configures nnsight automatically:
 ```python
 from nnsight import CONFIG
-CONFIG.API.APIKEY = os.getenv("NNSIGHT_API_KEY")
+CONFIG.API.APIKEY = os.getenv("NDIF_API_KEY")
 ```
 
-**Error handling**: If `remote=True` and `NNSIGHT_API_KEY` is not set, raise a clear error at the point of remote access (not at init, since user might override to `remote=False`).
+**Error handling**: If `remote=True` and `NDIF_API_KEY` is not set, raise a clear error at the point of remote access (not at init, since user might override to `remote=False`).
 
 ### Global Random State
 

--- a/docs/guides/datasets.md
+++ b/docs/guides/datasets.md
@@ -69,7 +69,7 @@ cache = UnifiedCache(
     model="meta-llama/Llama-3.1-70B-Instruct",
     layers="all",
     backend="nnsight",
-    remote=True,             # requires NNSIGHT_API_KEY, US-based access
+    remote=True,             # requires NDIF_API_KEY, US-based access
     batch_size=4,            # smaller batches for remote
 )
 stats = cache.warmup(all_prompts)

--- a/docs/guides/remote.md
+++ b/docs/guides/remote.md
@@ -18,7 +18,7 @@ pip install lmprobe[nnsight]
 Set your API key:
 
 ```bash
-export NNSIGHT_API_KEY="your-api-key-here"
+export NDIF_API_KEY="your-api-key-here"
 ```
 
 ---

--- a/src/lmprobe/extraction.py
+++ b/src/lmprobe/extraction.py
@@ -76,18 +76,18 @@ def clear_model_cache() -> None:
 def configure_remote() -> None:
     """Configure nnsight for remote execution.
 
-    Reads the API key from NNSIGHT_API_KEY environment variable.
+    Reads the API key from NDIF_API_KEY environment variable.
 
     Raises
     ------
     EnvironmentError
-        If NNSIGHT_API_KEY is not set.
+        If NDIF_API_KEY is not set.
     """
-    api_key = os.getenv("NNSIGHT_API_KEY")
+    api_key = os.getenv("NDIF_API_KEY")
     if not api_key:
         raise OSError(
-            "NNSIGHT_API_KEY environment variable is required for remote execution. "
-            "Set it with: export NNSIGHT_API_KEY='your-key-here'"
+            "NDIF_API_KEY environment variable is required for remote execution. "
+            "Set it with: export NDIF_API_KEY='your-key-here'"
         )
     nnsight = _require_nnsight()
     nnsight.CONFIG.API.APIKEY = api_key

--- a/src/lmprobe/probe.py
+++ b/src/lmprobe/probe.py
@@ -296,7 +296,7 @@ class Probe:
     device : str, default="auto"
         Device for model inference: "auto", "cpu", "cuda:0", etc.
     remote : bool, default=False
-        Use nnsight remote execution (requires NNSIGHT_API_KEY).
+        Use nnsight remote execution (requires NDIF_API_KEY).
     random_state : int | None, default=None
         Random seed for reproducibility. Propagates to classifier.
     batch_size : int, default=8

--- a/src/lmprobe/unified_cache.py
+++ b/src/lmprobe/unified_cache.py
@@ -132,7 +132,7 @@ class UnifiedCache:
     device : str, default="auto"
         Device for model inference.
     remote : bool, default=False
-        Use nnsight remote execution (requires NNSIGHT_API_KEY).
+        Use nnsight remote execution (requires NDIF_API_KEY).
     batch_size : int, default=8
         Number of prompts to process at once.
     cache_pooled : bool, default=True

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -3,10 +3,10 @@ Remote/NDIF tests for lmprobe.
 
 These tests require:
 1. US-based network access (NDIF restricts international access)
-2. NNSIGHT_API_KEY environment variable set
+2. NDIF_API_KEY environment variable set
 
 To run:
-    export NNSIGHT_API_KEY="your-key"
+    export NDIF_API_KEY="your-key"
     pytest tests/test_remote.py -v
 
 To skip these tests (they're slow, expensive, and may hit rate limits):
@@ -17,7 +17,7 @@ To skip these tests (they're slow, expensive, and may hit rate limits):
     export SKIP_REMOTE_TESTS=1
     pytest tests/test_remote.py
 
-These tests are skipped with a warning if NNSIGHT_API_KEY is not set.
+These tests are skipped with a warning if NDIF_API_KEY is not set.
 """
 
 import os
@@ -26,21 +26,21 @@ import warnings
 import pytest
 
 # Check skip conditions
-_api_key = os.getenv("NNSIGHT_API_KEY")
+_api_key = os.getenv("NDIF_API_KEY")
 _skip_remote = os.getenv("SKIP_REMOTE_TESTS", "").lower() in ("1", "true", "yes")
 
 # Determine skip reason
 if _skip_remote:
     _skip_reason = "SKIP_REMOTE_TESTS is set - skipping expensive remote tests"
 elif not _api_key:
-    _skip_reason = "NNSIGHT_API_KEY not set (required for remote/NDIF tests)"
+    _skip_reason = "NDIF_API_KEY not set (required for remote/NDIF tests)"
 else:
     _skip_reason = None
 
 # Issue warning when skipping due to missing API key
 if not _api_key and not _skip_remote:
     warnings.warn(
-        "Skipping remote tests: NNSIGHT_API_KEY environment variable not set. "
+        "Skipping remote tests: NDIF_API_KEY environment variable not set. "
         "Set it to run tests against NDIF, or use SKIP_REMOTE_TESTS=1 to suppress this warning.",
         UserWarning,
         stacklevel=1,
@@ -172,11 +172,11 @@ class TestRemoteErrorHandling:
     """Tests for error handling in remote mode."""
 
     def test_missing_api_key_error(self, monkeypatch, remote_model):
-        """Test clear error when NNSIGHT_API_KEY is missing."""
+        """Test clear error when NDIF_API_KEY is missing."""
         from lmprobe import LinearProbe
 
         # Temporarily remove the API key
-        monkeypatch.delenv("NNSIGHT_API_KEY", raising=False)
+        monkeypatch.delenv("NDIF_API_KEY", raising=False)
 
         probe = LinearProbe(
             model=remote_model,
@@ -185,5 +185,5 @@ class TestRemoteErrorHandling:
             backend="nnsight",
         )
 
-        with pytest.raises(EnvironmentError, match="NNSIGHT_API_KEY"):
+        with pytest.raises(EnvironmentError, match="NDIF_API_KEY"):
             probe.fit(["positive"], ["negative"])


### PR DESCRIPTION
## Summary
- Fix `configure_remote()` to read `NDIF_API_KEY` env var instead of the incorrect `NNSIGHT_API_KEY`
- Update all references across source, tests, and docs

Fixes #139

## Test plan
- [x] North star tests pass
- [ ] Verify remote execution works with `NDIF_API_KEY` set (requires US-based access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)