### PR TITLE
Batch cache status checks for large prompt sets

### DIFF
--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -659,10 +659,201 @@ def _get_tensor_keys_from_backend(key: str) -> set[str]:
         with safe_open(path, framework="pt") as f:
             return set(f.keys())
     else:
+        return _get_tensor_keys_header_only(backend, key)
+
+
+def _get_tensor_keys_header_only(backend: CacheBackend, key: str) -> set[str]:
+    """Get tensor key names by reading only the safetensors header.
+
+    Safetensors files start with an 8-byte little-endian header size,
+    followed by a JSON header that lists all tensor names and metadata.
+    This avoids downloading the full file (which can be GBs).
+    """
+    import struct
+
+    header_size_bytes = backend.read_range(key, 0, 8)
+    (header_size,) = struct.unpack("<Q", header_size_bytes)
+
+    # Sanity check: header should be < 100 MB
+    if header_size > 100_000_000:
         from safetensors.torch import load
 
         data = backend.read_bytes(key)
         return set(load(data).keys())
+
+    header_bytes = backend.read_range(key, 8, 8 + header_size)
+    header = json.loads(header_bytes)
+    # The header is a dict of tensor_name -> {dtype, shape, data_offsets}
+    # plus an optional "__metadata__" key
+    return {k for k in header if k != "__metadata__"}
+
+
+def _list_model_cache_keys(model_name: str) -> set[str]:
+    """List all cache keys for a model using a single LIST call.
+
+    Returns a set of backend keys (e.g. "abc123/def456.safetensors").
+    Much faster than per-prompt HEAD requests for large prompt sets.
+    """
+    backend = get_backend()
+    model_hash = _hash_string(model_name)
+    return set(backend.list_keys(model_hash))
+
+
+def batch_check_cache_status(
+    model_name: str,
+    prompts: list[str],
+    required_layers: set[int],
+    pooling: str | None = None,
+    compute_perplexity: bool = False,
+    cache_logits: bool = False,
+    logit_top_k: int | None = None,
+) -> tuple[list[str], list[str], list[str], int, set[int] | None]:
+    """Check cache status for many prompts using batch operations.
+
+    Uses a single LIST call to discover existing keys, then reads
+    safetensors headers (not full files) when needed to check layer
+    coverage. This is O(1) LIST + O(cached) header reads instead
+    of O(N) HEAD requests.
+
+    Parameters
+    ----------
+    model_name : str
+        HuggingFace model ID.
+    prompts : list[str]
+        Prompts to check.
+    required_layers : set[int]
+        Layer indices that must be cached.
+    pooling : str or None
+        Pooling strategy. If None, checks raw layers.
+    compute_perplexity : bool
+        Whether perplexity features are needed.
+    cache_logits : bool
+        Whether logits need to be cached.
+    logit_top_k : int or None
+        Top-k for logit caching.
+
+    Returns
+    -------
+    tuple
+        - need_activations: prompts needing activation extraction
+        - need_perplexity: prompts needing perplexity extraction
+        - need_logits: prompts needing logit extraction
+        - partial_cache_count: number of prompts with partial layer cache
+        - partial_cache_found_layers: example set of cached layers (or None)
+    """
+    backend = get_backend()
+    model_hash = _hash_string(model_name)
+
+    # Single LIST call to get all existing keys for this model
+    existing_keys = _list_model_cache_keys(model_name)
+
+    # Local cache for tensor keys to avoid re-reading the same file
+    _tensor_keys_cache: dict[str, set[str]] = {}
+
+    def _cached_tensor_keys(key: str) -> set[str]:
+        if key not in _tensor_keys_cache:
+            _tensor_keys_cache[key] = _get_tensor_keys_from_backend(key)
+        return _tensor_keys_cache[key]
+
+    need_activations: list[str] = []
+    need_perplexity: list[str] = []
+    need_logits: list[str] = []
+    partial_cache_count = 0
+    partial_cache_found_layers: set[int] | None = None
+
+    for prompt in prompts:
+        prompt_hash = _hash_string(prompt)
+        main_key = f"{model_hash}/{prompt_hash}.safetensors"
+        logits_key = f"{model_hash}/{prompt_hash}.logits.safetensors"
+        ppl_key = f"{model_hash}/{prompt_hash}.perplexity.safetensors"
+
+        # --- Activation check ---
+        act_cached = False
+        cached_layers: set[int] | None = None
+        if main_key in existing_keys:
+            tensor_keys = _cached_tensor_keys(main_key)
+            if pooling is not None:
+                cached_layers = _parse_pooled_layer_keys(tensor_keys, pooling)
+                act_cached = required_layers.issubset(cached_layers)
+            else:
+                cached_layers = _parse_raw_layer_keys(tensor_keys)
+                act_cached = (
+                    required_layers.issubset(cached_layers)
+                    and _ATTENTION_MASK_KEY in tensor_keys
+                )
+        elif isinstance(backend, LocalCacheBackend):
+            # v1 fallback for local backend
+            if pooling is not None:
+                act_cached = is_prompt_pooled_cached(
+                    model_name, prompt, required_layers, pooling
+                )
+            else:
+                act_cached = is_prompt_fully_cached(
+                    model_name, prompt, required_layers
+                )
+        else:
+            # Shard registry fallback
+            shard_info = _discover_from_shard(model_name, prompt)
+            if shard_info is not None:
+                if pooling is not None and pooling in shard_info.pooled:
+                    act_cached = required_layers.issubset(
+                        set(shard_info.pooled[pooling])
+                    )
+                elif pooling is None and shard_info.raw_layers:
+                    act_cached = required_layers.issubset(
+                        set(shard_info.raw_layers)
+                    )
+
+        if not act_cached:
+            need_activations.append(prompt)
+            # Check for partial cache (reuse cached_layers from above)
+            if cached_layers and len(cached_layers) > 0:
+                partial_cache_count += 1
+                if partial_cache_found_layers is None:
+                    partial_cache_found_layers = cached_layers
+
+        # --- Perplexity check ---
+        if compute_perplexity:
+            ppl_cached = ppl_key in existing_keys
+            if not ppl_cached and main_key in existing_keys:
+                tensor_keys = _cached_tensor_keys(main_key)
+                ppl_cached = _PERPLEXITY_KEY in tensor_keys
+            if not ppl_cached and isinstance(backend, LocalCacheBackend):
+                ppl_cached = is_prompt_perplexity_cached(model_name, prompt)
+            if not ppl_cached:
+                need_perplexity.append(prompt)
+
+        # --- Logits check ---
+        if cache_logits:
+            logits_cached = False
+            if logits_key in existing_keys:
+                tensor_keys = _cached_tensor_keys(logits_key)
+                if logit_top_k is not None:
+                    logits_cached = (
+                        _LOGITS_TOP_K_VALUES_KEY in tensor_keys
+                        and _LOGITS_TOP_K_INDICES_KEY in tensor_keys
+                    )
+                else:
+                    logits_cached = _LOGITS_KEY in tensor_keys
+            if not logits_cached and main_key in existing_keys:
+                tensor_keys = _cached_tensor_keys(main_key)
+                if logit_top_k is not None:
+                    logits_cached = (
+                        _LOGITS_TOP_K_VALUES_KEY in tensor_keys
+                        and _LOGITS_TOP_K_INDICES_KEY in tensor_keys
+                    )
+                else:
+                    logits_cached = _LOGITS_KEY in tensor_keys
+            if not logits_cached:
+                need_logits.append(prompt)
+
+    return (
+        need_activations,
+        need_perplexity,
+        need_logits,
+        partial_cache_count,
+        partial_cache_found_layers,
+    )
 
 
 def _merge_save_backend(key: str, new_tensors: dict[str, torch.Tensor]) -> None:

--- a/src/lmprobe/cache_backends.py
+++ b/src/lmprobe/cache_backends.py
@@ -64,6 +64,29 @@ class CacheBackend(ABC):
         """Update the last-modified time (for LRU tracking)."""
         ...
 
+    def read_range(self, key: str, start: int, end: int) -> bytes:
+        """Read a byte range from a key.
+
+        Parameters
+        ----------
+        start : int
+            Start byte offset (inclusive).
+        end : int
+            End byte offset (exclusive).
+
+        Returns
+        -------
+        bytes
+            The requested byte range.
+
+        Notes
+        -----
+        Default implementation reads the full object and slices.
+        Backends with native range-read support (e.g. S3) should override.
+        """
+        data = self.read_bytes(key)
+        return data[start:end]
+
     @abstractmethod
     def read_text(self, key: str) -> str:
         """Read a text entry."""
@@ -112,6 +135,12 @@ class LocalCacheBackend(CacheBackend):
 
     def read_bytes(self, key: str) -> bytes:
         return self._path(key).read_bytes()
+
+    def read_range(self, key: str, start: int, end: int) -> bytes:
+        path = self._path(key)
+        with open(path, "rb") as f:
+            f.seek(start)
+            return f.read(end - start)
 
     def write_bytes(self, key: str, data: bytes) -> None:
         path = self._path(key)
@@ -266,6 +295,14 @@ class S3CacheBackend(CacheBackend):
 
     def read_bytes(self, key: str) -> bytes:
         resp = self._s3.get_object(Bucket=self.bucket, Key=self._full_key(key))
+        return resp["Body"].read()
+
+    def read_range(self, key: str, start: int, end: int) -> bytes:
+        resp = self._s3.get_object(
+            Bucket=self.bucket,
+            Key=self._full_key(key),
+            Range=f"bytes={start}-{end - 1}",
+        )
         return resp["Body"].read()
 
     def write_bytes(self, key: str, data: bytes) -> None:

--- a/src/lmprobe/unified_cache.py
+++ b/src/lmprobe/unified_cache.py
@@ -18,13 +18,10 @@ from tqdm import tqdm
 
 from .backends import resolve_backend
 from .cache import (
+    batch_check_cache_status,
     evict,
-    get_prompt_cached_pooled_layers,
-    get_prompt_cached_raw_layers,
-    is_prompt_fully_cached,
     is_prompt_logits_cached,
     is_prompt_perplexity_cached,
-    is_prompt_pooled_cached,
     load_prompt_activations,
     load_prompt_logits,
     load_prompt_perplexity,
@@ -290,6 +287,11 @@ class UnifiedCache:
     ) -> tuple[list[str], list[str], list[str]]:
         """Check which prompts need extraction.
 
+        Uses batch_check_cache_status which does a single LIST call
+        instead of per-prompt HEAD requests. For large prompt sets
+        (e.g. 3000 prompts), this reduces S3 latency from minutes
+        to seconds.
+
         Returns
         -------
         tuple
@@ -299,58 +301,21 @@ class UnifiedCache:
         """
         required_layers = set(self.layer_indices)
 
-        need_activations = []
-        need_perplexity = []
-        need_logits = []
-        partial_cache_count = 0
-        partial_cache_found_layers: set[int] | None = None
-
-        for prompt in prompts:
-            # Check appropriate cache based on cache_pooled setting
-            if self.cache_pooled:
-                act_cached = is_prompt_pooled_cached(
-                    self.model_name, prompt, required_layers, self.pooling
-                )
-            else:
-                act_cached = is_prompt_fully_cached(
-                    self.model_name, prompt, required_layers
-                )
-
-            ppl_cached = (
-                is_prompt_perplexity_cached(self.model_name, prompt)
-                if self.compute_perplexity
-                else True
-            )
-
-            logits_cached = (
-                is_prompt_logits_cached(
-                    self.model_name, prompt, self.logit_top_k
-                )
-                if self.cache_logits
-                else True
-            )
-
-            if not act_cached:
-                need_activations.append(prompt)
-                # Check if cache file exists but is missing requested layers
-                if self.cache_pooled:
-                    cached_layers = get_prompt_cached_pooled_layers(
-                        self.model_name, prompt, self.pooling
-                    )
-                else:
-                    cached_layers = get_prompt_cached_raw_layers(
-                        self.model_name, prompt
-                    )
-                if cached_layers is not None and len(cached_layers) > 0:
-                    partial_cache_count += 1
-                    if partial_cache_found_layers is None:
-                        partial_cache_found_layers = cached_layers
-
-            if not ppl_cached:
-                need_perplexity.append(prompt)
-
-            if not logits_cached:
-                need_logits.append(prompt)
+        (
+            need_activations,
+            need_perplexity,
+            need_logits,
+            partial_cache_count,
+            partial_cache_found_layers,
+        ) = batch_check_cache_status(
+            model_name=self.model_name,
+            prompts=prompts,
+            required_layers=required_layers,
+            pooling=self.pooling if self.cache_pooled else None,
+            compute_perplexity=self.compute_perplexity,
+            cache_logits=self.cache_logits,
+            logit_top_k=self.logit_top_k,
+        )
 
         if partial_cache_count > 0:
             missing = sorted(required_layers - (partial_cache_found_layers or set()))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -12,6 +12,7 @@ from lmprobe.cache import (
     _prompt_cache_key,
     _prompt_logits_key,
     _prompt_perplexity_key,
+    batch_check_cache_status,
     cache_info,
     get_cached_layers,
     get_extraction_cache_dir,
@@ -1085,3 +1086,156 @@ class TestSidecarFiles:
         assert info.models[0].num_prompts == 1  # not 3
         assert info.models[0].has_logits is True
         assert info.models[0].has_perplexity is True
+
+
+class TestBatchCheckCacheStatus:
+    """Tests for batch_check_cache_status using LIST instead of per-prompt HEAD."""
+
+    @pytest.fixture(autouse=True)
+    def setup_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+        from lmprobe.cache import set_cache_backend
+
+        set_cache_backend(None)
+        self.model = "test-model"
+        yield
+        set_cache_backend(None)
+
+    def test_all_uncached(self):
+        """All prompts reported as needing extraction when cache is empty."""
+        prompts = ["hello", "world", "foo"]
+        need_act, need_ppl, need_log, partial, _ = batch_check_cache_status(
+            self.model, prompts, required_layers={0, 1}
+        )
+        assert need_act == prompts
+        assert need_ppl == []
+        assert need_log == []
+        assert partial == 0
+
+    def test_all_cached(self):
+        """No prompts need extraction when all are fully cached."""
+        prompts = ["prompt A", "prompt B"]
+        for p in prompts:
+            acts = torch.randn(1, 5, 64)
+            mask = torch.ones(1, 5)
+            save_prompt_activations(self.model, p, [0, 1], acts, mask)
+
+        need_act, _, _, partial, _ = batch_check_cache_status(
+            self.model, prompts, required_layers={0, 1}
+        )
+        assert need_act == []
+        assert partial == 0
+
+    def test_partial_cached(self):
+        """Detects partial cache (some layers missing)."""
+        prompt = "partial prompt"
+        # Save only layer 0
+        acts = torch.randn(1, 5, 32)
+        mask = torch.ones(1, 5)
+        save_prompt_activations(self.model, prompt, [0], acts, mask)
+
+        need_act, _, _, partial, found = batch_check_cache_status(
+            self.model, [prompt], required_layers={0, 1}
+        )
+        assert need_act == [prompt]
+        assert partial == 1
+        assert found is not None
+        assert 0 in found
+
+    def test_mixed_cached_and_uncached(self):
+        """Correctly separates cached vs uncached prompts."""
+        cached_prompt = "cached"
+        uncached_prompt = "uncached"
+        acts = torch.randn(1, 5, 64)
+        mask = torch.ones(1, 5)
+        save_prompt_activations(self.model, cached_prompt, [0, 1], acts, mask)
+
+        need_act, _, _, _, _ = batch_check_cache_status(
+            self.model,
+            [cached_prompt, uncached_prompt],
+            required_layers={0, 1},
+        )
+        assert need_act == [uncached_prompt]
+
+    def test_perplexity_check(self):
+        """Detects missing perplexity cache."""
+        prompt = "ppl test"
+        acts = torch.randn(1, 5, 64)
+        mask = torch.ones(1, 5)
+        save_prompt_activations(self.model, prompt, [0, 1], acts, mask)
+
+        _, need_ppl, _, _, _ = batch_check_cache_status(
+            self.model,
+            [prompt],
+            required_layers={0, 1},
+            compute_perplexity=True,
+        )
+        assert need_ppl == [prompt]
+
+        # Now cache perplexity
+        save_prompt_perplexity(self.model, prompt, torch.tensor([1.0, 2.0, 3.0]))
+        _, need_ppl, _, _, _ = batch_check_cache_status(
+            self.model,
+            [prompt],
+            required_layers={0, 1},
+            compute_perplexity=True,
+        )
+        assert need_ppl == []
+
+    def test_logits_check(self):
+        """Detects missing logits cache."""
+        prompt = "logits test"
+        acts = torch.randn(1, 5, 64)
+        mask = torch.ones(1, 5)
+        save_prompt_activations(self.model, prompt, [0, 1], acts, mask)
+
+        _, _, need_log, _, _ = batch_check_cache_status(
+            self.model,
+            [prompt],
+            required_layers={0, 1},
+            cache_logits=True,
+        )
+        assert need_log == [prompt]
+
+        # Now cache logits
+        logits = torch.randn(1, 5, 100)
+        save_prompt_logits(self.model, prompt, logits, mask)
+        _, _, need_log, _, _ = batch_check_cache_status(
+            self.model,
+            [prompt],
+            required_layers={0, 1},
+            cache_logits=True,
+        )
+        assert need_log == []
+
+    def test_pooled_check(self):
+        """Works with pooled activations."""
+        prompt = "pooled test"
+        pooled = torch.randn(1, 64)
+        save_prompt_pooled_activations(
+            self.model, prompt, [0, 1], pooled, "last_token"
+        )
+
+        need_act, _, _, _, _ = batch_check_cache_status(
+            self.model,
+            [prompt],
+            required_layers={0, 1},
+            pooling="last_token",
+        )
+        assert need_act == []
+
+    def test_header_only_read(self):
+        """_get_tensor_keys_header_only correctly parses safetensors header."""
+        from lmprobe.cache import _get_tensor_keys_header_only, get_backend
+
+        prompt = "header test"
+        acts = torch.randn(1, 5, 64)
+        mask = torch.ones(1, 5)
+        save_prompt_activations(self.model, prompt, [0, 1], acts, mask)
+
+        backend = get_backend()
+        key = _prompt_cache_key(self.model, prompt)
+        keys = _get_tensor_keys_header_only(backend, key)
+        assert "layer_0" in keys
+        assert "layer_1" in keys
+        assert "attention_mask" in keys


### PR DESCRIPTION
## Summary

- Replace per-prompt S3 HEAD requests in `_check_cache_status` with a single LIST call + local set lookups
- Add `_get_tensor_keys_header_only()` that parses safetensors file headers via range reads instead of downloading entire files (can be GBs for large models)
- Add `read_range()` to `CacheBackend` ABC — S3 uses HTTP Range header, local uses file seek
- For 3000 prompts × 3 cache types, this reduces cache checking from ~9000 HEAD requests (~7.5 min at 50ms each) to 1 LIST call (~seconds)

## Test plan

- [x] 8 new tests in `TestBatchCheckCacheStatus` covering: all-uncached, all-cached, partial cache, mixed, perplexity, logits, pooled, and header-only read
- [x] Full test suite: 743 passed, 5 skipped, 16 xpassed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)