### PR TITLE
Batch streaming uploads via create_commit for throughput

### DIFF
--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -1613,6 +1613,42 @@ def _push_dataset_streaming(
         repo_type="dataset",
     )
 
+    # Retry any pending batch from a prior failed create_commit.
+    # These files are already consolidated locally — skip re-reading from S3.
+    prior_batch = manifest.get("pending_batch", [])
+    if prior_batch:
+        local_files_exist = all(Path(lp).exists() for lp, _ in prior_batch)
+        if local_files_exist:
+            logger.info(
+                "[SHARING] Retrying pending batch of %d shards from "
+                "prior run", len(prior_batch),
+            )
+            operations = [
+                CommitOperationAdd(
+                    path_in_repo=rp,
+                    path_or_fileobj=lp,
+                )
+                for lp, rp in prior_batch
+            ]
+            api.create_commit(
+                repo_id=repo_id,
+                operations=operations,
+                commit_message=f"Add {len(prior_batch)} shards (retry)",
+                repo_type="dataset",
+            )
+            for lp, rp in prior_batch:
+                Path(lp).unlink(missing_ok=True)
+                manifest["completed_shards"].append(rp)
+            manifest.pop("pending_batch", None)
+            _save_manifest(staging_dir, manifest)
+        else:
+            # Files gone — clear pending_batch; re-consolidation will handle
+            logger.debug(
+                "[SHARING] Pending batch files missing, will re-consolidate"
+            )
+            manifest.pop("pending_batch", None)
+            _save_manifest(staging_dir, manifest)
+
     # Build the batched on_shard_written callback
     completed_set = set(manifest["completed_shards"])
     pending_shards: list[tuple[Path, str]] = []
@@ -1627,6 +1663,13 @@ def _push_dataset_streaming(
             len(pending_shards),
             ", ".join(paths_in_batch),
         )
+        # Save pending paths to manifest before commit so resume can
+        # find them if create_commit fails (avoids re-consolidation).
+        manifest["pending_batch"] = [
+            [str(lp), rp] for lp, rp in pending_shards
+        ]
+        _save_manifest(staging_dir, manifest)
+
         operations = [
             CommitOperationAdd(
                 path_in_repo=repo_path,
@@ -1647,6 +1690,7 @@ def _push_dataset_streaming(
             local_path.unlink(missing_ok=True)
             manifest["completed_shards"].append(repo_path)
             completed_set.add(repo_path)
+        manifest.pop("pending_batch", None)
         _save_manifest(staging_dir, manifest)
         pending_shards.clear()
 

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -1011,6 +1011,63 @@ class TestPushDatasetStreaming:
     @patch("lmprobe.sharing._check_hub_deps")
     @patch("lmprobe.sharing._check_pyarrow")
     @patch("huggingface_hub.HfApi")
+    def test_stream_retries_pending_batch_on_resume(
+        self, MockHfApi, mock_pyarrow, mock_deps, populated_cache,
+    ):
+        """Resume retries a pending batch from a prior failed create_commit."""
+        from safetensors.torch import save_file
+
+        mock_api = MagicMock()
+        MockHfApi.return_value = mock_api
+
+        staging_dir = _staging_dir_path(
+            "user/retry-batch", TEST_MODEL, populated_cache,
+            labels=[1, 1, 0], stream=True, stream_batch_size=10,
+        )
+
+        # Simulate a prior failed run: manifest has a pending_batch
+        # with local files that still exist on disk.
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        (staging_dir / "tensors").mkdir(parents=True, exist_ok=True)
+        (staging_dir / "index").mkdir(parents=True, exist_ok=True)
+
+        shard_file = staging_dir / "tensors" / "hidden_layer000_shard000.safetensors"
+        save_file(
+            {"hidden.layer_0": torch.randn(3, HIDDEN_DIM)},
+            str(shard_file),
+        )
+
+        manifest = _new_manifest("user/retry-batch")
+        manifest["pending_batch"] = [
+            [str(shard_file), "tensors/hidden_layer000_shard000.safetensors"],
+        ]
+        _save_manifest(staging_dir, manifest)
+
+        commit_messages = []
+
+        def track_commits(*, repo_id, operations, commit_message="", **kw):
+            commit_messages.append(commit_message)
+
+        mock_api.create_commit.side_effect = track_commits
+
+        push_dataset(
+            repo_id="user/retry-batch",
+            model_name=TEST_MODEL,
+            prompts=populated_cache,
+            labels=[1, 1, 0],
+            exist_ok=True,
+            stream=True,
+        )
+
+        # First commit should be the retry of the pending batch
+        assert any("retry" in m.lower() for m in commit_messages), (
+            f"Expected a retry commit, got: {commit_messages}"
+        )
+
+    @requires_pyarrow
+    @patch("lmprobe.sharing._check_hub_deps")
+    @patch("lmprobe.sharing._check_pyarrow")
+    @patch("huggingface_hub.HfApi")
     def test_stream_batch_size_controls_commit_grouping(
         self, MockHfApi, mock_pyarrow, mock_deps, populated_cache,
     ):


### PR DESCRIPTION
## Summary

Closes #151

- Replace per-shard `upload_file` (1 commit per shard, 252 commits for 252 shards) with batched `create_commit` (1 commit per N shards)
- Add `stream_batch_size` parameter (default 10) — controls how many shards are buffered before uploading as a single commit
- Metadata files also batched into a single `create_commit` call
- Manifest updated per-batch for resume granularity
- `stream_batch_size` included in staging dir hash to prevent collisions

### Trade-offs (N=10 default)

| | Before (per-shard) | After (batched) |
|---|---|---|
| Commits | 252 | ~25 |
| Peak disk | ~500MB (1 shard) | ~5GB (10 shards) |
| Parallelism | None | HF Hub parallel LFS |
| Resume granularity | Per-shard | Per-batch |

## Test plan

- [x] `test_stream_uses_create_commit` — uses `create_commit`, not `upload_file`/`upload_large_folder`
- [x] `test_stream_produces_correct_repo_paths` — all tensor + metadata paths uploaded
- [x] `test_stream_manifest_tracks_progress` — manifest survives partial failure
- [x] `test_stream_resume_skips_completed` — resume skips completed batches
- [x] `test_stream_batch_size_controls_commit_grouping` — `batch_size=1` → one commit per shard
- [x] `test_stream_large_batch_fewer_commits` — large batch → single shard commit
- [x] All 99 sharing tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)