### PR TITLE
Fix dataset= mode crash with last-token shard splitting

### DIFF
--- a/src/lmprobe/probe.py
+++ b/src/lmprobe/probe.py
@@ -597,9 +597,10 @@ class Probe:
         must already be in the local cache (populated by
         ``_pull_dataset_for_prompts``).
 
-        Pools each prompt individually to avoid padding-induced memory
-        waste.  Peak memory is O(max_seq × hidden_dim) rather than
-        O(batch × max_seq × hidden_dim).
+        For split-shard datasets (with ``token_shard_ids``), loads
+        pre-pooled activations directly via ``load_prompt_pooled_activations``
+        which correctly resolves the last-token shard.  For legacy datasets,
+        falls back to loading raw activations and pooling manually.
 
         Returns
         -------
@@ -607,7 +608,7 @@ class Probe:
             ``(pooled_activations, None)`` — attention mask is always None
             because dataset activations don't need score-level pooling.
         """
-        from .cache import load_prompt_activations
+        from .cache import load_prompt_activations, load_prompt_pooled_activations
 
         meta = self._ensure_dataset_metadata()
         pool_fn = get_pooling_fn(pooling_strategy)
@@ -615,6 +616,19 @@ class Probe:
         pooled_rows = []
         missing = []
         for prompt in prompts:
+            # Try loading pre-pooled activations first.  This handles
+            # split-shard datasets (token_shard_ids) correctly and is
+            # also faster since it skips raw-token loading.
+            try:
+                pooled = load_prompt_pooled_activations(
+                    meta.model_name, prompt, layers, pooling_strategy
+                )
+                pooled_rows.append(pooled.detach().cpu().float())
+                continue
+            except FileNotFoundError:
+                pass
+
+            # Fall back to raw loading + manual pooling (legacy datasets).
             try:
                 acts, mask = load_prompt_activations(
                     meta.model_name, prompt, layers

--- a/tests/test_dataset_param.py
+++ b/tests/test_dataset_param.py
@@ -156,6 +156,9 @@ class TestLoadAndPoolFromCache:
         mask = torch.ones(1, 3)
 
         with patch(
+            "lmprobe.cache.load_prompt_pooled_activations",
+            side_effect=FileNotFoundError("no pooled"),
+        ), patch(
             "lmprobe.cache.load_prompt_activations",
             return_value=(acts, mask),
         ):
@@ -174,6 +177,9 @@ class TestLoadAndPoolFromCache:
         probe._dataset_metadata = meta
 
         with patch(
+            "lmprobe.cache.load_prompt_pooled_activations",
+            side_effect=FileNotFoundError("not found"),
+        ), patch(
             "lmprobe.cache.load_prompt_activations",
             side_effect=FileNotFoundError("not found"),
         ):
@@ -181,6 +187,36 @@ class TestLoadAndPoolFromCache:
                 probe._load_and_pool_from_cache(
                     ["missing"], layers=[0], pooling_strategy="last_token"
                 )
+
+    def test_load_and_pool_split_shard_uses_pooled(self):
+        """Split-shard datasets should load via load_prompt_pooled_activations.
+
+        When a dataset uses last-token shard splitting (token_shard_ids),
+        load_prompt_activations fails because _load_raw_from_shard gets the
+        rest-token shard.  _load_and_pool_from_cache should fall through to
+        load_prompt_pooled_activations which handles this correctly.
+        (Regression test for GH-182.)
+        """
+        probe = Probe(dataset="user/repo", layers=-1, pooling="last_token")
+        meta = _make_metadata(model_name="test-model")
+        probe._dataset_metadata = meta
+
+        hidden_dim = 4
+        # Pooled result: (1, hidden_dim)
+        pooled_tensor = torch.randn(1, hidden_dim)
+
+        with patch(
+            "lmprobe.cache.load_prompt_pooled_activations",
+            return_value=pooled_tensor,
+        ) as mock_pooled:
+            result, attn = probe._load_and_pool_from_cache(
+                ["prompt1"], layers=[0], pooling_strategy="last_token",
+            )
+            assert result.shape == (1, hidden_dim)
+            assert attn is None
+            mock_pooled.assert_called_once_with(
+                "test-model", "prompt1", [0], "last_token"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes `_load_and_pool_from_cache` to try `load_prompt_pooled_activations` first, which correctly handles split-shard datasets with `token_shard_ids`
- Falls back to raw `load_prompt_activations` + manual pooling for legacy datasets
- Adds regression test for the split-shard path

Closes #182

## Test plan

- [x] New test `test_load_and_pool_split_shard_uses_pooled` verifies pooled path is used for split-shard datasets
- [x] Existing `test_load_and_pool_success` updated to verify raw fallback still works
- [x] All 15 dataset param tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)