### PR TITLE
Consolidate shard tensor slicing into shared helpers

### DIFF
--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -1458,10 +1458,10 @@ def _parse_shard_layer_nums(keys: Iterable[str]) -> list[int]:
 
 
 def _slice_hidden_from_tensors(
-    tensors: dict[str, "torch.Tensor"],
+    tensors: dict[str, torch.Tensor],
     layers: list[int] | None,
-    slice_fn: Callable[["torch.Tensor"], "torch.Tensor"],
-) -> list[tuple[int, "torch.Tensor"]]:
+    slice_fn: Callable[[torch.Tensor], torch.Tensor],
+) -> list[tuple[int, torch.Tensor]]:
     """Extract hidden layer slices from a pre-loaded tensor dict.
 
     Parameters
@@ -1493,9 +1493,9 @@ def _slice_hidden_from_tensors(
 
 
 def _slice_logits_from_tensors(
-    tensors: dict[str, "torch.Tensor"],
+    tensors: dict[str, torch.Tensor],
     row_offset: int,
-) -> tuple["torch.Tensor", "torch.Tensor"]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Extract top-k logit values and indices from a pre-loaded tensor dict."""
     values = tensors["logits_topk.values"][row_offset : row_offset + 1]
     indices = tensors["logits_topk.indices"][row_offset : row_offset + 1]

--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import re
 import tempfile
 import warnings
 from collections.abc import Callable


### PR DESCRIPTION
## Summary

Extracts 3 shared helpers in cache.py that operate on pre-loaded tensor dicts, eliminating duplicated shard reading logic between `_unpack_shard_prompts` (sharing.py) and cache.py's shard loaders:

- **`_parse_shard_layer_nums`**: Replaces 5 copies of the `hidden.layer_N` regex across both files
- **`_slice_hidden_from_tensors`**: Replaces duplicated "iterate keys, match layer, apply slice" pattern
- **`_slice_logits_from_tensors`**: Replaces duplicated logits row extraction

Refactors both cache.py loaders (`_load_colocated_slices`, `_load_logits_from_shard`) and sharing.py's `_unpack_shard_prompts` to use the shared helpers. The split full_sequence token reconstruction stays in sharing.py — it's a batch-level optimization unique to materialization.

Closes #174

## Test plan

- [x] Full test suite passes (787 passed, 0 failures)
- [x] No remaining standalone `re.match(r"^hidden\.layer_` outside the helper
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)