### PR TITLE
Update docs and tests for Probe rename, remove outdated content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ The `remote=True` functionality uses nnsight to connect to NDIF (National Deep I
 2. **API key requirement**: Requires `NDIF_API_KEY` environment variable
 
 **What needs testing:**
-- `LinearProbe(..., remote=True)` connects successfully
+- `Probe(..., remote=True)` connects successfully
 - `probe.fit(..., remote=True)` extracts activations from remote models
 - `probe.predict(..., remote=False)` override works (train remote, predict local)
 - Large models (e.g., `meta-llama/Llama-3.1-70B-Instruct`) work via remote
@@ -158,7 +158,7 @@ pytest tests/test_remote.py -v  # (test file to be created)
 ```python
 # Example test
 def test_fit_predict_roundtrip(tiny_model):
-    probe = LinearProbe(
+    probe = Probe(
         model=tiny_model,
         layers=-1,
         remote=False,
@@ -188,7 +188,7 @@ the library's public API is working as advertised.
 
 def test_readme_example_runs(tiny_model):
     """The README example code runs without error."""
-    from lmprobe import LinearProbe
+    from lmprobe import Probe
 
     positive_prompts = [
         "Who wants to go for a walk?",
@@ -205,7 +205,7 @@ def test_readme_example_runs(tiny_model):
         "Tail raised, back arched, eyes alert, whiskers forward.",
     ]
 
-    probe = LinearProbe(
+    probe = Probe(
         model=tiny_model,  # Use tiny model instead of Llama for tests
         layers=-1,         # Last layer (tiny model has few layers)
         pooling="last_token",
@@ -246,7 +246,7 @@ def test_readme_example_runs(tiny_model):
 When implementing, make tests pass in this order:
 
 1. `test_readme_example.py` — The north star (full integration)
-2. `test_probe.py` — LinearProbe unit tests
+2. `test_probe.py` — Probe unit tests
 3. `test_extraction.py` — Activation extraction tests
 4. `test_pooling.py` — Pooling strategy tests
 5. `test_cache.py` — Caching tests
@@ -267,10 +267,10 @@ pytest --cov=lmprobe
 ## Quick Reference
 
 ```python
-from lmprobe import LinearProbe
+from lmprobe import Probe
 
 # Train from a model (extracts activations live)
-probe = LinearProbe(
+probe = Probe(
     model="meta-llama/Llama-3.1-8B-Instruct",
     layers=16,                          # int | list[int] | "all" | "middle"
     pooling="last_token",               # or override with train_pooling / inference_pooling
@@ -287,7 +287,7 @@ predictions = probe.predict(new_prompts)
 from lmprobe import load_activations
 
 acts, labels = load_activations("user/my-dataset", layers=[16], return_labels=True)
-probe = LinearProbe(classifier="logistic_regression", random_state=42)
+probe = Probe(classifier="logistic_regression", random_state=42)
 probe.fit_from_activations(acts[16], labels)
 ```
 
@@ -304,22 +304,10 @@ probe.fit_from_activations(acts[16], labels)
 2. If not, add architecture-specific extraction in `src/lmprobe/extraction.py`
 3. Document any quirks in `docs/models/`
 
-## Future Work: Additional Baselines
+## Baselines
 
-The `BaselineProbe` class currently supports `bow`, `tfidf`, `random`, and `majority` methods.
-Future baselines to consider (see GitHub issue for details):
+`BaselineProbe` supports: `bow`, `tfidf`, `random`, `majority`, `sentence_length`, `sentence_transformers`, `shuffled_labels`, and `perplexity`.
 
-### Surface-level baselines
-- **Sentence length** — surprisingly predictive for some tasks
-- **Perplexity/logprob** — model's own token probabilities; critical for truthfulness tasks (Marks & Tegmark showed probable ≠ true)
+`ActivationBaseline` supports: `random_direction`, `pca`, and `layer_0`.
 
-### Activation baselines
-- **Random direction** — project activations onto random unit vector and classify; tests whether any direction works or learned direction is special
-- **PCA top-k** — classify using projection onto top principal components; tests if signal is in obvious variance or requires learning
-- **Layer 0 (embeddings)** — if input embeddings work as well as middle layers, probe might just be recovering token identity
-
-### External embedding baselines
-- **Sentence-transformers** — off-the-shelf semantic embeddings + logistic regression; tests whether finding something model-specific or just general semantics
-
-### Sanity checks
-- **Shuffled labels** — train probe on permuted labels, should get ~50%; validates probe isn't overfitting to noise
+`BaselineBattery` runs all applicable baselines at once and returns ranked results.

--- a/docs/design/001-api-philosophy.md
+++ b/docs/design/001-api-philosophy.md
@@ -14,7 +14,7 @@
 
 ### sklearn Compatibility
 
-The primary `LinearProbe` class follows sklearn conventions:
+The primary `Probe` class follows sklearn conventions:
 
 ```python
 # sklearn pattern
@@ -59,7 +59,7 @@ probe.fit(all_prompts, labels)  # labels: list[int] or np.array
 All configuration happens at construction time:
 
 ```python
-probe = LinearProbe(
+probe = Probe(
     model="...",
     layers=16,
     train_pooling="last_token",
@@ -82,16 +82,16 @@ The `remote` parameter controls whether nnsight runs model inference locally or 
 
 ```python
 # Local execution (default)
-probe = LinearProbe(model="meta-llama/Llama-3.1-8B-Instruct", remote=False)
+probe = Probe(model="meta-llama/Llama-3.1-8B-Instruct", remote=False)
 
 # Remote execution
-probe = LinearProbe(model="meta-llama/Llama-3.1-70B-Instruct", remote=True)
+probe = Probe(model="meta-llama/Llama-3.1-70B-Instruct", remote=True)
 ```
 
 **Override at method call**: The `remote` parameter can be overridden on `fit()` and `predict()`:
 
 ```python
-probe = LinearProbe(model="...", remote=True)  # default to remote
+probe = Probe(model="...", remote=True)  # default to remote
 
 # Train remotely (uses init default)
 probe.fit(pos, neg)
@@ -119,7 +119,7 @@ CONFIG.API.APIKEY = os.getenv("NDIF_API_KEY")
 The `random_state` parameter ensures reproducibility across all random operations:
 
 ```python
-probe = LinearProbe(
+probe = Probe(
     model="...",
     classifier="logistic_regression",
     random_state=42,  # Propagates to classifier and any other random operations
@@ -138,7 +138,7 @@ probe = LinearProbe(
 **Decision**: Activation caching to disk is **always enabled**. Extracting activations from LLMs (especially remotely) is expensive, so we cache by default to enable rapid iteration on classifier experiments.
 
 ```python
-probe = LinearProbe(model="meta-llama/Llama-3.1-8B-Instruct")
+probe = Probe(model="meta-llama/Llama-3.1-8B-Instruct")
 probe.fit(pos, neg)  # Extracts and caches activations
 probe.fit(pos, neg)  # Second call uses cached activations
 ```
@@ -157,7 +157,7 @@ probe.fit(pos, neg, invalidate_cache=True)
 A minimal example should work:
 
 ```python
-probe = LinearProbe()  # Uses reasonable defaults
+probe = Probe()  # Uses reasonable defaults
 probe.fit(pos, neg)
 probe.predict(test)
 ```
@@ -177,13 +177,13 @@ We provide three pooling parameters for progressive complexity:
 
 ```python
 # Simple: same strategy for train and inference (most users)
-probe = LinearProbe(pooling="last_token")
+probe = Probe(pooling="last_token")
 
 # Advanced: different strategies for train vs inference
-probe = LinearProbe(train_pooling="last_token", inference_pooling="max")
+probe = Probe(train_pooling="last_token", inference_pooling="max")
 
 # Mixed: set a base, override one
-probe = LinearProbe(pooling="last_token", inference_pooling="all")
+probe = Probe(pooling="last_token", inference_pooling="all")
 ```
 
 **Collision resolution** (most specific wins):
@@ -204,10 +204,10 @@ Simple things are simple, complex things are possible:
 
 ```python
 # Level 1: One-liner (local execution)
-probe = LinearProbe(model="meta-llama/Llama-3.1-8B-Instruct")
+probe = Probe(model="meta-llama/Llama-3.1-8B-Instruct")
 
 # Level 2: Common customization (remote execution for large models)
-probe = LinearProbe(
+probe = Probe(
     model="meta-llama/Llama-3.1-70B-Instruct",
     layers=[14, 15, 16],
     classifier="logistic_regression",
@@ -219,7 +219,7 @@ probe = LinearProbe(
 from sklearn.svm import SVC
 from lmprobe.pooling import WeightedMeanPooling
 
-probe = LinearProbe(
+probe = Probe(
     model="meta-llama/Llama-3.1-8B-Instruct",
     layers=[14, 15, 16],
     train_pooling=WeightedMeanPooling(weights="attention"),

--- a/docs/design/002-pooling-strategies.md
+++ b/docs/design/002-pooling-strategies.md
@@ -16,16 +16,16 @@ We provide three pooling parameters with a clear hierarchy:
 
 ```python
 # Simple: same strategy for train and inference (most common)
-probe = LinearProbe(pooling="last_token")
+probe = Probe(pooling="last_token")
 
 # Advanced: override for specific phases
-probe = LinearProbe(
+probe = Probe(
     pooling="last_token",        # base strategy
     inference_pooling="max",     # override for predict()
 )
 
 # Explicit: set both independently
-probe = LinearProbe(
+probe = Probe(
     train_pooling="last_token",
     inference_pooling="all",
 )
@@ -53,7 +53,7 @@ Using `train_pooling="all"` treats each token as an independent training example
 
 ```python
 # 10 prompts × 100 tokens = 1,000 training examples
-probe = LinearProbe(
+probe = Probe(
     model="meta-llama/Llama-3.1-8B-Instruct",
     train_pooling="all",
     inference_pooling="max",
@@ -89,7 +89,7 @@ Goal: **Detect the property of interest**, potentially at any point in generatio
 ```python
 # Train on the final token where the "intent" is crystallized
 # At inference, flag if ANY token crosses the threshold
-probe = LinearProbe(
+probe = Probe(
     pooling="last_token",
     inference_pooling="max",
 )
@@ -98,7 +98,7 @@ probe = LinearProbe(
 ### Example: Per-Token Visualization
 
 ```python
-probe = LinearProbe(
+probe = Probe(
     pooling="last_token",
     inference_pooling="all",
 )

--- a/docs/design/003-layer-selection.md
+++ b/docs/design/003-layer-selection.md
@@ -84,10 +84,10 @@ At `__init__` time (when model is loaded):
 
 ```python
 # Error: layer out of range
-LinearProbe(model="gpt2", layers=50)  # GPT-2 has 12 layers → ValueError
+Probe(model="gpt2", layers=50)  # GPT-2 has 12 layers → ValueError
 
 # Warning: probing layer 0 (usually not useful)
-LinearProbe(model="...", layers=0)  # UserWarning: Layer 0 is immediately post-embedding
+Probe(model="...", layers=0)  # UserWarning: Layer 0 is immediately post-embedding
 ```
 
 ### Deferred Validation with `remote=True`
@@ -99,7 +99,7 @@ When using remote execution via nnsight, the model architecture may not be known
 
 ```python
 # Remote model - validation deferred
-probe = LinearProbe(
+probe = Probe(
     model="meta-llama/Llama-3.1-70B-Instruct",
     layers="middle",
     remote=True,  # Model not loaded locally

--- a/docs/design/004-classifier-interface.md
+++ b/docs/design/004-classifier-interface.md
@@ -19,18 +19,18 @@ The `classifier` parameter accepts either a string (built-in) or an sklearn-comp
 
 ```python
 # Built-in (string)
-probe = LinearProbe(classifier="logistic_regression")
-probe = LinearProbe(classifier="svm")
-probe = LinearProbe(classifier="ridge")
+probe = Probe(classifier="logistic_regression")
+probe = Probe(classifier="svm")
+probe = Probe(classifier="ridge")
 
 # Custom sklearn estimator
 from sklearn.svm import SVC
-probe = LinearProbe(classifier=SVC(kernel="linear", probability=True))
+probe = Probe(classifier=SVC(kernel="linear", probability=True))
 
 # Custom with pipeline
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
-probe = LinearProbe(
+probe = Probe(
     classifier=Pipeline([
         ("scaler", StandardScaler()),
         ("clf", LogisticRegression()),
@@ -70,7 +70,7 @@ At `__init__` time, we validate:
 
 ```python
 # Warning: classifier lacks predict_proba
-probe = LinearProbe(classifier=RidgeClassifier())
+probe = Probe(classifier=RidgeClassifier())
 # UserWarning: RidgeClassifier does not support predict_proba().
 # probe.predict_proba() will raise an error.
 ```
@@ -83,7 +83,7 @@ For classifiers without native probability support, users can wrap with `Calibra
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.svm import LinearSVC
 
-probe = LinearProbe(
+probe = Probe(
     classifier=CalibratedClassifierCV(LinearSVC(), cv=3)
 )
 ```
@@ -104,7 +104,7 @@ from sklearn.decomposition import PCA
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import LogisticRegression
 
-probe = LinearProbe(
+probe = Probe(
     layers="all",  # 32 layers × 4096 = 131,072 dims
     classifier=Pipeline([
         ("pca", PCA(n_components=1000)),
@@ -179,11 +179,11 @@ probs = probe.predict_proba(test)
 
 ### Random State Propagation
 
-**Decision**: `LinearProbe.random_state` propagates to all built-in classifiers. This ensures reproducibility from a single parameter.
+**Decision**: `Probe.random_state` propagates to all built-in classifiers. This ensures reproducibility from a single parameter.
 
 ```python
-# LinearProbe's random_state flows to the classifier
-probe = LinearProbe(
+# Probe's random_state flows to the classifier
+probe = Probe(
     model="...",
     classifier="logistic_regression",
     random_state=42,  # Propagates to LogisticRegression
@@ -193,7 +193,7 @@ probe = LinearProbe(
 For custom classifiers, users must set `random_state` themselves:
 ```python
 # Custom classifier — user controls random_state
-probe = LinearProbe(
+probe = Probe(
     model="...",
     classifier=SVC(kernel="linear", probability=True, random_state=42),
     random_state=42,  # Does NOT automatically propagate to custom classifiers
@@ -202,7 +202,7 @@ probe = LinearProbe(
 
 ### Built-In Classifier Factory
 
-Built-in classifiers are constructed with `random_state` from `LinearProbe`:
+Built-in classifiers are constructed with `random_state` from `Probe`:
 
 ```python
 def _build_classifier(name: str, random_state: int | None) -> BaseEstimator:
@@ -261,7 +261,7 @@ Could automatically wrap classifiers lacking `predict_proba()`. Rejected because
 - Users who don't need probabilities shouldn't pay the cost
 
 ### Neural Network Classifiers
-Could support PyTorch-based classifiers for non-linear probing. Deferred to future work — the "linear" in `LinearProbe` is intentional. Could add `NonlinearProbe` later.
+Could support PyTorch-based classifiers for non-linear probing. Deferred to future work — the "linear" in `Probe` is intentional. Could add `NonlinearProbe` later.
 
 ### Ensemble of Layer-Specific Classifiers
 Train one classifier per layer, ensemble predictions. More complex, deferred to potential `EnsembleProbe` class.

--- a/docs/reference/datasets.md
+++ b/docs/reference/datasets.md
@@ -54,6 +54,11 @@ See the [HuggingFace Datasets guide](../guides/datasets.md) for a walkthrough.
       show_root_heading: true
       show_source: false
 
+::: lmprobe.sharing.migrate_dataset
+    options:
+      show_root_heading: true
+      show_source: false
+
 ::: lmprobe.sharing.upgrade_dataset_format
     options:
       show_root_heading: true

--- a/specs/005-hub-integration.md
+++ b/specs/005-hub-integration.md
@@ -238,7 +238,7 @@ Implementation notes:
 # Probe is in a "ready but model-less" state — classifier is loaded,
 # config is loaded, but ActivationExtractor isn't initialized until
 # the user calls predict() with a model available.
-probe = LinearProbe.from_hub(
+probe = Probe.from_hub(
     "alliedtoasters/cbrn-detector-llama3-8b",
     trust_classifier=True,
 )
@@ -247,7 +247,7 @@ probe.predict(["some new text"])  # requires base model already available locall
 # Full setup: download base model and initialize everything
 # Passes the pinned base_model.revision to transformers' from_pretrained(),
 # so the user gets exactly the right model weights for reproducibility.
-probe = LinearProbe.from_hub(
+probe = Probe.from_hub(
     "alliedtoasters/cbrn-detector-llama3-8b",
     load_model=True,            # downloads base model if not cached
     trust_classifier=True,
@@ -256,7 +256,7 @@ probe = LinearProbe.from_hub(
 probe.predict(["some new text"])  # works immediately
 
 # Pin a specific Hub commit of the probe repo itself
-probe = LinearProbe.from_hub(
+probe = Probe.from_hub(
     "alliedtoasters/cbrn-detector-llama3-8b",
     revision="abc123",          # specific probe repo commit
     trust_classifier=True,
@@ -265,7 +265,7 @@ probe = LinearProbe.from_hub(
 
 Implementation notes:
 
-- `from_hub` downloads the probe repo via `snapshot_download`, reads `probe_config.json`, constructs a `LinearProbe` with the saved config, then loads the classifier from `classifier.skops`.
+- `from_hub` downloads the probe repo via `snapshot_download`, reads `probe_config.json`, constructs a `Probe` with the saved config, then loads the classifier from `classifier.skops`.
 - **`load_model` parameter** (default `False`): when `False`, the probe is returned without initializing the `ActivationExtractor`. The extractor is lazily initialized on the first call to `predict()`, at which point the base model must be available locally. When `True`, `from_hub` eagerly initializes the extractor, downloading the base model via transformers' `from_pretrained()` if needed. The pinned `base_model.revision` is passed through, ensuring exact weight reproducibility.
 - **Model validation**: on load (or on first `predict()` if lazy), we compare the `base_model.name` in config against the model the user will run inference with. If they don't match, we **warn** but don't error — the user may intentionally be testing cross-model transfer. If the model is not available and `load_model=False`, `predict()` raises a clear error: `"This probe was trained on meta-llama/Llama-3.1-8B-Instruct (revision abc123). Pass load_model=True to from_hub() to download it, or ensure the model is available locally."`
 - **Revision validation**: if the user has a different revision of the base model checked out locally, we warn. We don't error because the user may not have the exact commit available.
@@ -293,7 +293,7 @@ A key feature: given a probe on the Hub, can I verify it?
 
 ```python
 # Reproduce from scratch
-probe = LinearProbe.from_hub(
+probe = Probe.from_hub(
     "alliedtoasters/cbrn-detector-llama3-8b",
     load_model=True,
     trust_classifier=True,
@@ -301,7 +301,7 @@ probe = LinearProbe.from_hub(
 card = ProbeCard.from_hub("alliedtoasters/cbrn-detector-llama3-8b")
 
 # Re-train with the published training data
-fresh_probe = LinearProbe(**card.to_reproduce_config())
+fresh_probe = Probe(**card.to_reproduce_config())
 fresh_probe.fit(card.positive_examples, card.negative_examples)
 
 # Compare
@@ -506,7 +506,7 @@ class ProbeCard:
         return self.base_model == model
 
     def to_reproduce_config(self) -> dict:
-        """Return kwargs suitable for LinearProbe(...) constructor."""
+        """Return kwargs suitable for Probe(...) constructor."""
         return {
             "model": self.base_model,
             "layers": self.layers_spec_original,
@@ -543,7 +543,7 @@ class ProbeCard:
 - `training_info.json` can grow large if training prompts are very long or numerous; consider a size cap or separate file for data
 
 **Migration**:
-- Existing `.pkl` probes saved with `probe.save()` still work via `LinearProbe.load()`
+- Existing `.pkl` probes saved with `probe.save()` still work via `Probe.load()`
 - No breaking changes to the existing API
 - `push_to_hub` / `from_hub` are purely additive
 

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -16,7 +16,7 @@ def test_readme_example_runs(tiny_model):
     This test mirrors the exact usage pattern from README.md,
     substituting the tiny test model for the full Llama model.
     """
-    from lmprobe import LinearProbe
+    from lmprobe import Probe
 
     positive_prompts = [
         "Who wants to go for a walk?",
@@ -34,7 +34,7 @@ def test_readme_example_runs(tiny_model):
     ]
 
     # Configure the probe (mirrors README, with test-appropriate values)
-    probe = LinearProbe(
+    probe = Probe(
         model=tiny_model,
         layers=-1,  # Last layer (tiny model has few layers)
         pooling="last_token",
@@ -72,9 +72,9 @@ def test_readme_example_runs(tiny_model):
 
 def test_readme_save_load(tiny_model, tmp_path):
     """The save/load functionality from README works."""
-    from lmprobe import LinearProbe
+    from lmprobe import Probe
 
-    probe = LinearProbe(
+    probe = Probe(
         model=tiny_model,
         layers=-1,
         pooling="last_token",
@@ -89,7 +89,7 @@ def test_readme_save_load(tiny_model, tmp_path):
     save_path = tmp_path / "test_probe.pkl"
     probe.save(str(save_path))
 
-    loaded_probe = LinearProbe.load(str(save_path))
+    loaded_probe = Probe.load(str(save_path))
 
     # Loaded probe should produce same predictions
     original_pred = probe.predict(["test input"])
@@ -100,9 +100,9 @@ def test_readme_save_load(tiny_model, tmp_path):
 
 def test_readme_different_pooling(tiny_model):
     """Different train vs inference pooling from README works."""
-    from lmprobe import LinearProbe
+    from lmprobe import Probe
 
-    probe = LinearProbe(
+    probe = Probe(
         model=tiny_model,
         layers=-1,
         pooling="last_token",
@@ -120,9 +120,9 @@ def test_readme_different_pooling(tiny_model):
 
 def test_readme_per_token_scores(tiny_model):
     """Per-token scoring with inference_pooling='all' works."""
-    from lmprobe import LinearProbe
+    from lmprobe import Probe
 
-    probe = LinearProbe(
+    probe = Probe(
         model=tiny_model,
         layers=-1,
         pooling="last_token",
@@ -144,9 +144,9 @@ def test_readme_per_token_scores(tiny_model):
 
 def test_readme_multilayer(tiny_model):
     """Multi-layer probing (concatenation) works."""
-    from lmprobe import LinearProbe
+    from lmprobe import Probe
 
-    probe = LinearProbe(
+    probe = Probe(
         model=tiny_model,
         layers=[-2, -1],  # Last two layers, concatenated
         pooling="last_token",


### PR DESCRIPTION
## Summary

- Rename `LinearProbe` → `Probe` across all design docs (001-004), spec 005, CLAUDE.md, and the north star test to match the breaking release
- Replace outdated "Future Work: Additional Baselines" section in CLAUDE.md with current-state summary (all baselines are now implemented)
- Add missing `migrate_dataset` to `docs/reference/datasets.md` API reference

## Test plan

- [x] North star test passes with `Probe` imports (`pytest tests/test_readme_example.py` — 5/5 passed)
- [x] Only remaining `LinearProbe` references are the backwards-compat alias mentions in README.md and CLAUDE.md package structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)