### PR TITLE
Add verify_cache param to skip S3 header reads in warmup()

### DIFF
--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -659,7 +659,10 @@ def _load_tensors_from_backend(
                         raise KeyError(
                             f"Corrupted or incomplete cache entry {key}: "
                             f"missing key {k!r}. Available keys: {sorted(available)}. "
-                            f"Delete this entry and re-run to rebuild the cache."
+                            f"If you used verify_cache=False, the cached entry "
+                            f"may have been created with a different layer config. "
+                            f"Re-run with verify_cache=True or delete this entry "
+                            f"and re-extract."
                         )
                     result[k] = f.get_tensor(k)
         return result
@@ -774,7 +777,10 @@ def _load_tensors_selective(
                 f"Corrupted or incomplete cache entry {key}: "
                 f"missing key {tensor_name!r}. "
                 f"Available keys: {sorted(available)}. "
-                f"Delete this entry and re-run to rebuild the cache."
+                f"If you used verify_cache=False, the cached entry "
+                f"may have been created with a different layer config. "
+                f"Re-run with verify_cache=True or delete this entry "
+                f"and re-extract."
             )
 
         # Check mask cache for attention_mask tensors
@@ -867,13 +873,12 @@ def batch_check_cache_status(
     compute_perplexity: bool = False,
     cache_logits: bool = False,
     logit_top_k: int | None = None,
+    verify_cache: bool = True,
 ) -> tuple[list[str], list[str], list[str], int, set[int] | None]:
     """Check cache status for many prompts using batch operations.
 
-    Uses a single LIST call to discover existing keys, then reads
-    safetensors headers (not full files) when needed to check layer
-    coverage. This is O(1) LIST + O(cached) header reads instead
-    of O(N) HEAD requests.
+    Uses a single LIST call to discover existing keys, then optionally
+    reads safetensors headers (not full files) to check layer coverage.
 
     Parameters
     ----------
@@ -891,6 +896,12 @@ def batch_check_cache_status(
         Whether logits need to be cached.
     logit_top_k : int or None
         Top-k for logit caching.
+    verify_cache : bool
+        If True (default), read safetensors headers to verify layer
+        coverage — O(cached) partial GETs on S3. If False, trust the
+        LIST hit and skip header verification. Use False when you know
+        the cache was populated with the same layer config (e.g.
+        consecutive runs of the same extraction script).
 
     Returns
     -------
@@ -931,16 +942,20 @@ def batch_check_cache_status(
         act_cached = False
         cached_layers: set[int] | None = None
         if main_key in existing_keys:
-            tensor_keys = _cached_tensor_keys(main_key)
-            if pooling is not None:
-                cached_layers = _parse_pooled_layer_keys(tensor_keys, pooling)
-                act_cached = required_layers.issubset(cached_layers)
+            if verify_cache:
+                tensor_keys = _cached_tensor_keys(main_key)
+                if pooling is not None:
+                    cached_layers = _parse_pooled_layer_keys(tensor_keys, pooling)
+                    act_cached = required_layers.issubset(cached_layers)
+                else:
+                    cached_layers = _parse_raw_layer_keys(tensor_keys)
+                    act_cached = (
+                        required_layers.issubset(cached_layers)
+                        and _ATTENTION_MASK_KEY in tensor_keys
+                    )
             else:
-                cached_layers = _parse_raw_layer_keys(tensor_keys)
-                act_cached = (
-                    required_layers.issubset(cached_layers)
-                    and _ATTENTION_MASK_KEY in tensor_keys
-                )
+                # Trust the LIST hit — skip header read
+                act_cached = True
         elif isinstance(backend, LocalCacheBackend):
             # v1 fallback for local backend
             if pooling is not None:
@@ -976,8 +991,11 @@ def batch_check_cache_status(
         if compute_perplexity:
             ppl_cached = ppl_key in existing_keys
             if not ppl_cached and main_key in existing_keys:
-                tensor_keys = _cached_tensor_keys(main_key)
-                ppl_cached = _PERPLEXITY_KEY in tensor_keys
+                if verify_cache:
+                    tensor_keys = _cached_tensor_keys(main_key)
+                    ppl_cached = _PERPLEXITY_KEY in tensor_keys
+                # When not verifying, ppl sidecar key not present means
+                # we need extraction — only the sidecar LIST hit is trusted
             if not ppl_cached and isinstance(backend, LocalCacheBackend):
                 ppl_cached = is_prompt_perplexity_cached(model_name, prompt)
             if not ppl_cached:
@@ -988,15 +1006,22 @@ def batch_check_cache_status(
             logits_cached = False
             want_topk = logit_top_k is not None
             if logits_key in existing_keys:
-                tensor_keys = _cached_tensor_keys(logits_key)
-                logits_cached = _has_logits_in_keys(
-                    tensor_keys, top_k=want_topk if want_topk else False
-                )
+                if verify_cache:
+                    tensor_keys = _cached_tensor_keys(logits_key)
+                    logits_cached = _has_logits_in_keys(
+                        tensor_keys, top_k=want_topk if want_topk else False
+                    )
+                else:
+                    # Trust the LIST hit for logits sidecar
+                    logits_cached = True
             if not logits_cached and main_key in existing_keys:
-                tensor_keys = _cached_tensor_keys(main_key)
-                logits_cached = _has_logits_in_keys(
-                    tensor_keys, top_k=want_topk if want_topk else False
-                )
+                if verify_cache:
+                    tensor_keys = _cached_tensor_keys(main_key)
+                    logits_cached = _has_logits_in_keys(
+                        tensor_keys, top_k=want_topk if want_topk else False
+                    )
+                # When not verifying and logits sidecar wasn't found,
+                # we can't assume main file has logits — need extraction
             if not logits_cached:
                 need_logits.append(prompt)
 

--- a/src/lmprobe/unified_cache.py
+++ b/src/lmprobe/unified_cache.py
@@ -283,7 +283,7 @@ class UnifiedCache:
         return self._layer_indices
 
     def _check_cache_status(
-        self, prompts: list[str]
+        self, prompts: list[str], verify_cache: bool = True
     ) -> tuple[list[str], list[str], list[str]]:
         """Check which prompts need extraction.
 
@@ -291,6 +291,12 @@ class UnifiedCache:
         instead of per-prompt HEAD requests. For large prompt sets
         (e.g. 3000 prompts), this reduces S3 latency from minutes
         to seconds.
+
+        Parameters
+        ----------
+        verify_cache : bool
+            If True (default), read safetensors headers to verify layer
+            coverage. If False, trust LIST hits and skip header reads.
 
         Returns
         -------
@@ -315,6 +321,7 @@ class UnifiedCache:
             compute_perplexity=self.compute_perplexity,
             cache_logits=self.cache_logits,
             logit_top_k=self.logit_top_k,
+            verify_cache=verify_cache,
         )
 
         if partial_cache_count > 0:
@@ -337,6 +344,7 @@ class UnifiedCache:
         prompts: list[str],
         remote: bool | None = None,
         max_retries: int | None = None,
+        verify_cache: bool = True,
     ) -> WarmupStats:
         """Extract and cache activations/perplexity for prompts.
 
@@ -352,6 +360,13 @@ class UnifiedCache:
         max_retries : int | None
             Maximum number of retry attempts per batch for transient errors.
             Defaults to 3 for remote extraction, 0 for local.
+        verify_cache : bool
+            If True (default), read safetensors headers to verify that
+            cached entries have the correct layers. If False, trust the
+            cache key existence and skip header verification. Use False
+            when you know the cache was populated with the same layer
+            config (e.g. consecutive runs of the same extraction script)
+            to avoid O(cached) S3 partial GETs.
 
         Returns
         -------
@@ -370,7 +385,7 @@ class UnifiedCache:
 
         # Check cache status
         need_activations, need_perplexity, need_logits = self._check_cache_status(
-            prompts
+            prompts, verify_cache=verify_cache
         )
 
         # Compute which prompts need unified extraction

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1232,6 +1232,55 @@ class TestBatchCheckCacheStatus:
         )
         assert need_act == []
 
+    def test_verify_cache_false_trusts_list_hit(self):
+        """verify_cache=False skips header reads and trusts LIST hits."""
+        prompt = "verify test"
+        # Save only layer 0
+        acts = torch.randn(1, 5, 32)
+        mask = torch.ones(1, 5)
+        save_prompt_activations(self.model, prompt, [0], acts, mask)
+
+        # With verify=True, this is detected as partial (missing layer 1)
+        need_act, _, _, partial, _ = batch_check_cache_status(
+            self.model, [prompt], required_layers={0, 1}, verify_cache=True
+        )
+        assert need_act == [prompt]
+        assert partial == 1
+
+        # With verify=False, the LIST hit is trusted — prompt is "cached"
+        need_act, _, _, partial, _ = batch_check_cache_status(
+            self.model, [prompt], required_layers={0, 1}, verify_cache=False
+        )
+        assert need_act == []
+        assert partial == 0
+
+    def test_verify_cache_false_uncached_still_detected(self):
+        """verify_cache=False still detects prompts with no cache entry."""
+        need_act, _, _, _, _ = batch_check_cache_status(
+            self.model, ["no-cache"], required_layers={0}, verify_cache=False
+        )
+        assert need_act == ["no-cache"]
+
+    def test_verify_cache_false_logits(self):
+        """verify_cache=False trusts logits sidecar LIST hit."""
+        prompt = "logits verify"
+        # Save logits sidecar
+        logits = torch.randn(1, 5, 100)
+        mask = torch.ones(1, 5)
+        save_prompt_logits(self.model, prompt, logits, mask)
+        # Save activations so activation check passes
+        acts = torch.randn(1, 5, 32)
+        save_prompt_activations(self.model, prompt, [0], acts, mask)
+
+        _, _, need_log, _, _ = batch_check_cache_status(
+            self.model,
+            [prompt],
+            required_layers={0},
+            cache_logits=True,
+            verify_cache=False,
+        )
+        assert need_log == []
+
     def test_header_only_read(self):
         """_get_tensor_keys_header_only correctly parses safetensors header."""
         from lmprobe.cache import _get_tensor_keys_header_only, get_backend


### PR DESCRIPTION
## Summary
- Adds `verify_cache` parameter (default `True`) to `warmup()`, `_check_cache_status()`, and `batch_check_cache_status()`
- When `verify_cache=False`, trusts S3 LIST hits instead of doing per-prompt safetensors header reads — eliminates O(cached) partial GETs
- Improves error messages when loading hits a missing layer to hint about `verify_cache=False` as a possible cause

## Test plan
- [x] New tests: `test_verify_cache_false_trusts_list_hit`, `test_verify_cache_false_uncached_still_detected`, `test_verify_cache_false_logits`
- [x] All 11 `TestBatchCheckCacheStatus` tests pass (no regressions)
- [ ] CI full suite

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)