### PR TITLE
Skip layer load when all shards exist on remote

### DIFF
--- a/src/lmprobe/extract.py
+++ b/src/lmprobe/extract.py
@@ -1595,6 +1595,18 @@ def push_extraction(
 
     try:
         for layer in tqdm(hidden_layers, desc="Layers", unit="layer"):
+            # Skip entire layer if all its shards already exist on remote
+            layer_shard_names = [
+                _hidden_shard_filename(layer, si)
+                for si in range(len(hidden_boundaries))
+            ]
+            if all(s in skip_shards for s in layer_shard_names):
+                logger.info(
+                    "[PUSH_EXTRACTION] Layer %d: all shards exist, skipping",
+                    layer,
+                )
+                continue
+
             # Stage batch files locally for remote sources
             if batch_staging_dir is not None:
                 effective_source = _download_layer_batches_to_staging(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -777,6 +777,40 @@ class TestPushExtractionStreaming:
             f"Shard {existing_shard} was uploaded despite being on remote"
         )
 
+    def test_skip_layer_load_when_all_shards_exist(
+        self, tiny_model, tmp_path, monkeypatch
+    ):
+        """Layer data is not loaded when all its shards already exist on remote."""
+        prefix = self._make_extraction(tiny_model, tmp_path, monkeypatch)
+
+        from unittest.mock import MagicMock, patch
+
+        mock_api = MagicMock()
+        # _check_shards_on_remote returns ALL expected files → every layer skipped
+        mock_api.repo_info.side_effect = Exception("should not be called directly")
+
+        from lmprobe.extract import push_extraction
+
+        with self._hub_patches():
+            with patch("huggingface_hub.HfApi", return_value=mock_api):
+                with patch("huggingface_hub.CommitOperationAdd", side_effect=lambda **kw: kw):
+                    with patch(
+                        "lmprobe.sharing._check_shards_on_remote",
+                        side_effect=lambda api, repo_id, expected: set(expected),
+                    ):
+                        with patch(
+                            "lmprobe.extract._build_shard_for_layer"
+                        ) as mock_build:
+                            push_extraction(
+                                source=prefix,
+                                repo_id="test-user/test-dataset",
+                                stream=True,
+                                staging_dir=str(tmp_path / "staging"),
+                            )
+
+        # _build_shard_for_layer should never be called — all layers skipped
+        mock_build.assert_not_called()
+
     def test_nonstream_unchanged(
         self, tiny_model, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary
- Before loading layer data from S3, check if all shards for that layer are already in `skip_shards`
- If so, `continue` past the layer entirely — no staging, no shard building, no cleanup
- For a 405B resume at layer 59/126: saves **~17 hours** of wasted S3 reads

## Changes
- `src/lmprobe/extract.py`: Added early `continue` check before `_download_layer_batches_to_staging` in the per-layer loop
- `tests/test_extract.py`: Added `test_skip_layer_load_when_all_shards_exist` verifying `_build_shard_for_layer` is never called when all shards exist

Closes #257

## Test plan
- [x] Existing push_extraction streaming tests pass (5/5)
- [x] New test confirms layer load is skipped when all shards exist on remote
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)