### PR TITLE
Pipeline layer staging with shard assembly in push_extraction()

### DIFF
--- a/src/lmprobe/extract.py
+++ b/src/lmprobe/extract.py
@@ -1594,26 +1594,62 @@ def push_extraction(
     )
 
     try:
-        for layer in tqdm(hidden_layers, desc="Layers", unit="layer"):
-            # Skip entire layer if all its shards already exist on remote
-            layer_shard_names = [
-                _hidden_shard_filename(layer, si)
+        from concurrent.futures import ThreadPoolExecutor
+
+        # Pipeline: download next layer's batches while building shards
+        # for the current layer.  Only matters for remote sources.
+        download_executor = (
+            ThreadPoolExecutor(max_workers=1)
+            if batch_staging_dir is not None
+            else None
+        )
+        next_layer_future = None
+
+        def _needs_work(layer: int) -> bool:
+            """Return True if at least one shard is missing for *layer*."""
+            return not all(
+                _hidden_shard_filename(layer, si) in skip_shards
                 for si in range(len(hidden_boundaries))
-            ]
-            if all(s in skip_shards for s in layer_shard_names):
+            )
+
+        for layer_idx, layer in enumerate(
+            tqdm(hidden_layers, desc="Layers", unit="layer")
+        ):
+            # Skip entire layer if all its shards already exist on remote
+            if not _needs_work(layer):
                 logger.info(
                     "[PUSH_EXTRACTION] Layer %d: all shards exist, skipping",
                     layer,
                 )
                 continue
 
-            # Stage batch files locally for remote sources
+            # Obtain staged batches — either from the prefetched future
+            # or by downloading synchronously (first layer / local source).
             if batch_staging_dir is not None:
-                effective_source = _download_layer_batches_to_staging(
-                    manifest, source_prefix, layer, batch_staging_dir,
-                )
+                if next_layer_future is not None:
+                    effective_source = next_layer_future.result()
+                    next_layer_future = None
+                else:
+                    effective_source = _download_layer_batches_to_staging(
+                        manifest, source_prefix, layer, batch_staging_dir,
+                    )
             else:
                 effective_source = source_prefix
+
+            # Kick off download for the next layer that needs work while
+            # we build shards for the current layer.
+            if download_executor is not None:
+                for future_idx in range(layer_idx + 1, len(hidden_layers)):
+                    future_layer = hidden_layers[future_idx]
+                    if _needs_work(future_layer):
+                        next_layer_future = download_executor.submit(
+                            _download_layer_batches_to_staging,
+                            manifest,
+                            source_prefix,
+                            future_layer,
+                            batch_staging_dir,
+                        )
+                        break
 
             key = f"hidden.layer_{layer}"
 
@@ -1641,6 +1677,12 @@ def push_extraction(
                 _cleanup_staged_layer(batch_staging_dir, layer)
 
             gc.collect()
+
+        # Shut down the prefetch executor (cancel any outstanding future)
+        if download_executor is not None:
+            if next_layer_future is not None:
+                next_layer_future.cancel()
+            download_executor.shutdown(wait=False)
     finally:
         # Clean up staging directory
         if batch_staging_dir is not None:

--- a/src/lmprobe/extract.py
+++ b/src/lmprobe/extract.py
@@ -1638,7 +1638,7 @@ def push_extraction(
 
             # Kick off download for the next layer that needs work while
             # we build shards for the current layer.
-            if download_executor is not None:
+            if download_executor is not None and batch_staging_dir is not None:
                 for future_idx in range(layer_idx + 1, len(hidden_layers)):
                     future_layer = hidden_layers[future_idx]
                     if _needs_work(future_layer):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -853,9 +853,9 @@ class TestPushExtractionStreaming:
             backend="local",
         )
 
+        import threading
         from pathlib import Path
         from unittest.mock import MagicMock, patch
-        import threading
 
         from lmprobe.extract import push_extraction
 
@@ -904,7 +904,7 @@ class TestPushExtractionStreaming:
                             )
 
         # Both layers should have been downloaded
-        downloaded_layers = [l for l, _ in download_calls]
+        downloaded_layers = [layer for layer, _ in download_calls]
         assert 0 in downloaded_layers, "Layer 0 should be downloaded"
         assert 1 in downloaded_layers, "Layer 1 should be downloaded"
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -833,3 +833,86 @@ class TestPushExtractionStreaming:
 
         mock_api.upload_large_folder.assert_called_once()
         mock_api.create_commit.assert_not_called()
+
+    def test_pipelined_staging_prefetches_next_layer(
+        self, tiny_model, tmp_path, monkeypatch
+    ):
+        """When staging is needed, download for the next layer starts before
+        shard building finishes for the current layer."""
+        # Extract with 2 layers so there's a "next layer" to prefetch
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path / "cache"))
+        prompts = POSITIVE_PROMPTS[:4]
+        prefix = extract(
+            model_name=tiny_model,
+            prompts=prompts,
+            layers=[0, 1],
+            output_dir=str(tmp_path / "extracted"),
+            batch_size=2,
+            remote=False,
+            device="cpu",
+            backend="local",
+        )
+
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+        import threading
+
+        from lmprobe.extract import push_extraction
+
+        mock_api = MagicMock()
+        mock_api.create_commit = MagicMock()
+
+        # Track call order and which thread calls _download_layer_batches_to_staging
+        download_calls = []
+        real_download = None
+
+        # Import the real function to wrap it
+        from lmprobe import extract as extract_mod
+
+        real_download = extract_mod._download_layer_batches_to_staging
+
+        def tracked_download(*args, **kwargs):
+            layer = args[2]  # 3rd positional arg is layer
+            download_calls.append(
+                (layer, threading.current_thread().name)
+            )
+            return real_download(*args, **kwargs)
+
+        with self._hub_patches():
+            with patch("huggingface_hub.HfApi", return_value=mock_api):
+                with patch("huggingface_hub.CommitOperationAdd", side_effect=lambda **kw: kw):
+                    # Force non-local source detection by patching Path.is_dir
+                    # to return False for the source_prefix
+                    orig_is_dir = Path.is_dir
+
+                    def fake_is_dir(self):
+                        if str(self) == prefix:
+                            return False
+                        return orig_is_dir(self)
+
+                    with patch.object(Path, "is_dir", fake_is_dir):
+                        with patch.object(
+                            extract_mod,
+                            "_download_layer_batches_to_staging",
+                            side_effect=tracked_download,
+                        ):
+                            push_extraction(
+                                source=prefix,
+                                repo_id="test-user/test-dataset",
+                                stream=True,
+                                staging_dir=str(tmp_path / "staging"),
+                            )
+
+        # Both layers should have been downloaded
+        downloaded_layers = [l for l, _ in download_calls]
+        assert 0 in downloaded_layers, "Layer 0 should be downloaded"
+        assert 1 in downloaded_layers, "Layer 1 should be downloaded"
+
+        # The second download (layer 1) should have been submitted to
+        # the background thread pool, i.e. on a different thread than
+        # the first download (layer 0).
+        threads = [t for _, t in download_calls]
+        assert threads[0] != threads[1], (
+            "Prefetched layer should run on a different thread "
+            f"(got {threads})"
+        )


### PR DESCRIPTION
## Summary
- Overlaps downloading batches for layer N+1 with shard assembly for layer N using a single-thread `ThreadPoolExecutor`
- Hides download latency behind shard-building time for remote/S3 sources
- Disk budget doubles to ~2 layers staged at once (~28 GB for 405B), well within EBS capacity
- Skipped layers are handled correctly — prefetch jumps to the next layer that needs work

Closes #256

## Test plan
- [x] All 21 existing extract tests pass
- [x] New test `test_pipelined_staging_prefetches_next_layer` verifies the second layer download runs on a background thread
- [ ] CI passes full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)