### PR TITLE
MoE router logits as first-class activation type

### DIFF
--- a/src/lmprobe/__init__.py
+++ b/src/lmprobe/__init__.py
@@ -20,6 +20,13 @@ Example
 from typing import Any
 
 from .activation_baseline import ActivationBaseline
+from .activation_types import (
+    ActivationType,
+    ExtractedBatch,
+    ExtractionSpec,
+    MoEInfo,
+    detect_moe_info,
+)
 from .baseline import BaselineProbe
 from .battery import BaselineBattery, BaselineResult, BaselineResults
 from .ensemble import ProbeEnsemble
@@ -33,6 +40,7 @@ except Exception:
     __version__ = "unknown"
 __all__ = [
     "ActivationBaseline",
+    "ActivationType",
     "ActivationStore",
     "BaselineBattery",
     "BaselineProbe",
@@ -42,9 +50,13 @@ __all__ = [
     "CachedLogits",
     "CachedPromptInfo",
     "DatasetMetadata",
+    "detect_moe_info",
+    "ExtractedBatch",
+    "ExtractionSpec",
     "LayerSweepResult",
     "LinearProbe",
     "ManifestEntry",
+    "MoEInfo",
     "Probe",
     "ProbeEnsemble",
     "load_layer_across_prompts",

--- a/src/lmprobe/activation_types.py
+++ b/src/lmprobe/activation_types.py
@@ -1,0 +1,309 @@
+"""Activation type definitions and MoE architecture detection.
+
+This module defines the structured types used to specify what activations
+to extract from a model and how to return them. It also provides
+config-only detection of MoE (Mixture of Experts) architectures.
+
+The key abstractions are:
+
+- ``ExtractionSpec``: What to extract in a single forward pass.
+- ``ExtractedBatch``: Structured result containing all requested activations.
+- ``MoEInfo``: Metadata about a model's MoE architecture (router paths, expert count).
+- ``detect_moe_info()``: Detect MoE architecture from HuggingFace config without loading weights.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    pass
+
+
+class ActivationType(str, Enum):
+    """Known activation types.
+
+    Used as identifiers in cache keys, tensor descriptors, and extraction specs.
+    """
+
+    HIDDEN = "hidden"
+    LOGITS = "logits"
+    ROUTER_LOGITS = "router"
+    # Future: ATTENTION = "attention", MLP = "mlp", etc.
+
+
+@dataclass
+class ExtractionSpec:
+    """Specification of what to extract in a single forward pass.
+
+    This replaces the pattern of having separate methods for each activation
+    combination (extract_batch, extract_batch_with_logits, etc.).
+
+    Parameters
+    ----------
+    hidden_layers : list[int]
+        Layer indices for hidden state extraction.
+    include_logits : bool
+        Whether to capture lm_head logits.
+    logit_top_k : int or None
+        If set with include_logits, perform top-k on logits (remote only).
+    router_layers : list[int] or None
+        Layer indices for MoE router logit extraction. None means skip.
+    router_module_template : str or None
+        Format string for the router module path, e.g.
+        ``"model.model.layers.{layer}.block_sparse_moe.gate"``.
+        Required when router_layers is not None. Obtained from
+        :func:`detect_moe_info`.
+    """
+
+    hidden_layers: list[int] = field(default_factory=list)
+    include_logits: bool = False
+    logit_top_k: int | None = None
+    router_layers: list[int] | None = None
+    router_module_template: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.router_layers and not self.router_module_template:
+            raise ValueError(
+                "router_module_template is required when router_layers is specified. "
+                "Use detect_moe_info() to obtain the template for your model."
+            )
+
+
+@dataclass
+class ExtractedBatch:
+    """Structured result from a single batch extraction.
+
+    Parameters
+    ----------
+    activations : torch.Tensor or None
+        Hidden state activations, shape ``(batch, seq_len, hidden_dim * num_layers)``.
+        None when no hidden layers were requested.
+    attention_mask : torch.Tensor
+        Attention mask, shape ``(batch, seq_len)``.
+    logits : torch.Tensor or None
+        LM head logits. Full: ``(batch, seq_len, vocab_size)``.
+        Top-k: ``(batch, seq_len, K)``.
+    logits_indices : torch.Tensor or None
+        Top-k indices when logit_top_k was set, else None.
+    router_logits : dict[int, torch.Tensor] or None
+        Router gate outputs keyed by layer index.
+        Each tensor has shape ``(batch, seq_len, num_experts)``.
+        Dict (not concatenated) because num_experts != hidden_dim.
+    """
+
+    activations: torch.Tensor | None
+    attention_mask: torch.Tensor
+    logits: torch.Tensor | None = None
+    logits_indices: torch.Tensor | None = None
+    router_logits: dict[int, torch.Tensor] | None = None
+
+
+@dataclass(frozen=True)
+class MoEInfo:
+    """MoE architecture metadata extracted from model config.
+
+    Parameters
+    ----------
+    num_experts : int
+        Number of experts in the MoE layers.
+    router_module_template : str
+        Python attribute path template for the router gate module.
+        Use ``template.format(layer=i)`` to get the path for layer ``i``.
+        Examples:
+        - Mixtral: ``"model.model.layers.{layer}.block_sparse_moe.gate"``
+        - Qwen2-MoE: ``"model.model.layers.{layer}.mlp.gate"``
+    moe_layer_indices : list[int] or None
+        If not all layers are MoE (e.g., DeepSeek-V2 interleaves dense and
+        MoE layers), this lists which layer indices have routers.
+        None means all layers have routers.
+    """
+
+    num_experts: int
+    router_module_template: str
+    moe_layer_indices: list[int] | None = None
+
+
+def detect_moe_info(model_name: str) -> MoEInfo | None:
+    """Detect MoE architecture from a HuggingFace model config.
+
+    Loads only the config (no weights) to determine whether the model
+    uses Mixture of Experts and, if so, extracts the router module path
+    template and expert count.
+
+    Parameters
+    ----------
+    model_name : str
+        HuggingFace model ID or local path.
+
+    Returns
+    -------
+    MoEInfo or None
+        MoE metadata if the model is an MoE architecture, None for dense models.
+    """
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(model_name)
+    model_type = getattr(config, "model_type", "")
+
+    # Mixtral
+    if model_type == "mixtral":
+        num_experts = getattr(config, "num_local_experts", None)
+        if num_experts is not None:
+            return MoEInfo(
+                num_experts=num_experts,
+                router_module_template=(
+                    "model.model.layers.{layer}.block_sparse_moe.gate"
+                ),
+            )
+
+    # Qwen2-MoE
+    if model_type == "qwen2_moe":
+        num_experts = getattr(config, "num_experts", None)
+        if num_experts is not None:
+            return MoEInfo(
+                num_experts=num_experts,
+                router_module_template="model.model.layers.{layer}.mlp.gate",
+            )
+
+    # DeepSeek-V2 / DeepSeek-V3
+    if model_type in ("deepseek_v2", "deepseek_v3"):
+        num_experts = getattr(config, "n_routed_experts", None)
+        if num_experts is not None:
+            # DeepSeek interleaves dense and MoE layers.
+            # MoE layers start at first_k_dense_replace and repeat every
+            # moe_layer_freq layers.
+            first_moe = getattr(config, "first_k_dense_replace", 1)
+            moe_freq = getattr(config, "moe_layer_freq", 1)
+            num_layers = getattr(config, "num_hidden_layers", 0)
+            moe_indices = [
+                i for i in range(num_layers)
+                if i >= first_moe and (i - first_moe) % moe_freq == 0
+            ]
+            return MoEInfo(
+                num_experts=num_experts,
+                router_module_template="model.model.layers.{layer}.mlp.gate",
+                moe_layer_indices=moe_indices if moe_indices else None,
+            )
+
+    # DBRX
+    if model_type == "dbrx":
+        ffn_config = getattr(config, "ffn_config", None)
+        if ffn_config is not None:
+            num_experts = getattr(ffn_config, "moe_num_experts", None)
+            if num_experts is not None:
+                return MoEInfo(
+                    num_experts=num_experts,
+                    router_module_template=(
+                        "model.transformer.blocks.{layer}.ffn.router.layer"
+                    ),
+                )
+
+    # Arctic (Snowflake)
+    if model_type == "arctic":
+        num_experts = getattr(config, "num_local_experts", None)
+        if num_experts is not None:
+            return MoEInfo(
+                num_experts=num_experts,
+                router_module_template=(
+                    "model.model.layers.{layer}.block_sparse_moe.gate"
+                ),
+            )
+
+    # OLMoE
+    if model_type == "olmoe":
+        num_experts = getattr(config, "num_experts", None)
+        if num_experts is not None:
+            return MoEInfo(
+                num_experts=num_experts,
+                router_module_template="model.model.layers.{layer}.mlp.gate",
+            )
+
+    return None
+
+
+def get_router_module(model: object, template: str, layer: int) -> object:
+    """Resolve a router module from a model using a dot-path template.
+
+    Parameters
+    ----------
+    model : object
+        The loaded model (HuggingFace or nnsight LanguageModel).
+    template : str
+        Dot-path template, e.g.
+        ``"model.model.layers.{layer}.block_sparse_moe.gate"``.
+    layer : int
+        Layer index to substitute into the template.
+
+    Returns
+    -------
+    object
+        The router module.
+
+    Raises
+    ------
+    AttributeError
+        If the module path does not exist on the model.
+    """
+    path = template.format(layer=layer)
+    # Strip leading "model." since we start from the model object itself
+    # (the template includes "model." as the top-level attribute for nnsight
+    # LanguageModel which wraps the HF model as .model)
+    parts = path.split(".")
+    obj = model
+    for part in parts:
+        if part.isdigit():
+            obj = obj[int(part)]  # type: ignore[index]
+        else:
+            obj = getattr(obj, part)
+    return obj
+
+
+def validate_router_layers(
+    moe_info: MoEInfo,
+    requested_layers: list[int],
+) -> list[int]:
+    """Validate that requested layers actually have MoE routers.
+
+    Parameters
+    ----------
+    moe_info : MoEInfo
+        MoE architecture info from :func:`detect_moe_info`.
+    requested_layers : list[int]
+        Layer indices the user wants router logits from.
+
+    Returns
+    -------
+    list[int]
+        Validated layer indices (subset of requested_layers that have routers).
+
+    Raises
+    ------
+    ValueError
+        If none of the requested layers have routers.
+    """
+    if moe_info.moe_layer_indices is None:
+        # All layers have routers
+        return requested_layers
+
+    valid = [i for i in requested_layers if i in moe_info.moe_layer_indices]
+    if not valid:
+        raise ValueError(
+            f"None of the requested layers {requested_layers} have MoE routers. "
+            f"MoE layers for this model: {moe_info.moe_layer_indices}"
+        )
+    skipped = set(requested_layers) - set(valid)
+    if skipped:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Layers %s do not have MoE routers and will be skipped. "
+            "MoE layers: %s",
+            sorted(skipped),
+            moe_info.moe_layer_indices,
+        )
+    return valid

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -17,6 +17,8 @@ import torch
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizerBase
 
+    from .activation_types import ExtractedBatch, ExtractionSpec
+
 
 class ExtractionBackend(ABC):
     """Abstract base class for activation extraction backends.
@@ -109,6 +111,43 @@ class ExtractionBackend(ABC):
         - LocalBackend: transformers.PreTrainedModel
         """
 
+    def extract_batch_extended(
+        self,
+        prompts: list[str],
+        spec: ExtractionSpec,
+        **kwargs: Any,
+    ) -> ExtractedBatch:
+        """Extract multiple activation types in a single forward pass.
+
+        This is the extensible extraction method. New activation types
+        (router logits, attention patterns, etc.) are added by extending
+        :class:`~lmprobe.activation_types.ExtractionSpec` and
+        :class:`~lmprobe.activation_types.ExtractedBatch`.
+
+        Parameters
+        ----------
+        prompts : list[str]
+            List of text prompts.
+        spec : ExtractionSpec
+            Specification of what to extract.
+        **kwargs
+            Backend-specific parameters.
+
+        Returns
+        -------
+        ExtractedBatch
+            Structured result containing all requested activations.
+
+        Raises
+        ------
+        NotImplementedError
+            If the backend does not support extended extraction.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support extract_batch_extended. "
+            f"Use extract_batch() or extract_batch_with_logits() instead."
+        )
+
 
 class NnsightBackend(ExtractionBackend):
     """Backend using nnsight for activation extraction.
@@ -200,6 +239,18 @@ class NnsightBackend(ExtractionBackend):
             logit_top_k=logit_top_k,
         )
 
+    def extract_batch_extended(
+        self,
+        prompts: list[str],
+        spec: ExtractionSpec,
+        **kwargs: Any,
+    ) -> ExtractedBatch:
+        from .extraction import _extract_batch_extended
+
+        remote = kwargs.get("remote", self.remote)
+        model = self._get_model_for_remote() if remote else self.model
+        return _extract_batch_extended(model, prompts, spec, remote=remote)
+
 
 # Global cache for locally-loaded HuggingFace models
 # Key: (model_name, device, dtype), Value: (model, tokenizer)
@@ -256,6 +307,58 @@ def _get_decoder_layers(model: Any) -> list[Any]:
         f"Llama, Mistral, Phi, GPT-2, GPT-NeoX, Falcon, MPT, OPT, "
         f"and other models using standard layer attribute paths."
     )
+
+
+def _get_router_modules(
+    model: Any,
+    layer_indices: list[int],
+    router_module_template: str,
+) -> dict[int, Any]:
+    """Get MoE router gate modules for specified layers.
+
+    Uses the ``router_module_template`` from :class:`MoEInfo` to resolve
+    the router gate submodule for each layer. The template is a dot-path
+    like ``"model.model.layers.{layer}.block_sparse_moe.gate"`` where the
+    leading ``"model."`` prefix corresponds to the top-level HF model
+    object itself.
+
+    Parameters
+    ----------
+    model : PreTrainedModel
+        A HuggingFace transformers model.
+    layer_indices : list[int]
+        Layer indices to get router modules for.
+    router_module_template : str
+        Dot-path template with ``{layer}`` placeholder.
+
+    Returns
+    -------
+    dict[int, Any]
+        Mapping from layer index to router gate module.
+        Layers without a router module (e.g., dense layers in a mixed
+        architecture) are silently skipped.
+    """
+    result: dict[int, Any] = {}
+    for layer_idx in layer_indices:
+        path = router_module_template.format(layer=layer_idx)
+        # Strip leading "model." — the template is written for nnsight's
+        # LanguageModel where the HF model is at .model, but here we
+        # already have the HF model directly.
+        if path.startswith("model."):
+            path = path[len("model."):]
+        parts = path.split(".")
+        try:
+            obj: Any = model
+            for part in parts:
+                if part.isdigit():
+                    obj = obj[int(part)]
+                else:
+                    obj = getattr(obj, part)
+            result[layer_idx] = obj
+        except (AttributeError, IndexError, TypeError):
+            # Layer doesn't have this router module (e.g., dense layer)
+            pass
+    return result
 
 
 def _get_local_model(
@@ -475,6 +578,102 @@ class LocalBackend(ExtractionBackend):
         logits = outputs.logits.detach().cpu()
 
         return combined, tokenized["attention_mask"], logits, None
+
+    def extract_batch_extended(
+        self,
+        prompts: list[str],
+        spec: ExtractionSpec,
+        **kwargs: Any,
+    ) -> ExtractedBatch:
+        from .activation_types import ExtractedBatch
+
+        model = self.model
+        tokenizer = self.tokenizer
+
+        tokenized = tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+        )
+
+        device = next(model.parameters()).device
+        input_ids = tokenized["input_ids"].to(device)
+        attention_mask = tokenized["attention_mask"].to(device)
+
+        # --- Set up hooks ---
+        captured_hidden: dict[int, torch.Tensor] = {}
+        captured_router: dict[int, torch.Tensor] = {}
+        hooks: list[Any] = []
+
+        # Hidden state hooks
+        if spec.hidden_layers:
+            decoder_layers = _get_decoder_layers(model)
+            for layer_idx in spec.hidden_layers:
+                layer_module = decoder_layers[layer_idx]
+
+                def make_hidden_hook(idx: int) -> Any:
+                    def hook_fn(_module: Any, _input: Any, output: Any) -> None:
+                        if isinstance(output, tuple):
+                            captured_hidden[idx] = output[0].detach()
+                        else:
+                            captured_hidden[idx] = output.detach()
+                    return hook_fn
+
+                hooks.append(
+                    layer_module.register_forward_hook(make_hidden_hook(layer_idx))
+                )
+
+        # Router logit hooks
+        if spec.router_layers and spec.router_module_template:
+            router_modules = _get_router_modules(
+                model, spec.router_layers, spec.router_module_template
+            )
+            for layer_idx, router_module in router_modules.items():
+                def make_router_hook(idx: int) -> Any:
+                    def hook_fn(_module: Any, _input: Any, output: Any) -> None:
+                        if isinstance(output, tuple):
+                            captured_router[idx] = output[0].detach()
+                        else:
+                            captured_router[idx] = output.detach()
+                    return hook_fn
+
+                hooks.append(
+                    router_module.register_forward_hook(make_router_hook(layer_idx))
+                )
+
+        # --- Forward pass ---
+        try:
+            with torch.no_grad():
+                outputs = model(input_ids=input_ids, attention_mask=attention_mask)
+        finally:
+            for h in hooks:
+                h.remove()
+
+        # --- Collect results ---
+        activations: torch.Tensor | None = None
+        if spec.hidden_layers and captured_hidden:
+            activation_tensors = [
+                captured_hidden[idx].cpu() for idx in spec.hidden_layers
+            ]
+            activations = torch.cat(activation_tensors, dim=-1)
+
+        logits: torch.Tensor | None = None
+        if spec.include_logits:
+            logits = outputs.logits.detach().cpu()
+
+        router_logits: dict[int, torch.Tensor] | None = None
+        if captured_router:
+            router_logits = {
+                idx: t.cpu() for idx, t in captured_router.items()
+            }
+
+        return ExtractedBatch(
+            activations=activations,
+            attention_mask=tokenized["attention_mask"],
+            logits=logits,
+            logits_indices=None,
+            router_logits=router_logits,
+        )
 
 
 def resolve_backend(

--- a/src/lmprobe/cache.py
+++ b/src/lmprobe/cache.py
@@ -309,6 +309,12 @@ _TOKEN_IDS_KEY = "token_ids"
 _LOGITS_KEY = "logits"
 _LOGITS_TOP_K_VALUES_KEY = "logits_top_k_values"
 _LOGITS_TOP_K_INDICES_KEY = "logits_top_k_indices"
+_ROUTER_LAYER_KEY_PREFIX = "router_layer_"
+
+
+def _router_layer_key(layer: int) -> str:
+    """Cache key for MoE router logits at a given layer."""
+    return f"router_layer_{layer}"
 
 
 def _parse_raw_layer_keys(keys: set[str] | list[str]) -> set[int]:
@@ -318,6 +324,18 @@ def _parse_raw_layer_keys(keys: set[str] | list[str]) -> set[int]:
         if k.startswith("layer_"):
             try:
                 result.add(int(k[6:]))
+            except ValueError:
+                continue
+    return result
+
+
+def _parse_router_layer_keys(keys: set[str] | list[str]) -> set[int]:
+    """Extract router layer indices from safetensors keys."""
+    result = set()
+    for k in keys:
+        if k.startswith(_ROUTER_LAYER_KEY_PREFIX):
+            try:
+                result.add(int(k[len(_ROUTER_LAYER_KEY_PREFIX):]))
             except ValueError:
                 continue
     return result
@@ -375,6 +393,7 @@ class CachedPromptInfo:
     has_perplexity: bool
     has_token_perplexity: bool
     num_tokens: int | None
+    router_layers: list[int] = field(default_factory=list)
 
 
 def _has_logits_in_keys(
@@ -553,6 +572,9 @@ def discover_cached(model_name: str, prompt: str) -> CachedPromptInfo | None:
         except Exception:
             pass
 
+    # Parse router layer keys
+    router_layers = sorted(_parse_router_layer_keys(tensor_keys))
+
     return CachedPromptInfo(
         raw_layers=raw_layers,
         pooled=pooled,
@@ -561,6 +583,7 @@ def discover_cached(model_name: str, prompt: str) -> CachedPromptInfo | None:
         has_perplexity=has_perplexity,
         has_token_perplexity=has_token_perplexity,
         num_tokens=num_tokens,
+        router_layers=router_layers,
     )
 
 
@@ -2179,6 +2202,75 @@ def save_prompt_activations(
         old_dir = get_prompt_cache_dir(model_name, prompt)
         if old_dir.is_dir():
             shutil.rmtree(old_dir)
+
+
+def save_prompt_router_logits(
+    model_name: str,
+    prompt: str,
+    router_logits: dict[int, torch.Tensor],
+) -> None:
+    """Save MoE router logits for a prompt.
+
+    Router logits are stored in the same per-prompt safetensors file
+    alongside hidden states, using ``router_layer_{i}`` keys.
+
+    Parameters
+    ----------
+    model_name : str
+        HuggingFace model ID.
+    prompt : str
+        The prompt text.
+    router_logits : dict[int, torch.Tensor]
+        Mapping from layer index to router logits tensor.
+        Each tensor has shape ``(seq_len, num_experts)``.
+    """
+    key = _prompt_cache_key(model_name, prompt)
+    new_tensors: dict[str, torch.Tensor] = {}
+    for layer_idx, tensor in router_logits.items():
+        new_tensors[_router_layer_key(layer_idx)] = _prepare_tensor(tensor)
+    _merge_save_backend(key, new_tensors)
+
+
+def load_prompt_router_logits(
+    model_name: str,
+    prompt: str,
+    layers: list[int],
+) -> dict[int, torch.Tensor]:
+    """Load MoE router logits from cache.
+
+    Parameters
+    ----------
+    model_name : str
+        HuggingFace model ID.
+    prompt : str
+        The prompt text.
+    layers : list[int]
+        Layer indices to load router logits for.
+
+    Returns
+    -------
+    dict[int, torch.Tensor]
+        Mapping from layer index to router logits tensor.
+
+    Raises
+    ------
+    KeyError
+        If router logits for a requested layer are not cached.
+    """
+    key = _prompt_cache_key(model_name, prompt)
+    keys_to_load = [_router_layer_key(layer) for layer in layers]
+    tensors = _load_tensors_from_backend(key, keys_to_load)
+    result: dict[int, torch.Tensor] = {}
+    for layer in layers:
+        rkey = _router_layer_key(layer)
+        if rkey in tensors:
+            result[layer] = tensors[rkey]
+        else:
+            raise KeyError(
+                f"Router logits for layer {layer} not found in cache "
+                f"for model={model_name!r}, prompt={prompt[:50]!r}..."
+            )
+    return result
 
 
 def is_prompt_perplexity_cached(model_name: str, prompt: str) -> bool:

--- a/src/lmprobe/extract.py
+++ b/src/lmprobe/extract.py
@@ -77,6 +77,8 @@ class ExtractionManifest:
     created_at: str = ""
     dtype: str = "float32"
     completed_layers: list[int] | None = None
+    router_layers: list[int] | None = None
+    router_dim: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -106,6 +108,10 @@ class ExtractionManifest:
             d["metadata"] = self.metadata
         if self.completed_layers is not None:
             d["completed_layers"] = self.completed_layers
+        if self.router_layers is not None:
+            d["router_layers"] = self.router_layers
+        if self.router_dim is not None:
+            d["router_dim"] = self.router_dim
         return d
 
     @classmethod
@@ -134,6 +140,8 @@ class ExtractionManifest:
             created_at=d.get("created_at", ""),
             dtype=d.get("dtype", "float32"),
             completed_layers=d.get("completed_layers"),
+            router_layers=d.get("router_layers"),
+            router_dim=d.get("router_dim"),
         )
 
 
@@ -241,6 +249,7 @@ def _save_batch(
     *,
     local_root: Path | None = None,
     num_workers: int = 1,
+    batch_router_logits: dict[int, torch.Tensor] | None = None,
 ) -> None:
     """Save a batch as one safetensors file per layer.
 
@@ -307,6 +316,22 @@ def _save_batch(
         else:
             logits_key = f"{prefix}/logits/{_batch_filename(batch_idx)}"
             _save_tensors_to_backend(logits_key, logits_tensors)
+
+    # Save router logits per-layer (same pattern as hidden states)
+    if batch_router_logits:
+        for router_layer_idx, router_tensor in batch_router_logits.items():
+            router_rel = f"router_layer_{router_layer_idx}/{_batch_filename(batch_idx)}"
+            router_tensors: dict[str, torch.Tensor] = {
+                "router_logits": router_tensor,
+                "mask": batch_mask,
+            }
+            if local_root is not None:
+                out = local_root / router_rel
+                out.parent.mkdir(parents=True, exist_ok=True)
+                save_file(router_tensors, str(out))
+            else:
+                router_key = f"{prefix}/{router_rel}"
+                _save_tensors_to_backend(router_key, router_tensors)
 
 
 def load_batch_layer(
@@ -418,6 +443,7 @@ def extract(
     cache_logits: bool = False,
     logit_top_k: int | None = None,
     max_retries: int = 3,
+    extract_router: bool = False,
 ) -> str:
     """Extract activations and save raw batch responses to disk.
 
@@ -495,6 +521,26 @@ def extract(
             f"[EXTRACT] Resuming: {len(completed_batches)} batches already complete"
         )
 
+    # Detect MoE architecture if router extraction requested
+    moe_info = None
+    router_layer_indices: list[int] | None = None
+    if extract_router:
+        from .activation_types import detect_moe_info, validate_router_layers
+
+        moe_info = detect_moe_info(model_name)
+        if moe_info is None:
+            raise ValueError(
+                f"extract_router=True but model {model_name!r} is not a "
+                f"recognized MoE architecture. Only MoE models have router "
+                f"logits to extract."
+            )
+        # Default: extract routers for the same layers as hidden states
+        router_layer_indices = validate_router_layers(moe_info, layer_indices)
+        logger.info(
+            f"[EXTRACT] MoE detected: {moe_info.num_experts} experts, "
+            f"router layers: {router_layer_indices}"
+        )
+
     # Build manifest
     manifest = ExtractionManifest(
         model_name=model_name,
@@ -506,6 +552,8 @@ def extract(
         labels=list(labels) if labels is not None else None,
         metadata=list(metadata) if metadata is not None else None,
         created_at=datetime.now(timezone.utc).isoformat(),
+        router_layers=router_layer_indices,
+        router_dim=moe_info.num_experts if moe_info is not None else None,
     )
 
     # Configure remote
@@ -566,27 +614,62 @@ def extract(
                 continue
 
             # Extract
+            batch_router_logits: dict[int, torch.Tensor] | None = None
             try:
-                if retry_fn is not None:
-                    batch_acts, batch_mask, batch_logits, batch_logits_indices = (
-                        retry_fn(
-                            lambda bp=batch_prompts: extraction_backend.extract_batch_with_logits(  # type: ignore[misc]
-                                bp, layer_indices,
-                                remote=remote,
-                                logit_top_k=effective_top_k,
+                if extract_router and moe_info is not None and router_layer_indices:
+                    # Use extended extraction for router + hidden + logits
+                    from .activation_types import ExtractionSpec
+
+                    spec = ExtractionSpec(
+                        hidden_layers=layer_indices,
+                        include_logits=compute_perplexity or cache_logits,
+                        logit_top_k=effective_top_k,
+                        router_layers=router_layer_indices,
+                        router_module_template=moe_info.router_module_template,
+                    )
+                    if retry_fn is not None:
+                        result = retry_fn(
+                            lambda bp=batch_prompts, s=spec: (  # type: ignore[misc]
+                                extraction_backend.extract_batch_extended(
+                                    bp, s, remote=remote,
+                                )
                             ),
                             max_retries=effective_retries,
                             context=f"batch {batch_idx + 1}/{num_batches}",
                         )
-                    )
-                else:
-                    batch_acts, batch_mask, batch_logits, batch_logits_indices = (
-                        extraction_backend.extract_batch_with_logits(
-                            batch_prompts, layer_indices,
-                            remote=remote,
-                            logit_top_k=effective_top_k,
+                    else:
+                        result = extraction_backend.extract_batch_extended(
+                            batch_prompts, spec, remote=remote,
                         )
-                    )
+                    batch_acts = result.activations
+                    batch_mask = result.attention_mask
+                    batch_logits = result.logits
+                    batch_logits_indices = result.logits_indices
+                    batch_router_logits = result.router_logits
+                else:
+                    # Standard extraction path (no router)
+                    if retry_fn is not None:
+                        batch_acts, batch_mask, batch_logits, batch_logits_indices = (
+                            retry_fn(
+                                lambda bp=batch_prompts: (  # type: ignore[misc]
+                                    extraction_backend.extract_batch_with_logits(
+                                        bp, layer_indices,
+                                        remote=remote,
+                                        logit_top_k=effective_top_k,
+                                    )
+                                ),
+                                max_retries=effective_retries,
+                                context=f"batch {batch_idx + 1}/{num_batches}",
+                            )
+                        )
+                    else:
+                        batch_acts, batch_mask, batch_logits, batch_logits_indices = (
+                            extraction_backend.extract_batch_with_logits(
+                                batch_prompts, layer_indices,
+                                remote=remote,
+                                logit_top_k=effective_top_k,
+                            )
+                        )
             except Exception:
                 if remote and effective_retries > 0:
                     logger.error(
@@ -603,6 +686,10 @@ def extract(
                 batch_logits = batch_logits.cpu()
             if batch_logits_indices is not None:
                 batch_logits_indices = batch_logits_indices.cpu()
+            if batch_router_logits is not None:
+                batch_router_logits = {
+                    k: v.cpu() for k, v in batch_router_logits.items()
+                }
 
             # Compute num_tokens from attention_mask
             num_tokens = batch_mask.sum(dim=-1).int().tolist()
@@ -627,6 +714,7 @@ def extract(
                 batch_idx=batch_idx,
                 batch_logits=batch_logits if cache_logits else None,
                 batch_logits_indices=batch_logits_indices if cache_logits else None,
+                batch_router_logits=batch_router_logits,
             )
 
             # Update manifest
@@ -644,7 +732,7 @@ def extract(
             batches_extracted += 1
 
             # Free memory
-            del batch_acts, batch_mask, batch_logits, batch_logits_indices
+            del batch_acts, batch_mask, batch_logits, batch_logits_indices, batch_router_logits
             gc.collect()
             _release_memory()
 

--- a/src/lmprobe/extraction.py
+++ b/src/lmprobe/extraction.py
@@ -15,6 +15,8 @@ from tqdm import tqdm
 if TYPE_CHECKING:
     from nnsight import LanguageModel
 
+    from .activation_types import ExtractedBatch
+
 
 def _require_nnsight() -> Any:
     """Import and return the nnsight module, raising a clear error if not installed."""
@@ -710,7 +712,7 @@ def _extract_batch_extended(
     prompts: list[str],
     spec: Any,
     remote: bool = False,
-) -> Any:
+) -> ExtractedBatch:
     """Extract multiple activation types in a single forward pass (nnsight).
 
     Parameters

--- a/src/lmprobe/extraction.py
+++ b/src/lmprobe/extraction.py
@@ -381,6 +381,8 @@ def _build_remote_extract_fn(
     layer_indices: list[int],
     with_logits: bool = False,
     logit_top_k: int | None = None,
+    router_layer_indices: list[int] | None = None,
+    router_module_template: str | None = None,
 ) -> Any:
     """Build a trace function for remote nnsight execution.
 
@@ -397,37 +399,44 @@ def _build_remote_extract_fn(
 
     To work around both issues we dynamically generate a real ``.py``
     file containing one ``output.save()`` statement per layer (and
-    optionally a logits save). The file is importable so that
+    optionally logits/router saves). The file is importable so that
     ``inspect.getsourcelines`` succeeds during nnsight's code capture.
 
     Parameters
     ----------
     layer_indices : list[int]
-        Positive layer indices to extract.
+        Positive layer indices to extract hidden states from.
     with_logits : bool
         If True, also save the lm_head logits output.
     logit_top_k : int | None
         If set and with_logits is True, perform server-side top-k on
         logits so only compressed tensors are transferred. The trace
         will return ``(values, indices)`` instead of full logits.
+    router_layer_indices : list[int] or None
+        Layer indices to extract MoE router logits from.
+    router_module_template : str or None
+        Dot-path template for the router module, e.g.
+        ``"model.model.layers.{layer}.block_sparse_moe.gate"``.
+        Required when router_layer_indices is not None.
 
     Returns
     -------
     callable
-        A function ``(model, tokenized) -> tuple[list[Tensor], ...]``
-        that runs the trace and returns layer outputs plus logits info.
-        When logit_top_k is set: ``(layers, (topk_values, topk_indices))``
-        Otherwise: ``(layers, logits_or_none)``
+        A function ``(model, tokenized) -> tuple[list[Tensor], logits_info, list[Tensor]]``
+        that runs the trace and returns layer outputs, logits info, and
+        router outputs.
     """
     import importlib.util
     import tempfile
 
+    # --- Hidden state save lines ---
     var_names = [f"_l{i}" for i in layer_indices]
     save_lines = "\n".join(
         f"        {v} = model.model.layers[{i}].output.save()"
         for v, i in zip(var_names, layer_indices)
     )
 
+    # --- Logits save lines ---
     if with_logits and logit_top_k is not None:
         # Server-side top-k: compute topk inside the trace
         logits_line = (
@@ -444,15 +453,37 @@ def _build_remote_extract_fn(
         logits_line = ""
         return_logits = "None"
 
-    return_layers = f"[{', '.join(var_names)}]"
+    # --- Router logit save lines ---
+    router_var_names: list[str] = []
+    router_save_lines = ""
+    if router_layer_indices and router_module_template:
+        router_var_names = [f"_r{i}" for i in router_layer_indices]
+        # Convert dot-path template to nnsight attribute access
+        # e.g., "model.model.layers.{layer}.block_sparse_moe.gate"
+        # becomes "model.model.layers[{i}].block_sparse_moe.gate"
+        # We need to handle the layers[i] indexing specially
+        router_save_lines = "\n".join(
+            f"        {v} = {router_module_template.format(layer=i)}.output.save()"
+            for v, i in zip(router_var_names, router_layer_indices)
+        )
 
-    code = (
-        "def extract(model, tokenized):\n"
-        "    with model.trace(tokenized, remote=True, scan=False) as tracer:\n"
-        f"{save_lines}\n"
-        f"{logits_line}\n"
-        f"    return ({return_layers}, {return_logits})\n"
+    return_layers = f"[{', '.join(var_names)}]"
+    return_routers = f"[{', '.join(router_var_names)}]" if router_var_names else "[]"
+
+    code_parts = [
+        "def extract(model, tokenized):\n",
+        "    with model.trace(tokenized, remote=True, scan=False) as tracer:\n",
+    ]
+    if save_lines:
+        code_parts.append(f"{save_lines}\n")
+    if logits_line:
+        code_parts.append(f"{logits_line}\n")
+    if router_save_lines:
+        code_parts.append(f"{router_save_lines}\n")
+    code_parts.append(
+        f"    return ({return_layers}, {return_logits}, {return_routers})\n"
     )
+    code = "".join(code_parts)
 
     tmp = tempfile.NamedTemporaryFile(
         mode="w", suffix=".py", prefix="_lmprobe_remote_", delete=False
@@ -540,7 +571,7 @@ def _extract_batch(
         # pickling issue (nnsight #501). See _build_remote_extract_fn
         # docstring for details.
         fn = _build_remote_extract_fn(layer_indices, with_logits=False)
-        layer_outputs, _ = fn(model, tokenized)
+        layer_outputs, _, _routers = fn(model, tokenized)
         activation_tensors = _unwrap_layer_outputs(layer_outputs)
     else:
         # Local: tracer.cache() works fine without serialization.
@@ -625,7 +656,7 @@ def _extract_batch_with_logits(
         fn = _build_remote_extract_fn(
             layer_indices, with_logits=True, logit_top_k=logit_top_k
         )
-        layer_outputs, logits_proxy = fn(model, tokenized)
+        layer_outputs, logits_proxy, _routers = fn(model, tokenized)
         activation_tensors = _unwrap_layer_outputs(layer_outputs)
 
         if logit_top_k is not None:
@@ -672,6 +703,144 @@ def _extract_batch_with_logits(
     attention_mask = tokenized["attention_mask"]
 
     return combined, attention_mask, logits_val, logits_indices
+
+
+def _extract_batch_extended(
+    model: LanguageModel,
+    prompts: list[str],
+    spec: Any,
+    remote: bool = False,
+) -> Any:
+    """Extract multiple activation types in a single forward pass (nnsight).
+
+    Parameters
+    ----------
+    model : LanguageModel
+        The nnsight model.
+    prompts : list[str]
+        List of text prompts.
+    spec : ExtractionSpec
+        What to extract.
+    remote : bool
+        Whether to use remote execution.
+
+    Returns
+    -------
+    ExtractedBatch
+        Structured extraction result.
+    """
+    from .activation_types import ExtractedBatch
+
+    tokenized = model.tokenizer(
+        prompts,
+        return_tensors="pt",
+        padding=True,
+    )
+
+    router_layer_indices = spec.router_layers or []
+    router_template = spec.router_module_template
+
+    if remote:
+        fn = _build_remote_extract_fn(
+            spec.hidden_layers,
+            with_logits=spec.include_logits,
+            logit_top_k=spec.logit_top_k,
+            router_layer_indices=router_layer_indices,
+            router_module_template=router_template,
+        )
+        layer_outputs, logits_proxy, router_outputs = fn(model, tokenized)
+        activation_tensors = _unwrap_layer_outputs(layer_outputs)
+
+        # Process logits
+        logits_val = None
+        logits_indices = None
+        if spec.include_logits and logits_proxy is not None:
+            if spec.logit_top_k is not None:
+                vals_proxy, idxs_proxy = logits_proxy
+                logits_val = _unwrap_proxy(vals_proxy)
+                logits_indices = _unwrap_proxy(idxs_proxy)
+            else:
+                logits_val = _unwrap_proxy(logits_proxy)
+
+        # Process router outputs
+        router_logits: dict[int, torch.Tensor] | None = None
+        if router_outputs:
+            router_tensors = _unwrap_layer_outputs(router_outputs)
+            router_logits = {
+                idx: t for idx, t in zip(router_layer_indices, router_tensors)
+            }
+    else:
+        # Local nnsight extraction
+        modules_to_cache = [model.model.layers[i] for i in spec.hidden_layers]
+
+        # For router modules, we use output.save() directly
+        # since tracer.cache() may not work for deeply nested submodules
+        with model.trace(tokenized, remote=False) as tracer:
+            if modules_to_cache:
+                cache = tracer.cache(modules=modules_to_cache).save()
+
+            # Logits
+            logits_save = None
+            if spec.include_logits:
+                logits_save = model.lm_head.output.save()
+
+            # Router logits via output.save() on each router module
+            router_saves: dict[int, Any] = {}
+            if router_layer_indices and router_template:
+                for layer_idx in router_layer_indices:
+                    # Navigate nnsight model's attribute tree
+                    parts = router_template.format(layer=layer_idx).split(".")
+                    obj: Any = model
+                    for part in parts:
+                        if part.isdigit():
+                            obj = obj[int(part)]
+                        else:
+                            obj = getattr(obj, part)
+                    router_saves[layer_idx] = obj.output.save()
+
+        # Collect hidden states
+        activation_tensors = []
+        if modules_to_cache:
+            for layer_idx in spec.hidden_layers:
+                key = f"model.model.layers.{layer_idx}"
+                entry = cache[key]  # noqa: F821
+                if hasattr(entry, "output"):
+                    output = entry.output
+                else:
+                    output = entry["output"]
+                tensor = _unwrap_proxy(output)
+                if isinstance(tensor, tuple):
+                    tensor = tensor[0]
+                activation_tensors.append(tensor)
+
+        # Collect logits
+        logits_val = None
+        logits_indices = None
+        if logits_save is not None:
+            logits_val = _unwrap_proxy(logits_save)
+
+        # Collect router logits
+        router_logits = None
+        if router_saves:
+            router_logits = {}
+            for layer_idx, saved in router_saves.items():
+                val = _unwrap_proxy(saved)
+                if isinstance(val, tuple):
+                    val = val[0]
+                router_logits[layer_idx] = val
+
+    # Build result
+    combined = None
+    if activation_tensors:
+        combined = torch.cat(activation_tensors, dim=-1)
+
+    return ExtractedBatch(
+        activations=combined,
+        attention_mask=tokenized["attention_mask"],
+        logits=logits_val,
+        logits_indices=logits_indices,
+        router_logits=router_logits,
+    )
 
 
 def compute_perplexity_from_logits(

--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -1102,7 +1102,7 @@ def _compute_shard_plan(
             n, max(router_row_bytes, 1), shard_max_bytes,
         )
     else:
-        router_boundaries: list[int] = []
+        router_boundaries = []
 
     # --- Phase 4a: Assign shard metadata (no data loading) ---
     if has_hidden and hidden_boundaries and use_raw and lt_boundaries:

--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -399,6 +399,7 @@ def _compute_tensor_intersection(
             "logits_top_k": None,
             "has_perplexity": False,
             "has_token_perplexity": False,
+            "router_layers": [],
         }
 
     raw_sets = [set(i.raw_layers) for i in infos]
@@ -444,6 +445,12 @@ def _compute_tensor_intersection(
     has_perplexity = all(i.has_perplexity for i in infos)
     has_token_perplexity = all(i.has_token_perplexity for i in infos)
 
+    # Router layers: intersection of router_layers across all infos
+    router_sets = [set(i.router_layers) for i in infos]
+    router_intersection = sorted(
+        router_sets[0].intersection(*router_sets[1:])
+    ) if all(rs for rs in router_sets) else []
+
     return {
         "raw_layers": raw_intersection,
         "pooled": pooled,
@@ -451,6 +458,7 @@ def _compute_tensor_intersection(
         "logits_top_k": logits_top_k,
         "has_perplexity": has_perplexity,
         "has_token_perplexity": has_token_perplexity,
+        "router_layers": router_intersection,
     }
 
 
@@ -472,6 +480,7 @@ def _filter_tensor_types(
         "logits_top_k": available.get("logits_top_k"),
         "has_perplexity": False,
         "has_token_perplexity": False,
+        "router_layers": [],
     }
 
     for key in tensors_filter:
@@ -488,6 +497,10 @@ def _filter_tensor_types(
         if key == "perplexity" and available["has_perplexity"]:
             result["has_perplexity"] = True
             result["has_token_perplexity"] = available.get("has_token_perplexity", False)
+            continue
+
+        if key == "router_logits" and available.get("router_layers"):
+            result["router_layers"] = list(available["router_layers"])
             continue
 
         logger.warning(
@@ -564,6 +577,31 @@ def _load_logits_for_prompt(
         "logits_topk.values": values.reshape(1, -1),
         "logits_topk.indices": indices.reshape(1, -1),
     }
+
+
+def _load_router_for_prompt(
+    model_name: str,
+    prompt: str,
+    layers: list[int],
+) -> dict[str, torch.Tensor]:
+    """Load router logits for a prompt, keyed for shard storage.
+
+    Returns dict like ``{"router.layer_0": (1, num_experts), ...}``.
+    Each value is reshaped to ``(1, num_experts)`` for row-based sharding.
+    """
+    from .cache import load_prompt_router_logits
+
+    router_dict = load_prompt_router_logits(model_name, prompt, layers)
+    result: dict[str, torch.Tensor] = {}
+    for layer, tensor in router_dict.items():
+        # Router logits per prompt: (seq_len, num_experts) or (num_experts,)
+        # For pooled (last_token) storage, take last token and reshape to (1, num_experts)
+        if tensor.dim() >= 2:
+            # Take last token position
+            result[f"router.layer_{layer}"] = tensor[-1:].reshape(1, -1)
+        else:
+            result[f"router.layer_{layer}"] = tensor.reshape(1, -1)
+    return result
 
 
 def _load_hidden_raw_for_prompt(
@@ -838,6 +876,7 @@ def _compute_shard_plan(
     logits_top_k = tensor_types["logits_top_k"]
     has_perplexity = tensor_types.get("has_perplexity", False)
     has_token_perplexity = tensor_types.get("has_token_perplexity", False)
+    router_layers = tensor_types.get("router_layers", [])
 
     raw_layers = tensor_types.get("raw_layers", [])
     use_raw = bool(raw_layers)
@@ -998,6 +1037,23 @@ def _compute_shard_plan(
     if has_logits and logits_top_k is not None:
         logits_row_bytes = logits_top_k * 4 + logits_top_k * 8
 
+    # Router: estimate row bytes from a sample prompt
+    router_dim = 0
+    want_router = bool(router_layers)
+    if want_router and valid_prompts:
+        try:
+            sample_router = _load_router_for_prompt(
+                model_name, valid_prompts[0], router_layers[:1],
+            )
+            sample_key = f"router.layer_{router_layers[0]}"
+            if sample_key in sample_router:
+                router_dim = sample_router[sample_key].shape[-1]
+            del sample_router
+        except (FileNotFoundError, KeyError):
+            want_router = False
+            router_layers = []
+    router_row_bytes = router_dim * 4 * len(router_layers) if want_router else 0
+
     has_hidden = bool(hidden_layers and (hidden_strategy or use_raw))
     want_logits = bool(has_logits and logits_top_k is not None)
 
@@ -1040,6 +1096,13 @@ def _compute_shard_plan(
         )
     else:
         logits_boundaries = []
+
+    if want_router:
+        router_boundaries = _compute_shard_boundaries(
+            n, max(router_row_bytes, 1), shard_max_bytes,
+        )
+    else:
+        router_boundaries: list[int] = []
 
     # --- Phase 4a: Assign shard metadata (no data loading) ---
     if has_hidden and hidden_boundaries and use_raw and lt_boundaries:
@@ -1209,6 +1272,28 @@ def _compute_shard_plan(
             "shards": logits_shards,
         }
 
+    if want_router and router_boundaries:
+        router_shards = []
+        off = 0
+        for si, sz in enumerate(router_boundaries):
+            actual = min(sz, n - off)
+            router_shards.append({
+                "file": f"tensors/router_logits_{si:03d}.safetensors",
+                "num_prompts": actual,
+            })
+            off += actual
+
+        tensor_descriptors["router_logits"] = {
+            "type": "router",
+            "layers": router_layers,
+            "num_experts": router_dim,
+            "dtype": "float32",
+            "pooling": "last_token",
+            "file_pattern": "tensors/router_logits_{shard:03d}.safetensors",
+            "row_bytes": router_row_bytes,
+            "shards": router_shards,
+        }
+
     return {
         "prompt_metadata": prompt_metadata,
         "valid_prompts": valid_prompts,
@@ -1228,6 +1313,9 @@ def _compute_shard_plan(
         "lt_shard_count": lt_shard_count,
         "lt_boundaries": lt_boundaries,
         "rest_boundaries": rest_boundaries,
+        "want_router": want_router,
+        "router_layers": router_layers,
+        "router_boundaries": router_boundaries,
     }
 
 
@@ -1254,6 +1342,12 @@ def _reconstruct_plan_from_cached(cached_meta: dict) -> dict[str, Any]:
         s["num_prompts"] for s in logits_info.get("shards", [])
     ]
 
+    router_info = td.get("router_logits", {})
+    want_router = bool(router_info)
+    router_boundaries = [
+        s["num_prompts"] for s in router_info.get("shards", [])
+    ]
+
     return {
         "has_hidden": has_hidden,
         "hidden_layers": hidden_layers,
@@ -1261,6 +1355,8 @@ def _reconstruct_plan_from_cached(cached_meta: dict) -> dict[str, Any]:
         "want_logits": want_logits,
         "logits_boundaries": logits_boundaries,
         "lt_shard_count": lt_shard_count,
+        "want_router": want_router,
+        "router_boundaries": router_boundaries,
     }
 
 
@@ -1276,6 +1372,9 @@ def _enumerate_shard_files(plan: dict[str, Any]) -> list[str]:
     if plan["want_logits"] and plan["logits_boundaries"]:
         for shard_idx in range(len(plan["logits_boundaries"])):
             files.append(f"tensors/logits_topk_{shard_idx:03d}.safetensors")
+    if plan.get("want_router") and plan.get("router_boundaries"):
+        for shard_idx in range(len(plan["router_boundaries"])):
+            files.append(f"tensors/router_logits_{shard_idx:03d}.safetensors")
     return files
 
 
@@ -1384,6 +1483,9 @@ def _consolidate_and_shard(
     lt_shard_count = plan.get("lt_shard_count", 0)
     lt_boundaries = plan.get("lt_boundaries", [])
     rest_boundaries = plan.get("rest_boundaries", [])
+    want_router = plan.get("want_router", False)
+    router_layers_plan = plan.get("router_layers", [])
+    router_boundaries = plan.get("router_boundaries", [])
 
     from tqdm import tqdm
 
@@ -1644,6 +1746,53 @@ def _consolidate_and_shard(
                 del logits_tensors_out
 
             del shard_data_logits
+            offset += shard_size
+
+    # --- Router pass ---
+    if want_router and router_boundaries and router_layers_plan:
+        offset = 0
+        for shard_idx, shard_size in enumerate(tqdm(
+            router_boundaries, desc="Writing router shards", unit="shard",
+        )):
+            fname = f"tensors/router_logits_{shard_idx:03d}.safetensors"
+            if fname in skip_shards:
+                offset += shard_size
+                continue
+
+            shard_prompts_text = valid_prompts[offset : offset + shard_size]
+
+            # Load and concatenate router tensors for this shard
+            shard_data_router: list[dict[str, torch.Tensor]] = []
+            for prompt in shard_prompts_text:
+                try:
+                    loaded_r = _load_router_for_prompt(
+                        model_name, prompt, router_layers_plan,
+                    )
+                    shard_data_router.append(loaded_r)
+                except (FileNotFoundError, KeyError, OSError) as e:
+                    raise OSError(
+                        f"Prompt passed metadata scan but failed to load "
+                        f"router logits during shard write (cache may have "
+                        f"been modified concurrently): {e}"
+                    ) from e
+
+            # Concatenate per-layer router tensors
+            router_tensors_out: dict[str, torch.Tensor] = {}
+            for layer in router_layers_plan:
+                key = f"router.layer_{layer}"
+                layer_tensors = [
+                    p[key] for p in shard_data_router if key in p
+                ]
+                if layer_tensors:
+                    router_tensors_out[key] = torch.cat(layer_tensors, dim=0)
+
+            if router_tensors_out:
+                save_file(router_tensors_out, str(tmpdir / fname))
+                if on_shard_written is not None:
+                    on_shard_written(tmpdir / fname, fname)
+                del router_tensors_out
+
+            del shard_data_router
             offset += shard_size
 
     return tmpdir, tensor_descriptors, prompt_metadata

--- a/tests/test_activation_types.py
+++ b/tests/test_activation_types.py
@@ -1,0 +1,255 @@
+"""Tests for activation_types module: MoE detection, ExtractionSpec, ExtractedBatch."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from lmprobe.activation_types import (
+    ActivationType,
+    ExtractedBatch,
+    ExtractionSpec,
+    MoEInfo,
+    detect_moe_info,
+    get_router_module,
+    validate_router_layers,
+)
+
+
+class TestActivationType:
+    def test_enum_values(self):
+        assert ActivationType.HIDDEN == "hidden"
+        assert ActivationType.LOGITS == "logits"
+        assert ActivationType.ROUTER_LOGITS == "router"
+
+    def test_string_comparison(self):
+        assert ActivationType.HIDDEN == "hidden"
+        assert ActivationType.ROUTER_LOGITS == "router"
+
+
+class TestExtractionSpec:
+    def test_defaults(self):
+        spec = ExtractionSpec(hidden_layers=[0, 1, 2])
+        assert spec.hidden_layers == [0, 1, 2]
+        assert spec.include_logits is False
+        assert spec.logit_top_k is None
+        assert spec.router_layers is None
+        assert spec.router_module_template is None
+
+    def test_with_router(self):
+        spec = ExtractionSpec(
+            hidden_layers=[0, 1],
+            router_layers=[0, 1],
+            router_module_template="model.model.layers.{layer}.block_sparse_moe.gate",
+        )
+        assert spec.router_layers == [0, 1]
+        assert spec.router_module_template is not None
+
+    def test_router_without_template_raises(self):
+        with pytest.raises(ValueError, match="router_module_template is required"):
+            ExtractionSpec(
+                hidden_layers=[0],
+                router_layers=[0],
+            )
+
+    def test_empty_router_layers_ok_without_template(self):
+        # None router_layers is fine without template
+        spec = ExtractionSpec(hidden_layers=[0], router_layers=None)
+        assert spec.router_layers is None
+
+    def test_with_logits(self):
+        spec = ExtractionSpec(
+            hidden_layers=[0],
+            include_logits=True,
+            logit_top_k=50,
+        )
+        assert spec.include_logits is True
+        assert spec.logit_top_k == 50
+
+
+class TestExtractedBatch:
+    def test_construction(self):
+        batch = ExtractedBatch(
+            activations=torch.randn(2, 10, 64),
+            attention_mask=torch.ones(2, 10),
+        )
+        assert batch.activations is not None
+        assert batch.logits is None
+        assert batch.router_logits is None
+
+    def test_with_router_logits(self):
+        router = {
+            0: torch.randn(2, 10, 8),
+            1: torch.randn(2, 10, 8),
+        }
+        batch = ExtractedBatch(
+            activations=torch.randn(2, 10, 64),
+            attention_mask=torch.ones(2, 10),
+            router_logits=router,
+        )
+        assert batch.router_logits is not None
+        assert len(batch.router_logits) == 2
+        assert batch.router_logits[0].shape == (2, 10, 8)
+
+
+class TestMoEInfo:
+    def test_frozen(self):
+        info = MoEInfo(
+            num_experts=8,
+            router_module_template="model.model.layers.{layer}.block_sparse_moe.gate",
+        )
+        assert info.num_experts == 8
+        assert info.moe_layer_indices is None
+
+    def test_with_moe_indices(self):
+        info = MoEInfo(
+            num_experts=64,
+            router_module_template="model.model.layers.{layer}.mlp.gate",
+            moe_layer_indices=[1, 3, 5, 7],
+        )
+        assert info.moe_layer_indices == [1, 3, 5, 7]
+
+
+class TestDetectMoEInfo:
+    def _mock_config(self, **kwargs):
+        config = MagicMock()
+        # Default to no MoE attributes
+        config.model_type = kwargs.get("model_type", "llama")
+        config.num_local_experts = kwargs.get("num_local_experts", None)
+        config.num_experts = kwargs.get("num_experts", None)
+        config.n_routed_experts = kwargs.get("n_routed_experts", None)
+        config.num_hidden_layers = kwargs.get("num_hidden_layers", 32)
+        config.first_k_dense_replace = kwargs.get("first_k_dense_replace", 1)
+        config.moe_layer_freq = kwargs.get("moe_layer_freq", 1)
+        config.ffn_config = kwargs.get("ffn_config", None)
+        return config
+
+    @patch("transformers.AutoConfig")
+    def test_dense_model_returns_none(self, mock_autoconfig):
+        mock_autoconfig.from_pretrained.return_value = self._mock_config(
+            model_type="llama"
+        )
+        result = detect_moe_info("meta-llama/Llama-3.1-8B")
+        assert result is None
+
+    @patch("transformers.AutoConfig")
+    def test_mixtral(self, mock_autoconfig):
+        mock_autoconfig.from_pretrained.return_value = self._mock_config(
+            model_type="mixtral",
+            num_local_experts=8,
+        )
+        result = detect_moe_info("mistralai/Mixtral-8x7B")
+        assert result is not None
+        assert result.num_experts == 8
+        assert "block_sparse_moe.gate" in result.router_module_template
+        assert result.moe_layer_indices is None
+
+    @patch("transformers.AutoConfig")
+    def test_qwen2_moe(self, mock_autoconfig):
+        mock_autoconfig.from_pretrained.return_value = self._mock_config(
+            model_type="qwen2_moe",
+            num_experts=60,
+        )
+        result = detect_moe_info("Qwen/Qwen1.5-MoE-A2.7B")
+        assert result is not None
+        assert result.num_experts == 60
+        assert "mlp.gate" in result.router_module_template
+
+    @patch("transformers.AutoConfig")
+    def test_deepseek_v2(self, mock_autoconfig):
+        mock_autoconfig.from_pretrained.return_value = self._mock_config(
+            model_type="deepseek_v2",
+            n_routed_experts=64,
+            num_hidden_layers=60,
+            first_k_dense_replace=2,
+            moe_layer_freq=2,
+        )
+        result = detect_moe_info("deepseek-ai/DeepSeek-V2")
+        assert result is not None
+        assert result.num_experts == 64
+        assert result.moe_layer_indices is not None
+        # MoE layers start at 2, every 2 layers
+        assert 0 not in result.moe_layer_indices
+        assert 1 not in result.moe_layer_indices
+        assert 2 in result.moe_layer_indices
+        assert 4 in result.moe_layer_indices
+
+    @patch("transformers.AutoConfig")
+    def test_dbrx(self, mock_autoconfig):
+        ffn_config = MagicMock()
+        ffn_config.moe_num_experts = 16
+        mock_autoconfig.from_pretrained.return_value = self._mock_config(
+            model_type="dbrx",
+            ffn_config=ffn_config,
+        )
+        result = detect_moe_info("databricks/dbrx-instruct")
+        assert result is not None
+        assert result.num_experts == 16
+        assert "ffn.router.layer" in result.router_module_template
+
+
+class TestValidateRouterLayers:
+    def test_all_layers_moe(self):
+        info = MoEInfo(num_experts=8, router_module_template="t.{layer}")
+        result = validate_router_layers(info, [0, 1, 2, 3])
+        assert result == [0, 1, 2, 3]
+
+    def test_partial_moe_layers(self):
+        info = MoEInfo(
+            num_experts=8,
+            router_module_template="t.{layer}",
+            moe_layer_indices=[1, 3, 5],
+        )
+        result = validate_router_layers(info, [0, 1, 2, 3])
+        assert result == [1, 3]
+
+    def test_no_valid_layers_raises(self):
+        info = MoEInfo(
+            num_experts=8,
+            router_module_template="t.{layer}",
+            moe_layer_indices=[10, 20],
+        )
+        with pytest.raises(ValueError, match="None of the requested layers"):
+            validate_router_layers(info, [0, 1, 2])
+
+
+class TestGetRouterModule:
+    def test_simple_path(self):
+        # Build a real object hierarchy (MagicMock auto-creates attributes
+        # which interferes with navigation)
+        class Gate:
+            pass
+
+        class MoE:
+            def __init__(self):
+                self.gate = Gate()
+
+        class Layer:
+            def __init__(self):
+                self.block_sparse_moe = MoE()
+
+        class Layers:
+            def __init__(self):
+                self._layers = [Layer()]
+            def __getitem__(self, idx):
+                return self._layers[idx]
+
+        class InnerModel:
+            def __init__(self):
+                self.layers = Layers()
+
+        class Model:
+            def __init__(self):
+                self.model = InnerModel()
+
+        top = Model()
+        # Template: model.model.layers.{layer}.block_sparse_moe.gate
+        # get_router_module starts from the object passed in and walks
+        # each part of the formatted path
+        result = get_router_module(
+            top,
+            "model.layers.{layer}.block_sparse_moe.gate",
+            layer=0,
+        )
+        assert isinstance(result, Gate)
+        assert result is top.model.layers[0].block_sparse_moe.gate

--- a/tests/test_router_extraction.py
+++ b/tests/test_router_extraction.py
@@ -1,5 +1,6 @@
 """Tests for MoE router extraction via LocalBackend and cache round-trip."""
 
+
 import pytest
 import torch
 
@@ -185,3 +186,176 @@ class TestCachedPromptInfoRouter:
         info = discover_cached(model_name, prompt)
         assert info is not None
         assert info.router_layers == []
+
+
+class TestSaveBatchWithRouter:
+    """Test _save_batch with router logits."""
+
+    def test_save_batch_router_logits(self, tmp_path):
+        """_save_batch saves router logits to separate per-layer directories."""
+        from safetensors.torch import load_file
+
+        from lmprobe.extract import _save_batch
+
+        batch_acts = torch.randn(2, 5, 64)  # 2 prompts, 5 tokens, 2 layers * 32 dim
+        batch_mask = torch.ones(2, 5)
+        router_logits = {
+            0: torch.randn(2, 5, 8),  # 8 experts
+            1: torch.randn(2, 5, 8),
+        }
+
+        _save_batch(
+            batch_acts=batch_acts,
+            batch_mask=batch_mask,
+            layer_indices=[0, 1],
+            hidden_dim=32,
+            prefix="test",
+            batch_idx=0,
+            local_root=tmp_path,
+            batch_router_logits=router_logits,
+        )
+
+        # Check hidden state files exist
+        assert (tmp_path / "layer_000" / "batch_000000.safetensors").exists()
+        assert (tmp_path / "layer_001" / "batch_000000.safetensors").exists()
+
+        # Check router files exist
+        router_path_0 = tmp_path / "router_layer_0" / "batch_000000.safetensors"
+        router_path_1 = tmp_path / "router_layer_1" / "batch_000000.safetensors"
+        assert router_path_0.exists()
+        assert router_path_1.exists()
+
+        # Verify router file contents
+        loaded = load_file(str(router_path_0))
+        assert "router_logits" in loaded
+        assert "mask" in loaded
+        assert loaded["router_logits"].shape == (2, 5, 8)
+
+    def test_save_batch_no_router(self, tmp_path):
+        """_save_batch without router logits doesn't create router dirs."""
+        from lmprobe.extract import _save_batch
+
+        batch_acts = torch.randn(2, 5, 32)
+        batch_mask = torch.ones(2, 5)
+
+        _save_batch(
+            batch_acts=batch_acts,
+            batch_mask=batch_mask,
+            layer_indices=[0],
+            hidden_dim=32,
+            prefix="test",
+            batch_idx=0,
+            local_root=tmp_path,
+        )
+
+        assert (tmp_path / "layer_000" / "batch_000000.safetensors").exists()
+        # No router directories
+        assert not list(tmp_path.glob("router_layer_*"))
+
+
+class TestExtractionManifestRouter:
+    """Test ExtractionManifest with router fields."""
+
+    def test_roundtrip(self):
+        from lmprobe.extract import ExtractionManifest
+
+        manifest = ExtractionManifest(
+            model_name="test-model",
+            layers=[0, 1, 2],
+            hidden_dim=64,
+            total_prompts=10,
+            router_layers=[0, 1],
+            router_dim=8,
+        )
+
+        d = manifest.to_dict()
+        assert d["router_layers"] == [0, 1]
+        assert d["router_dim"] == 8
+
+        loaded = ExtractionManifest.from_dict(d)
+        assert loaded.router_layers == [0, 1]
+        assert loaded.router_dim == 8
+
+    def test_backward_compat(self):
+        """Old manifests without router fields load with None defaults."""
+        from lmprobe.extract import ExtractionManifest
+
+        old_dict = {
+            "model_name": "test",
+            "layers": [0],
+            "hidden_dim": 32,
+            "total_prompts": 5,
+        }
+        loaded = ExtractionManifest.from_dict(old_dict)
+        assert loaded.router_layers is None
+        assert loaded.router_dim is None
+
+    def test_no_router_not_serialized(self):
+        """When router fields are None, they aren't in the dict."""
+        from lmprobe.extract import ExtractionManifest
+
+        manifest = ExtractionManifest(
+            model_name="test",
+            layers=[0],
+            hidden_dim=32,
+            total_prompts=5,
+        )
+        d = manifest.to_dict()
+        assert "router_layers" not in d
+        assert "router_dim" not in d
+
+
+class TestParseRouterLayerKeys:
+    """Test _parse_router_layer_keys."""
+
+    def test_parse_router_keys(self):
+        from lmprobe.cache import _parse_router_layer_keys
+
+        keys = {"layer_0", "layer_1", "router_layer_0", "router_layer_3", "attention_mask"}
+        result = _parse_router_layer_keys(keys)
+        assert result == {0, 3}
+
+    def test_empty(self):
+        from lmprobe.cache import _parse_router_layer_keys
+
+        result = _parse_router_layer_keys(set())
+        assert result == set()
+
+    def test_no_router_keys(self):
+        from lmprobe.cache import _parse_router_layer_keys
+
+        keys = {"layer_0", "layer_1", "attention_mask"}
+        result = _parse_router_layer_keys(keys)
+        assert result == set()
+
+
+class TestRouterLayerKey:
+    """Test _router_layer_key."""
+
+    def test_format(self):
+        from lmprobe.cache import _router_layer_key
+
+        assert _router_layer_key(0) == "router_layer_0"
+        assert _router_layer_key(15) == "router_layer_15"
+
+
+class TestNnsightBackendExtendedNotSupported:
+    """Test that NnsightBackend.extract_batch_extended is callable."""
+
+    def test_nnsight_backend_has_method(self):
+        """NnsightBackend inherits extract_batch_extended from ABC."""
+        from lmprobe.backends import NnsightBackend
+
+        # Just verify the method exists (don't call it — requires nnsight model)
+        assert hasattr(NnsightBackend, "extract_batch_extended")
+
+
+class TestExtractionBackendDefaultRaises:
+    """Test that base class extract_batch_extended raises NotImplementedError."""
+
+    def test_default_raises(self):
+        from lmprobe.backends import ExtractionBackend
+
+        # The ABC can't be instantiated, but we can check the method
+        # exists and its docstring mentions extensibility
+        assert hasattr(ExtractionBackend, "extract_batch_extended")

--- a/tests/test_router_extraction.py
+++ b/tests/test_router_extraction.py
@@ -359,3 +359,154 @@ class TestExtractionBackendDefaultRaises:
         # The ABC can't be instantiated, but we can check the method
         # exists and its docstring mentions extensibility
         assert hasattr(ExtractionBackend, "extract_batch_extended")
+
+
+class TestSharingRouterDescriptor:
+    """Test router logits in tensor descriptors and sharing functions."""
+
+    def test_compute_tensor_intersection_with_router(self):
+        """Router layers are intersected across infos."""
+        from lmprobe.cache import CachedPromptInfo
+        from lmprobe.sharing import _compute_tensor_intersection
+
+        infos = [
+            CachedPromptInfo(
+                raw_layers=[0, 1], pooled={}, has_logits=False,
+                logits_top_k=None, has_perplexity=False,
+                has_token_perplexity=False, num_tokens=10,
+                router_layers=[0, 1, 2],
+            ),
+            CachedPromptInfo(
+                raw_layers=[0, 1], pooled={}, has_logits=False,
+                logits_top_k=None, has_perplexity=False,
+                has_token_perplexity=False, num_tokens=8,
+                router_layers=[1, 2, 3],
+            ),
+        ]
+        result = _compute_tensor_intersection(infos)
+        assert result["router_layers"] == [1, 2]
+
+    def test_compute_tensor_intersection_no_router(self):
+        """Empty router_layers when not all infos have router data."""
+        from lmprobe.cache import CachedPromptInfo
+        from lmprobe.sharing import _compute_tensor_intersection
+
+        infos = [
+            CachedPromptInfo(
+                raw_layers=[0], pooled={}, has_logits=False,
+                logits_top_k=None, has_perplexity=False,
+                has_token_perplexity=False, num_tokens=10,
+                router_layers=[0, 1],
+            ),
+            CachedPromptInfo(
+                raw_layers=[0], pooled={}, has_logits=False,
+                logits_top_k=None, has_perplexity=False,
+                has_token_perplexity=False, num_tokens=8,
+                router_layers=[],  # no router data
+            ),
+        ]
+        result = _compute_tensor_intersection(infos)
+        assert result["router_layers"] == []
+
+    def test_compute_tensor_intersection_empty(self):
+        """Empty infos returns empty router_layers."""
+        from lmprobe.sharing import _compute_tensor_intersection
+
+        result = _compute_tensor_intersection([])
+        assert result["router_layers"] == []
+
+    def test_filter_tensor_types_router(self):
+        """Filter includes router_layers when requested."""
+        from lmprobe.sharing import _filter_tensor_types
+
+        available = {
+            "raw_layers": [0, 1],
+            "pooled": {},
+            "has_logits": False,
+            "logits_top_k": None,
+            "has_perplexity": False,
+            "has_token_perplexity": False,
+            "router_layers": [0, 1, 2],
+        }
+        result = _filter_tensor_types(available, ["router_logits"])
+        assert result["router_layers"] == [0, 1, 2]
+        # Hidden not included
+        assert result["raw_layers"] == []
+
+    def test_filter_tensor_types_no_router(self):
+        """Filter without router_logits key returns empty router_layers."""
+        from lmprobe.sharing import _filter_tensor_types
+
+        available = {
+            "raw_layers": [0],
+            "pooled": {},
+            "has_logits": False,
+            "logits_top_k": None,
+            "has_perplexity": False,
+            "has_token_perplexity": False,
+            "router_layers": [0, 1],
+        }
+        result = _filter_tensor_types(available, ["hidden_layers"])
+        assert result["router_layers"] == []
+
+    def test_enumerate_shard_files_with_router(self):
+        """_enumerate_shard_files includes router shard files."""
+        from lmprobe.sharing import _enumerate_shard_files
+
+        plan = {
+            "has_hidden": False,
+            "hidden_layers": [],
+            "hidden_boundaries": [],
+            "want_logits": False,
+            "logits_boundaries": [],
+            "lt_shard_count": 0,
+            "want_router": True,
+            "router_boundaries": [5, 5],
+        }
+        files = _enumerate_shard_files(plan)
+        assert files == [
+            "tensors/router_logits_000.safetensors",
+            "tensors/router_logits_001.safetensors",
+        ]
+
+    def test_reconstruct_plan_with_router(self):
+        """_reconstruct_plan_from_cached includes router fields."""
+        from lmprobe.sharing import _reconstruct_plan_from_cached
+
+        cached_meta = {
+            "tensor_descriptors": {
+                "router_logits": {
+                    "type": "router",
+                    "layers": [0, 1],
+                    "num_experts": 8,
+                    "shards": [
+                        {"file": "f1.safetensors", "num_prompts": 10},
+                        {"file": "f2.safetensors", "num_prompts": 5},
+                    ],
+                }
+            }
+        }
+        plan = _reconstruct_plan_from_cached(cached_meta)
+        assert plan["want_router"] is True
+        assert plan["router_boundaries"] == [10, 5]
+
+    def test_load_router_for_prompt(self, tmp_path, monkeypatch):
+        """_load_router_for_prompt loads and reshapes router logits."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        from lmprobe.cache import save_prompt_router_logits
+        from lmprobe.sharing import _load_router_for_prompt
+
+        model_name = "test-model"
+        prompt = "Hello world"
+        # Save router with seq_len=5, num_experts=8
+        save_prompt_router_logits(
+            model_name, prompt, {0: torch.randn(5, 8), 1: torch.randn(5, 8)}
+        )
+
+        result = _load_router_for_prompt(model_name, prompt, [0, 1])
+        assert "router.layer_0" in result
+        assert "router.layer_1" in result
+        # Should be reshaped to (1, num_experts) — last token
+        assert result["router.layer_0"].shape == (1, 8)
+        assert result["router.layer_1"].shape == (1, 8)

--- a/tests/test_router_extraction.py
+++ b/tests/test_router_extraction.py
@@ -1,0 +1,187 @@
+"""Tests for MoE router extraction via LocalBackend and cache round-trip."""
+
+import pytest
+import torch
+
+from lmprobe.activation_types import ExtractedBatch, ExtractionSpec
+from lmprobe.backends import LocalBackend, _get_router_modules
+
+
+class TestGetRouterModules:
+    """Test _get_router_modules with a real tiny model."""
+
+    def test_dense_model_returns_empty(self, tiny_model):
+        """Dense models have no router modules."""
+        backend = LocalBackend(tiny_model, device="cpu")
+        model = backend.model
+        result = _get_router_modules(
+            model,
+            [0, 1],
+            # Use a template that won't exist on a dense model
+            "model.layers.{layer}.block_sparse_moe.gate",
+        )
+        assert result == {}
+
+
+class TestLocalBackendExtractBatchExtended:
+    """Test extract_batch_extended on LocalBackend with a real tiny model."""
+
+    def test_hidden_only(self, tiny_model):
+        """Extract hidden states only via extended method."""
+        backend = LocalBackend(tiny_model, device="cpu")
+        spec = ExtractionSpec(hidden_layers=[0, 1])
+        result = backend.extract_batch_extended(
+            ["Hello world", "Test prompt"],
+            spec,
+        )
+        assert isinstance(result, ExtractedBatch)
+        assert result.activations is not None
+        assert result.attention_mask is not None
+        assert result.logits is None
+        assert result.router_logits is None
+        # Check shapes
+        batch_size = 2
+        assert result.activations.shape[0] == batch_size
+        assert result.attention_mask.shape[0] == batch_size
+
+    def test_hidden_with_logits(self, tiny_model):
+        """Extract hidden states + logits via extended method."""
+        backend = LocalBackend(tiny_model, device="cpu")
+        spec = ExtractionSpec(hidden_layers=[0], include_logits=True)
+        result = backend.extract_batch_extended(
+            ["Hello world"],
+            spec,
+        )
+        assert result.activations is not None
+        assert result.logits is not None
+        assert result.logits.dim() == 3  # (batch, seq, vocab)
+
+    def test_no_hidden_with_logits(self, tiny_model):
+        """Extract logits only (no hidden states)."""
+        backend = LocalBackend(tiny_model, device="cpu")
+        spec = ExtractionSpec(hidden_layers=[], include_logits=True)
+        result = backend.extract_batch_extended(
+            ["Hello world"],
+            spec,
+        )
+        assert result.activations is None
+        assert result.logits is not None
+
+    def test_router_on_dense_model_no_crash(self, tiny_model):
+        """Requesting router logits on a dense model shouldn't crash,
+        but router_logits should be None (no modules found)."""
+        backend = LocalBackend(tiny_model, device="cpu")
+        spec = ExtractionSpec(
+            hidden_layers=[0],
+            router_layers=[0],
+            router_module_template="model.layers.{layer}.block_sparse_moe.gate",
+        )
+        result = backend.extract_batch_extended(
+            ["Hello world"],
+            spec,
+        )
+        assert result.activations is not None
+        # Router logits should be None since no router modules exist
+        assert result.router_logits is None
+
+
+class TestCacheRoundTrip:
+    """Test saving and loading router logits from cache."""
+
+    def test_save_load_router_logits(self, tmp_path, monkeypatch):
+        """Router logits survive a cache round-trip."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        from lmprobe.cache import (
+            load_prompt_router_logits,
+            save_prompt_router_logits,
+        )
+
+        model_name = "test-model"
+        prompt = "Hello world"
+        router_logits = {
+            0: torch.randn(5, 8),   # 5 tokens, 8 experts
+            3: torch.randn(5, 8),
+        }
+
+        save_prompt_router_logits(model_name, prompt, router_logits)
+        loaded = load_prompt_router_logits(model_name, prompt, [0, 3])
+
+        assert set(loaded.keys()) == {0, 3}
+        torch.testing.assert_close(loaded[0], router_logits[0])
+        torch.testing.assert_close(loaded[3], router_logits[3])
+
+    def test_load_missing_layer_raises(self, tmp_path, monkeypatch):
+        """Loading a router layer that wasn't saved raises KeyError."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        from lmprobe.cache import (
+            load_prompt_router_logits,
+            save_prompt_router_logits,
+        )
+
+        model_name = "test-model"
+        prompt = "Hello world"
+        save_prompt_router_logits(
+            model_name, prompt, {0: torch.randn(5, 8)}
+        )
+
+        with pytest.raises(KeyError, match="router_layer_5"):
+            load_prompt_router_logits(model_name, prompt, [0, 5])
+
+
+class TestCachedPromptInfoRouter:
+    """Test that discover_cached includes router layer info."""
+
+    def test_discover_with_router(self, tmp_path, monkeypatch):
+        """CachedPromptInfo.router_layers populated after saving router logits."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        from lmprobe.cache import (
+            discover_cached,
+            save_prompt_activations,
+            save_prompt_router_logits,
+        )
+
+        model_name = "test-model"
+        prompt = "Hello world"
+
+        # Save hidden states first (so there's a cache entry)
+        save_prompt_activations(
+            model_name, prompt,
+            layers=[0, 1],
+            activations=torch.randn(1, 5, 64),  # 1 batch, 5 tokens, 2*32 dim
+            attention_mask=torch.ones(5),
+        )
+
+        # Save router logits
+        save_prompt_router_logits(
+            model_name, prompt,
+            {0: torch.randn(5, 8), 1: torch.randn(5, 8)},
+        )
+
+        info = discover_cached(model_name, prompt)
+        assert info is not None
+        assert sorted(info.router_layers) == [0, 1]
+
+    def test_discover_without_router(self, tmp_path, monkeypatch):
+        """CachedPromptInfo.router_layers is empty when no router data cached."""
+        monkeypatch.setenv("LMPROBE_CACHE_DIR", str(tmp_path))
+
+        from lmprobe.cache import (
+            discover_cached,
+            save_prompt_activations,
+        )
+
+        model_name = "test-model"
+        prompt = "Hello world"
+        save_prompt_activations(
+            model_name, prompt,
+            layers=[0],
+            activations=torch.randn(1, 5, 32),
+            attention_mask=torch.ones(5),
+        )
+
+        info = discover_cached(model_name, prompt)
+        assert info is not None
+        assert info.router_layers == []


### PR DESCRIPTION
## Summary

Closes #260

- Adds `ExtractionSpec` / `ExtractedBatch` abstraction for extensible multi-type extraction (hidden states, logits, router logits — future: attention, MLP)
- Config-only MoE detection via `detect_moe_info()` — supports Mixtral, Qwen2-MoE, DeepSeek-V2/V3, DBRX, Arctic, OLMoE
- `extract_batch_extended()` on both LocalBackend (forward hooks) and NnsightBackend (code-gen + tracer)
- Cache support: `router_layer_{i}` keys, `save_prompt_router_logits()` / `load_prompt_router_logits()`, `CachedPromptInfo.router_layers`
- Bulk `extract()` gains `extract_router=True` with auto MoE detection and per-layer router logit storage
- Existing `extract_batch()` / `extract_batch_with_logits()` unchanged for backward compatibility

### Deferred to follow-up
- `sharing.py` router tensor descriptor for dataset sharding
- `Probe` integration (`activations` parameter)

### Design note for #261 (layer-chunked extraction)
The `ExtractionSpec` + `ExtractedBatch` pattern directly enables chunked extraction — the spec tells the chunked backend exactly which modules to hook per chunk, and the structured result can be written to disk per chunk without loss of type information.

## Test plan
- [x] 20 unit tests for `activation_types.py` (MoE detection, spec validation, module resolution)
- [x] 9 tests for router extraction + cache round-trip
- [x] Full suite: 1390 passed, 0 regressions (1 pre-existing CUDA skip)
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)