### PR TITLE
Add multimodal model support for extraction backends

### DIFF
--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -284,6 +284,14 @@ def _get_decoder_layers(model: Any) -> list[Any]:
     # (Llama, Mistral, Phi, Qwen, BitNet, Gemma)
     if hasattr(model, "model") and hasattr(model.model, "layers"):
         return list(model.model.layers)
+    # Multimodal models (e.g. Mistral3ForConditionalGeneration) nest the
+    # text decoder inside model.language_model
+    if (
+        hasattr(model, "model")
+        and hasattr(model.model, "language_model")
+        and hasattr(model.model.language_model, "layers")
+    ):
+        return list(model.model.language_model.layers)
     # GPT-2, GPT-J
     if hasattr(model, "transformer") and hasattr(model.transformer, "h"):
         return list(model.transformer.h)
@@ -740,6 +748,13 @@ def _get_embedding_module(model: Any) -> Any:
     # Llama, Mistral, Phi, Qwen, Gemma
     if hasattr(model, "model") and hasattr(model.model, "embed_tokens"):
         return model.model.embed_tokens
+    # Multimodal models (e.g. Mistral3ForConditionalGeneration)
+    if (
+        hasattr(model, "model")
+        and hasattr(model.model, "language_model")
+        and hasattr(model.model.language_model, "embed_tokens")
+    ):
+        return model.model.language_model.embed_tokens
     # GPT-2, GPT-J
     if hasattr(model, "transformer") and hasattr(model.transformer, "wte"):
         return model.transformer.wte
@@ -776,6 +791,13 @@ def _get_final_norm(model: Any) -> Any:
     # Llama, Mistral, Phi, Qwen, Gemma
     if hasattr(model, "model") and hasattr(model.model, "norm"):
         return model.model.norm
+    # Multimodal models (e.g. Mistral3ForConditionalGeneration)
+    if (
+        hasattr(model, "model")
+        and hasattr(model.model, "language_model")
+        and hasattr(model.model.language_model, "norm")
+    ):
+        return model.model.language_model.norm
     # GPT-2
     if hasattr(model, "transformer") and hasattr(model.transformer, "ln_f"):
         return model.transformer.ln_f
@@ -893,8 +915,10 @@ def _estimate_chunk_size(
     from transformers import AutoConfig
 
     config = AutoConfig.from_pretrained(model_name)
-    hidden_size = config.hidden_size
-    intermediate_size = getattr(config, "intermediate_size", hidden_size * 4)
+    # Multimodal models nest text params under text_config
+    text_cfg = getattr(config, "text_config", config)
+    hidden_size = text_cfg.hidden_size
+    intermediate_size = getattr(text_cfg, "intermediate_size", hidden_size * 4)
 
     bytes_per_param = 2 if dtype in (torch.float16, torch.bfloat16) else 4
     # Approximate params per layer: 4 attention matrices + 3 FFN matrices
@@ -988,13 +1012,27 @@ class ChunkedLocalBackend(ExtractionBackend):
         hold the full weights while GPU VRAM is not.
         """
         if not hasattr(self, "_full_model"):
-            from transformers import AutoModelForCausalLM
+            from transformers import AutoConfig, AutoModelForCausalLM
 
-            self._full_model = AutoModelForCausalLM.from_pretrained(
-                self.model_name,
-                torch_dtype=self.dtype,
-                attn_implementation="eager",
-            )
+            config = AutoConfig.from_pretrained(self.model_name)
+
+            # Multimodal / conditional-generation models (e.g. Mistral3)
+            # are not registered under AutoModelForCausalLM. Detect them
+            # via the presence of text_config and load with the right class.
+            if hasattr(config, "text_config"):
+                from transformers import AutoModelForImageTextToText
+
+                self._full_model = AutoModelForImageTextToText.from_pretrained(
+                    self.model_name,
+                    torch_dtype=self.dtype,
+                    attn_implementation="eager",
+                )
+            else:
+                self._full_model = AutoModelForCausalLM.from_pretrained(
+                    self.model_name,
+                    torch_dtype=self.dtype,
+                    attn_implementation="eager",
+                )
             self._full_model.eval()
         return self._full_model
 
@@ -1208,6 +1246,13 @@ class ChunkedLocalBackend(ExtractionBackend):
         # Llama, Mistral, Qwen, Gemma
         if hasattr(model, "model") and hasattr(model.model, "rotary_emb"):
             return "model.rotary_emb"
+        # Multimodal models (e.g. Mistral3ForConditionalGeneration)
+        if (
+            hasattr(model, "model")
+            and hasattr(model.model, "language_model")
+            and hasattr(model.model.language_model, "rotary_emb")
+        ):
+            return "model.language_model.rotary_emb"
         return None
 
     # --- ExtractionBackend interface ---

--- a/src/lmprobe/extraction.py
+++ b/src/lmprobe/extraction.py
@@ -130,9 +130,18 @@ def get_num_layers_from_config(model_name: str) -> int:
 
     # Different model architectures use different config field names
     # Try common ones in order of prevalence
-    for attr in ("num_hidden_layers", "n_layer", "num_layers", "n_layers"):
+    layer_attrs = ("num_hidden_layers", "n_layer", "num_layers", "n_layers")
+    for attr in layer_attrs:
         if hasattr(config, attr):
             return int(getattr(config, attr))
+
+    # Multimodal models (e.g. Mistral-Small-3.1) nest the text transformer
+    # config under text_config
+    if hasattr(config, "text_config"):
+        text_config = config.text_config
+        for attr in layer_attrs:
+            if hasattr(text_config, attr):
+                return int(getattr(text_config, attr))
 
     raise ValueError(
         f"Could not determine layer count from config for {model_name}. "


### PR DESCRIPTION
## Summary
- Adds support for multimodal models (e.g. Mistral-Small-3.1) that nest the text decoder under `model.language_model` instead of directly under `model.model`
- Handles decoder layer resolution, embedding lookup, final norm, rotary embedding, chunk size estimation, and model loading (`AutoModelForImageTextToText`)
- Adds `text_config` fallback in `get_num_layers_from_config` for multimodal model configs

## Test plan
- [ ] Verify existing tests still pass (no regressions for standard causal LM architectures)
- [ ] Test with a multimodal model (e.g. `mistralai/Mistral-Small-3.1-24B-Instruct-2503`) to confirm extraction works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)