### PR TITLE
Add SampleScan: breadth-first activation indexing

### DIFF
--- a/docs/design/005-sample-scan.md
+++ b/docs/design/005-sample-scan.md
@@ -1,0 +1,147 @@
+# 005: SampleScan — Breadth-First Activation Indexing
+
+**Status**: Draft  
+**Date**: 2026-04-15  
+**Author**: Toast
+
+## Context
+
+Current interpretability workflows are depth-first: pick a layer, pick a contrast, extract full activations, probe. This is expensive to redo when hypotheses change and infeasible at frontier scale. SampleScan inverts this: produce a compressed, multi-lens index of model behavior across the entire depth and token axis in a single forward pass, then surgically retrieve full activations only where the index indicates signal.
+
+## Core Concept
+
+A SampleScan is a compressed activation index consisting of:
+
+1. **Samples**: tokenized prompts (and completions) run through the model
+2. **Deltas**: per-layer attention and MLP update vectors (the output of each sub-layer *before* it's added to the residual stream — not cumulative residual state)
+3. **Channels**: named PCA bases fit on different subsets/contrasts of the samples (e.g. "global", "honesty", "deception")
+4. **Projections**: per-token, per-layer, per-delta projections onto the top-k principal components of each channel
+
+A scan enables cheap exploratory queries like "which layer/token/delta best separates contrast X?" without storing full activations.
+
+## Single-Pass Pipeline
+
+The critical design insight: PCA fitting and projection happen *between layer chunks* during the forward pass, not as a separate phase. The chunked pipeline already has idle GPU time while offloading layer weights — PCA slots into that window on CPU.
+
+### Per-Layer Loop
+
+```
+For each layer L:
+  GPU:  Run layer L forward on all sample batches
+        Capture attn_delta and mlp_delta (pre-residual update vectors)
+  GPU→CPU:  Offload layer L weights (existing chunked pipeline behavior)
+  CPU:  Fit PCA on [N_tokens_total, hidden_dim] for attn_delta
+  CPU:  Fit PCA on [N_tokens_total, hidden_dim] for mlp_delta
+        (one fit per channel — global channel fits on all; contrastive channels fit on subsets)
+  CPU:  Project all deltas onto top-k PCs for each channel
+  CPU:  Append projections + coordinates to flat storage
+  CPU:  Discard full deltas for layer L
+  GPU:  Load layer L+1
+```
+
+### Memory Budget
+
+Peak memory is one layer's deltas across all samples. For a 7B model (hidden_dim=4096), 1000 samples averaging 100 tokens:
+
+```
+1000 samples × 100 tokens × 4096 hidden × 2 (attn+mlp) × 2 bytes (float16) ≈ 1.6 GB
+```
+
+Well within a 128GB CPU memory budget. The full delta set is never materialized across layers.
+
+### PCA Implementation
+
+- Use sklearn `IncrementalPCA` for CPU-only environments
+- Use cuml `IncrementalPCA` when RAPIDS is available (GPU-accelerated fitting during the CPU phase)
+- Each (layer, delta_type, channel) gets its own PCA fit — `n_layers × 2 × n_channels` fits total
+- Only the top-k components are retained (k=12 default, configurable per channel)
+
+## Storage Schema
+
+### Flat Sparse Projection Store
+
+Variable sequence lengths across samples are handled with flat storage and a coordinate index — no padding or ragged arrays:
+
+```
+scan_name/
+  metadata.json
+  samples/
+    samples.parquet            # sample_id, prompt_text, completion_text, token_ids, labels...
+  channels/
+    0_global/
+      config.json              # channel name, k, fit_method
+      basis.npy                # [n_layers, 2, hidden_dim, k] float16
+    1_<contrast_name>/
+      config.json
+      basis.npy
+      fit_metadata.json        # which sample_ids/labels used to fit
+  projections/
+    values.npy                 # [N_total, n_channels, k] float16
+    coords.parquet             # N_total rows: sample_id, layer, token_pos, delta_type
+```
+
+**`values.npy`**: flat stack of all projected vectors. Row i is the projection of one token at one layer and delta type across all channels.
+
+**`coords.parquet`**: coordinate index. Standard parquet filters give fast slicing (e.g. "all projections for sample 123 at layer 45") without loading the full values array.
+
+**`basis.npy`**: the PCA basis matrices needed to interpret projections or add channels post-hoc.
+
+### Adding Channels Post-Hoc
+
+Adding a new channel requires either:
+- (a) Re-running the forward pass for the fit subset to recompute deltas, or
+- (b) Having cached full deltas (user's choice to retain them)
+
+Once the new basis is fit, projecting existing samples is cheap: load basis, load full deltas (or re-extract), project, append new columns to `values.npy`.
+
+## Query API
+
+```python
+scan = SampleScan.load("my_scan")
+
+# Retrieve projections for a sample
+proj = scan.get_projections(sample_id=123, channel="global")
+# Returns [seq_len, n_layers, 2, k] by filtering coords + slicing values
+
+# Separability map: which (layer, delta_type) best separates a binary label?
+signal_map = scan.separability_map(
+    channel="global",
+    labels=scan.samples["is_honest"],
+)
+# Returns [n_layers, 2] array of separability scores (e.g. AUROC or t-statistic)
+
+# Nearest neighbors in PC space at a specific coordinate
+neighbors = scan.nearest_neighbors(
+    sample_id=123, layer=45, delta="mlp", channel="global", n=50
+)
+```
+
+## Second-Pass Retrieval (Post-MVP)
+
+Given coordinates flagged by the scan, re-run the chunked forward pass with targeted hooks that only materialize full-precision activations at those points:
+
+```python
+full_acts = scan.retrieve_full(
+    coordinates=[(123, 45, 17, "mlp"), (123, 46, 17, "mlp"), ...],
+    precision="float32",
+)
+```
+
+This is deferred from the MVP — it requires modifying the chunked pipeline to support selective materialization, and the retrieval patterns will be clearer once we've worked with real scan data.
+
+## Open Design Questions
+
+1. **Float precision for projections**: float16 is likely sufficient; validate on GoT downstream task
+2. **Token alignment**: for decoder-only models, the delta at position i is computed when processing token i. Document clearly.
+3. **MoE models**: project the combined MLP delta (post-routing, pre-residual-add), not individual expert outputs — that's what enters the residual stream
+4. **Contrastive channel fit methods** (post-MVP): PCA on difference vectors, PCA on labeled subset, LDA, etc.
+5. **cuml vs sklearn PCA**: cuml is faster but adds a RAPIDS dependency. Default to sklearn, detect cuml at runtime?
+
+## MVP Scope
+
+- Single model (Qwen 2.5 7B for fast iteration, then scale to larger)
+- Global channel only (defer contrastive channels)
+- Single-pass delta extraction + PCA fit + projection
+- Flat sparse storage with parquet coordinate index
+- Query API: `get_projections`, `separability_map`
+- **Validation**: run on Geometry of Truth (GoT) dataset. The scan should automatically identify layer ~45 as the truth-separability peak, matching known results. This is a clean binary test of whether the compressed index preserves enough signal.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ remote = [
 s3 = [
     "boto3>=1.26",
 ]
+scan = [
+    "pyarrow>=14.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
@@ -57,6 +60,7 @@ dev = [
     "black>=23.0",
     "moto[s3]>=5.0",
     "mypy>=1.10",
+    "pyarrow>=14.0",
 ]
 auto = [
     "skglm>=0.3",

--- a/src/lmprobe/__init__.py
+++ b/src/lmprobe/__init__.py
@@ -87,6 +87,7 @@ __all__ = [
     "set_cache_dtype",
     "set_cache_limit",
     "set_max_threads",
+    "SampleScan",
     "set_profiling",
     "is_profiling",
     "cuml_available",
@@ -116,6 +117,10 @@ def set_max_threads(n: int) -> None:
 
 def __getattr__(name: str) -> Any:
     """Lazy import for optional modules."""
+    if name == "SampleScan":
+        from .sample_scan import SampleScan
+
+        return SampleScan
     if name == "cuml_available":
         from .classifiers import cuml_available
 

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -996,6 +996,8 @@ class ChunkedLocalBackend(ExtractionBackend):
         self._chunk_size = chunk_size
         self._tokenizer: PreTrainedTokenizerBase | None = None
         self._config: Any = None
+        self._num_layers: int | None = None
+        self._resolved_chunk_size: int | None = None
 
     @property
     def model(self) -> Any:
@@ -1022,9 +1024,22 @@ class ChunkedLocalBackend(ExtractionBackend):
         return self._config
 
     def _resolve_chunk_size(self) -> int:
+        if self._resolved_chunk_size is not None:
+            return self._resolved_chunk_size
         if isinstance(self._chunk_size, int):
-            return self._chunk_size
-        return _estimate_chunk_size(self.model_name, self.device, self.dtype)
+            self._resolved_chunk_size = self._chunk_size
+        else:
+            self._resolved_chunk_size = _estimate_chunk_size(
+                self.model_name, self.device, self.dtype,
+            )
+        return self._resolved_chunk_size
+
+    def _get_num_layers(self) -> int:
+        if self._num_layers is None:
+            from .extraction import get_num_layers_from_config
+
+            self._num_layers = get_num_layers_from_config(self.model_name)
+        return self._num_layers
 
     def _load_full_model_cpu(self) -> Any:
         """Load the full model on CPU with eager attention.
@@ -1324,15 +1339,13 @@ class ChunkedLocalBackend(ExtractionBackend):
         cache_position, position_embeddings, layer_types, decoder_layers,
         num_layers, chunk_size, model, device.
         """
-        from .extraction import get_num_layers_from_config
-
         tokenized = self.tokenizer(
             prompts, return_tensors="pt", padding=True,
         )
         input_ids = tokenized["input_ids"]
         attention_mask_2d = tokenized["attention_mask"]
 
-        num_layers = get_num_layers_from_config(self.model_name)
+        num_layers = self._get_num_layers()
         chunk_size = self._resolve_chunk_size()
 
         model = self._load_full_model_cpu()
@@ -1572,12 +1585,11 @@ class ChunkedLocalBackend(ExtractionBackend):
         from tqdm import tqdm
 
         from .activation_types import detect_moe_info
-        from .extraction import get_num_layers_from_config
 
         if signals is None:
             signals = ["attn_delta", "mlp_delta"]
 
-        num_layers = get_num_layers_from_config(self.model_name)
+        num_layers = self._get_num_layers()
         model = self._load_full_model_cpu()
         device = self.device
         chunk_size = self._resolve_chunk_size()

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1097,19 +1097,40 @@ class ChunkedLocalBackend(ExtractionBackend):
         # Compute rotary position embeddings
         # Some architectures (Llama, Mistral) return (cos, sin) tuples;
         # DeepSeek-V2 returns a single complex freqs_cis tensor.
-        position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | None = None
+        # Gemma3 computes per-layer-type embeddings via a layer_type arg.
+        position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | dict | None = None
+        layer_types: list[str] | None = None
         rotary_name = self._find_rotary_embedding_name(model)
         if rotary_name is not None:
             rotary_mod = model
             for part in rotary_name.split("."):
                 rotary_mod = getattr(rotary_mod, part)
             rotary_mod.to(device)
-            with torch.no_grad():
-                pe = rotary_mod(hidden_states.to(device), position_ids.to(device))
-                if isinstance(pe, tuple):
-                    position_embeddings = tuple(t.cpu() for t in pe)
-                else:
-                    position_embeddings = pe.cpu()
+
+            # Detect Gemma3-style per-layer-type rotary embeddings
+            text_cfg = getattr(
+                getattr(model, "config", None), "text_config",
+                getattr(model, "config", None),
+            )
+            layer_types_cfg = getattr(text_cfg, "layer_types", None)
+            if layer_types_cfg is not None:
+                layer_types = list(layer_types_cfg)
+                position_embeddings = {}
+                with torch.no_grad():
+                    for lt in set(layer_types):
+                        pe = rotary_mod(
+                            hidden_states.to(device),
+                            position_ids.to(device),
+                            layer_type=lt,
+                        )
+                        position_embeddings[lt] = tuple(t.cpu() for t in pe)
+            else:
+                with torch.no_grad():
+                    pe = rotary_mod(hidden_states.to(device), position_ids.to(device))
+                    if isinstance(pe, tuple):
+                        position_embeddings = tuple(t.cpu() for t in pe)
+                    else:
+                        position_embeddings = pe.cpu()
             rotary_mod.to("cpu")
 
         # --- Phase 2: Layer chunks ---
@@ -1127,12 +1148,20 @@ class ChunkedLocalBackend(ExtractionBackend):
             hs = hidden_states.to(device)
             mask_dev = causal_mask.to(device)
             pos_dev = position_ids.to(device)
-            pe_dev: tuple[torch.Tensor, ...] | torch.Tensor | None = None
+
+            # Pre-compute position embeddings on device
+            pe_dev_map: dict | tuple | torch.Tensor | None = None
             if position_embeddings is not None:
-                if isinstance(position_embeddings, tuple):
-                    pe_dev = tuple(t.to(device) for t in position_embeddings)
+                if isinstance(position_embeddings, dict):
+                    # Gemma3-style: dict of {layer_type: (cos, sin)}
+                    pe_dev_map = {
+                        lt: tuple(t.to(device) for t in pe)
+                        for lt, pe in position_embeddings.items()
+                    }
+                elif isinstance(position_embeddings, tuple):
+                    pe_dev_map = tuple(t.to(device) for t in position_embeddings)
                 else:
-                    pe_dev = position_embeddings.to(device)
+                    pe_dev_map = position_embeddings.to(device)
 
             with torch.no_grad():
                 for layer_idx in range(chunk_start, chunk_end):
@@ -1190,8 +1219,13 @@ class ChunkedLocalBackend(ExtractionBackend):
                         "use_cache": False,
                         "cache_position": cache_position.to(device),
                     }
-                    if pe_dev is not None:
-                        layer_kwargs["position_embeddings"] = pe_dev
+                    if pe_dev_map is not None:
+                        if isinstance(pe_dev_map, dict) and layer_types is not None:
+                            # Gemma3-style: select by layer type
+                            lt = layer_types[layer_idx]
+                            layer_kwargs["position_embeddings"] = pe_dev_map[lt]
+                        else:
+                            layer_kwargs["position_embeddings"] = pe_dev_map
 
                     output = layer_module(hs, **layer_kwargs)
                     hs = output[0] if isinstance(output, tuple) else output
@@ -1205,7 +1239,7 @@ class ChunkedLocalBackend(ExtractionBackend):
                             captured_router[layer_idx] = router_hook_output[0]
 
             hidden_states = hs.cpu()
-            del hs, mask_dev, pos_dev, pe_dev
+            del hs, mask_dev, pos_dev, pe_dev_map
 
             # Move chunk back to CPU
             for i in range(chunk_start, chunk_end):

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import torch
 
 if TYPE_CHECKING:
@@ -317,6 +318,28 @@ def _get_decoder_layers(model: Any) -> list[Any]:
         f"{type(model).__name__}. Supported architectures include "
         f"Llama, Mistral, Phi, GPT-2, GPT-NeoX, Falcon, MPT, OPT, "
         f"and other models using standard layer attribute paths."
+    )
+
+
+def _get_attn_submodule(layer: Any) -> Any:
+    """Get the self-attention submodule from a transformer layer."""
+    for name in ("self_attn", "attention", "attn"):
+        if hasattr(layer, name):
+            return getattr(layer, name)
+    raise ValueError(
+        f"Cannot find attention submodule in {type(layer).__name__}. "
+        f"Expected one of: self_attn, attention, attn"
+    )
+
+
+def _get_mlp_submodule(layer: Any) -> Any:
+    """Get the MLP/feed-forward submodule from a transformer layer."""
+    for name in ("mlp", "feed_forward", "ffn"):
+        if hasattr(layer, name):
+            return getattr(layer, name)
+    raise ValueError(
+        f"Cannot find MLP submodule in {type(layer).__name__}. "
+        f"Expected one of: mlp, feed_forward, ffn"
     )
 
 
@@ -1288,6 +1311,691 @@ class ChunkedLocalBackend(ExtractionBackend):
         ):
             return "model.language_model.rotary_emb"
         return None
+
+    # --- Shared chunked-pass setup ---
+
+    def _prepare_chunked_pass(
+        self, prompts: list[str],
+    ) -> dict[str, Any]:
+        """Run embedding phase and compute position embeddings.
+
+        Returns a dict with all state needed to iterate the layer loop:
+        hidden_states, attention_mask_2d, causal_mask, position_ids,
+        cache_position, position_embeddings, layer_types, decoder_layers,
+        num_layers, chunk_size, model, device.
+        """
+        from .extraction import get_num_layers_from_config
+
+        tokenized = self.tokenizer(
+            prompts, return_tensors="pt", padding=True,
+        )
+        input_ids = tokenized["input_ids"]
+        attention_mask_2d = tokenized["attention_mask"]
+
+        num_layers = get_num_layers_from_config(self.model_name)
+        chunk_size = self._resolve_chunk_size()
+
+        model = self._load_full_model_cpu()
+        device = self.device
+
+        # --- Embedding ---
+        embed = _get_embedding_module(model)
+        embed.to(device)
+        with torch.no_grad():
+            hidden_states = embed(input_ids.to(device)).cpu()
+        embed.to("cpu")
+
+        # Position IDs, cache position, causal mask
+        seq_len = input_ids.shape[1]
+        position_ids = attention_mask_2d.long().cumsum(-1) - 1
+        position_ids.masked_fill_(attention_mask_2d == 0, 1)
+        cache_position = torch.arange(seq_len)
+        causal_mask = _make_causal_mask(attention_mask_2d, self.dtype)
+
+        # Rotary position embeddings
+        position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | dict | None = None
+        layer_types: list[str] | None = None
+        rotary_name = self._find_rotary_embedding_name(model)
+        if rotary_name is not None:
+            rotary_mod = model
+            for part in rotary_name.split("."):
+                rotary_mod = getattr(rotary_mod, part)
+            rotary_mod.to(device)
+
+            text_cfg = getattr(
+                getattr(model, "config", None), "text_config",
+                getattr(model, "config", None),
+            )
+            layer_types_cfg = getattr(text_cfg, "layer_types", None)
+            if layer_types_cfg is not None:
+                layer_types = list(layer_types_cfg)
+                position_embeddings = {}
+                with torch.no_grad():
+                    for lt in set(layer_types):
+                        pe = rotary_mod(
+                            hidden_states.to(device),
+                            position_ids.to(device),
+                            layer_type=lt,
+                        )
+                        position_embeddings[lt] = tuple(t.cpu() for t in pe)
+            else:
+                with torch.no_grad():
+                    pe = rotary_mod(hidden_states.to(device), position_ids.to(device))
+                    if isinstance(pe, tuple):
+                        position_embeddings = tuple(t.cpu() for t in pe)
+                    else:
+                        position_embeddings = pe.cpu()
+            rotary_mod.to("cpu")
+
+        decoder_layers = _get_decoder_layers(model)
+
+        return {
+            "hidden_states": hidden_states,
+            "attention_mask_2d": attention_mask_2d,
+            "causal_mask": causal_mask,
+            "position_ids": position_ids,
+            "cache_position": cache_position,
+            "position_embeddings": position_embeddings,
+            "layer_types": layer_types,
+            "decoder_layers": decoder_layers,
+            "num_layers": num_layers,
+            "chunk_size": chunk_size,
+            "model": model,
+            "device": device,
+            "input_ids": input_ids,
+        }
+
+    def _compute_logits(
+        self, model: Any, hidden_states: torch.Tensor, device: str,
+    ) -> torch.Tensor:
+        """Run final norm + lm_head to produce logits."""
+        final_norm = _get_final_norm(model)
+        lm_head = _get_lm_head(model)
+        final_norm.to(device)
+        lm_head.to(device)
+        with torch.no_grad():
+            logits = lm_head(final_norm(hidden_states.to(device))).cpu()
+        final_norm.to("cpu")
+        lm_head.to("cpu")
+        return logits
+
+    @staticmethod
+    def _build_layer_kwargs(
+        mask_dev: torch.Tensor,
+        pos_dev: torch.Tensor,
+        cache_position: torch.Tensor,
+        pe_dev_map: Any,
+        layer_types: list[str] | None,
+        layer_idx: int,
+        device: str,
+    ) -> dict[str, Any]:
+        """Build the kwargs dict for a single layer forward call."""
+        layer_kwargs: dict[str, Any] = {
+            "attention_mask": mask_dev,
+            "position_ids": pos_dev,
+            "use_cache": False,
+            "cache_position": cache_position.to(device),
+        }
+        if pe_dev_map is not None:
+            if isinstance(pe_dev_map, dict) and layer_types is not None:
+                lt = layer_types[layer_idx]
+                layer_kwargs["position_embeddings"] = pe_dev_map[lt]
+            else:
+                layer_kwargs["position_embeddings"] = pe_dev_map
+        return layer_kwargs
+
+    @staticmethod
+    def _pe_to_device(
+        position_embeddings: Any, device: str,
+    ) -> Any:
+        """Move position embeddings to device."""
+        if position_embeddings is None:
+            return None
+        if isinstance(position_embeddings, dict):
+            return {
+                lt: tuple(t.to(device) for t in pe)
+                for lt, pe in position_embeddings.items()
+            }
+        elif isinstance(position_embeddings, tuple):
+            return tuple(t.to(device) for t in position_embeddings)
+        else:
+            return position_embeddings.to(device)
+
+    # --- Scan methods ---
+
+    # Valid signal names for scan_forward / project_forward
+    SCAN_SIGNALS = ("residual", "attn_delta", "mlp_delta", "router_logits")
+
+    def _resolve_signal_hooks(
+        self,
+        signals: list[str],
+        layer_module: Any,
+        layer_idx: int,
+        router_module_template: str | None,
+        model: Any,
+    ) -> tuple[
+        list[tuple[str, Any, list[torch.Tensor]]],  # [(signal_name, hook_handle, buffer)]
+        bool,  # capture_residual — no hook, just layer output
+    ]:
+        """Set up forward hooks for the requested signals on a single layer.
+
+        Returns list of (signal_name, hook_handle, buffer) for hookable signals,
+        plus a flag indicating whether to capture the residual (layer output).
+        """
+        hooks: list[tuple[str, Any, list[torch.Tensor]]] = []
+        capture_residual = False
+
+        for sig in signals:
+            if sig == "residual":
+                capture_residual = True
+                continue
+
+            buf: list[torch.Tensor] = []
+
+            def _hook(
+                _mod: Any, _inp: Any, out: Any,
+                _buf: list = buf,
+            ) -> None:
+                delta = out[0] if isinstance(out, tuple) else out
+                _buf.append(delta.detach().cpu())
+
+            if sig == "attn_delta":
+                mod = _get_attn_submodule(layer_module)
+                h = mod.register_forward_hook(_hook)
+                hooks.append((sig, h, buf))
+            elif sig == "mlp_delta":
+                mod = _get_mlp_submodule(layer_module)
+                h = mod.register_forward_hook(_hook)
+                hooks.append((sig, h, buf))
+            elif sig == "router_logits":
+                if router_module_template is None:
+                    continue  # skip silently — no MoE in this model
+                router_path = router_module_template.format(layer=layer_idx)
+                if router_path.startswith("model."):
+                    router_path = router_path[len("model."):]
+                try:
+                    router_mod = model
+                    for part in router_path.split("."):
+                        if part.isdigit():
+                            router_mod = router_mod[int(part)]
+                        else:
+                            router_mod = getattr(router_mod, part)
+                    h = router_mod.register_forward_hook(_hook)
+                    hooks.append((sig, h, buf))
+                except (AttributeError, IndexError):
+                    continue  # skip layers without routers
+
+        return hooks, capture_residual
+
+    def scan_forward(
+        self,
+        prompts: list[str],
+        signals: list[str] | None = None,
+        n_components: int = 64,
+        batch_size: int = 4,
+    ) -> tuple[
+        dict[str, Any],                # metadata
+        dict[str, np.ndarray],          # bases: {signal_name: [n_layers, dim, k_eff]}
+        np.ndarray,                     # projections [N_total, 1, k]
+        dict[str, list],                # coords {sample_id, layer, token_pos, signal}
+        list[list[int]],                # token_ids per sample
+        list[int],                      # seq_lengths per sample
+        torch.Tensor,                   # attention_mask [n_samples, max_seq_len]
+        dict[str, int],                 # signal_dims: {signal_name: dim}
+    ]:
+        """Run a full scan forward pass with between-chunk PCA.
+
+        Parameters
+        ----------
+        prompts : list[str]
+            Corpus prompts.
+        signals : list[str] or None
+            Which signals to capture. Defaults to ["attn_delta", "mlp_delta"].
+            Valid: "residual", "attn_delta", "mlp_delta", "router_logits".
+        n_components : int
+            Max PCA components per (layer, signal).
+        batch_size : int
+            Prompts per batch.
+
+        Returns all data needed to write a SampleScan to disk.
+        """
+        import gc
+
+        import numpy as np
+        from sklearn.decomposition import PCA
+        from tqdm import tqdm
+
+        from .activation_types import detect_moe_info
+        from .extraction import get_num_layers_from_config
+
+        if signals is None:
+            signals = ["attn_delta", "mlp_delta"]
+
+        num_layers = get_num_layers_from_config(self.model_name)
+        model = self._load_full_model_cpu()
+        device = self.device
+        chunk_size = self._resolve_chunk_size()
+        hidden_dim: int | None = None
+
+        # Detect MoE for router_logits signal
+        router_module_template: str | None = None
+        if "router_logits" in signals:
+            try:
+                moe_info = detect_moe_info(self.model_name)
+                if moe_info is not None:
+                    router_module_template = moe_info.router_module_template
+                else:
+                    signals = [s for s in signals if s != "router_logits"]
+            except Exception:
+                signals = [s for s in signals if s != "router_logits"]
+
+        # Tokenize all prompts
+        tokenized = self.tokenizer(
+            prompts, return_tensors="pt", padding=True,
+        )
+        all_input_ids = tokenized["input_ids"]
+        all_attention_mask = tokenized["attention_mask"]
+
+        # Per-sample token IDs (unpadded) and seq lengths
+        token_ids_per_sample: list[list[int]] = []
+        seq_lengths: list[int] = []
+        for i in range(len(prompts)):
+            mask_i = all_attention_mask[i]
+            real_len = int(mask_i.sum().item())
+            seq_lengths.append(real_len)
+            token_ids_per_sample.append(
+                all_input_ids[i, :real_len].tolist()
+            )
+
+        # Split into batches
+        n_samples = len(prompts)
+        batches: list[tuple[int, int]] = []
+        for start in range(0, n_samples, batch_size):
+            end = min(start + batch_size, n_samples)
+            batches.append((start, end))
+
+        # Run embedding for each batch
+        embed = _get_embedding_module(model)
+        embed.to(device)
+        batch_hidden_states: list[torch.Tensor] = []
+        batch_pos_ids: list[torch.Tensor] = []
+        batch_causal_masks: list[torch.Tensor] = []
+        batch_cache_positions: list[torch.Tensor] = []
+
+        for start, end in batches:
+            ids = all_input_ids[start:end]
+            mask = all_attention_mask[start:end]
+
+            with torch.no_grad():
+                hs = embed(ids.to(device)).cpu()
+            batch_hidden_states.append(hs)
+
+            seq_len = ids.shape[1]
+            pos_ids = mask.long().cumsum(-1) - 1
+            pos_ids.masked_fill_(mask == 0, 1)
+            batch_pos_ids.append(pos_ids)
+            batch_causal_masks.append(_make_causal_mask(mask, self.dtype))
+            batch_cache_positions.append(torch.arange(seq_len))
+
+            if hidden_dim is None:
+                hidden_dim = hs.shape[-1]
+
+        embed.to("cpu")
+
+        # Rotary embeddings
+        position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | dict | None = None
+        layer_types: list[str] | None = None
+        rotary_name = self._find_rotary_embedding_name(model)
+        if rotary_name is not None:
+            rotary_mod = model
+            for part in rotary_name.split("."):
+                rotary_mod = getattr(rotary_mod, part)
+            rotary_mod.to(device)
+
+            text_cfg = getattr(
+                getattr(model, "config", None), "text_config",
+                getattr(model, "config", None),
+            )
+            layer_types_cfg = getattr(text_cfg, "layer_types", None)
+            if layer_types_cfg is not None:
+                layer_types = list(layer_types_cfg)
+                position_embeddings = {}
+                with torch.no_grad():
+                    for lt in set(layer_types):
+                        pe = rotary_mod(
+                            batch_hidden_states[0].to(device),
+                            batch_pos_ids[0].to(device),
+                            layer_type=lt,
+                        )
+                        position_embeddings[lt] = tuple(t.cpu() for t in pe)
+            else:
+                with torch.no_grad():
+                    pe = rotary_mod(
+                        batch_hidden_states[0].to(device),
+                        batch_pos_ids[0].to(device),
+                    )
+                    if isinstance(pe, tuple):
+                        position_embeddings = tuple(t.cpu() for t in pe)
+                    else:
+                        position_embeddings = pe.cpu()
+            rotary_mod.to("cpu")
+
+        assert hidden_dim is not None
+        decoder_layers = _get_decoder_layers(model)
+
+        # Accumulators
+        # Per-signal basis: {signal_name: [n_layers, dim, k_eff]}
+        # We'll build these after seeing actual dims from hooks
+        signal_bases: dict[str, list[np.ndarray | None]] = {
+            sig: [None] * num_layers for sig in signals
+        }
+        signal_dims: dict[str, int] = {}  # discovered during first chunk
+        all_proj_chunks: list[np.ndarray] = []
+        all_coord_sample_id: list[int] = []
+        all_coord_layer: list[int] = []
+        all_coord_token_pos: list[int] = []
+        all_coord_signal: list[int] = []
+
+        # --- Layer chunk loop ---
+        n_chunks = (num_layers + chunk_size - 1) // chunk_size
+        chunk_pbar = tqdm(
+            range(0, num_layers, chunk_size),
+            desc="Scan: layer chunks",
+            total=n_chunks,
+        )
+        for chunk_start in chunk_pbar:
+            chunk_end = min(chunk_start + chunk_size, num_layers)
+            chunk_pbar.set_postfix(layers=f"{chunk_start}-{chunk_end-1}")
+
+            for i in range(chunk_start, chunk_end):
+                decoder_layers[i].to(device)
+
+            # {layer_idx: {signal_name: [tensor_per_batch, ...]}}
+            per_layer_captures: dict[int, dict[str, list[torch.Tensor]]] = {
+                L: {sig: [] for sig in signals}
+                for L in range(chunk_start, chunk_end)
+            }
+
+            for batch_idx, (start, end) in enumerate(batches):
+                hs = batch_hidden_states[batch_idx].to(device)
+                mask_dev = batch_causal_masks[batch_idx].to(device)
+                pos_dev = batch_pos_ids[batch_idx].to(device)
+                pe_dev = self._pe_to_device(position_embeddings, device)
+
+                with torch.no_grad():
+                    for layer_idx in range(chunk_start, chunk_end):
+                        layer_module = decoder_layers[layer_idx]
+
+                        hook_list, capture_residual = self._resolve_signal_hooks(
+                            signals, layer_module, layer_idx,
+                            router_module_template, model,
+                        )
+
+                        layer_kwargs = self._build_layer_kwargs(
+                            mask_dev, pos_dev, batch_cache_positions[batch_idx],
+                            pe_dev, layer_types, layer_idx, device,
+                        )
+
+                        output = layer_module(hs, **layer_kwargs)
+                        hs = output[0] if isinstance(output, tuple) else output
+
+                        # Collect hooked signals
+                        for sig_name, handle, buf in hook_list:
+                            handle.remove()
+                            if buf:
+                                per_layer_captures[layer_idx][sig_name].append(buf[0])
+
+                        # Residual = layer output (already in hs)
+                        if capture_residual:
+                            per_layer_captures[layer_idx]["residual"].append(
+                                hs.detach().cpu()
+                            )
+
+                batch_hidden_states[batch_idx] = hs.cpu()
+                del hs, mask_dev, pos_dev, pe_dev
+
+            # Offload chunk
+            for i in range(chunk_start, chunk_end):
+                decoder_layers[i].to("cpu")
+            gc.collect()
+            if torch.cuda.is_available() and device != "cpu":
+                torch.cuda.empty_cache()
+
+            # --- Between-chunk PCA ---
+            pca_items = [
+                (layer_idx, sig_idx, sig_name)
+                for layer_idx in range(chunk_start, chunk_end)
+                for sig_idx, sig_name in enumerate(signals)
+            ]
+            for layer_idx, sig_idx, sig_name in tqdm(
+                pca_items,
+                desc=f"  PCA fit (layers {chunk_start}-{chunk_end-1})",
+                leave=False,
+            ):
+                captures = per_layer_captures[layer_idx][sig_name]
+                if not captures:
+                    continue
+
+                stacked = torch.cat(captures, dim=0)  # [B_total, S, dim]
+                B_total, S, dim = stacked.shape
+                flat = stacked.reshape(-1, dim).float().numpy()
+
+                # Record signal dimension
+                if sig_name not in signal_dims:
+                    signal_dims[sig_name] = dim
+
+                k = min(n_components, flat.shape[0] - 1, dim)
+                pca = PCA(n_components=k)
+                pca.fit(flat)
+
+                # Store basis: components_ is [k, dim], we store [dim, k]
+                basis = pca.components_.T.astype(np.float16)
+                signal_bases[sig_name][layer_idx] = basis
+
+                # Project
+                projected = pca.transform(flat).astype(np.float16)
+                if k < n_components:
+                    padded = np.zeros(
+                        (projected.shape[0], n_components), dtype=np.float16,
+                    )
+                    padded[:, :k] = projected
+                    projected = padded
+
+                all_proj_chunks.append(projected)
+
+                for sample_idx in range(B_total):
+                    for tok in range(S):
+                        all_coord_sample_id.append(sample_idx)
+                        all_coord_layer.append(layer_idx)
+                        all_coord_token_pos.append(tok)
+                        all_coord_signal.append(sig_idx)
+
+                del stacked, flat, projected
+
+            del per_layer_captures
+            gc.collect()
+
+        # Assemble per-signal basis arrays: {sig: [n_layers, dim, k_eff]}
+        final_bases: dict[str, np.ndarray] = {}
+        for sig_name in signals:
+            dim = signal_dims.get(sig_name, hidden_dim)
+            k_eff = min(n_components, dim)
+            basis_arr = np.zeros((num_layers, dim, k_eff), dtype=np.float16)
+            for L in range(num_layers):
+                layer_basis = signal_bases[sig_name][L]
+                if layer_basis is not None:
+                    actual_k = layer_basis.shape[1]
+                    basis_arr[L, :, :actual_k] = layer_basis
+            final_bases[sig_name] = basis_arr
+
+        # Stack projections
+        all_projections = np.concatenate(all_proj_chunks, axis=0)
+        all_projections = all_projections[:, np.newaxis, :]  # [N_total, 1, k]
+
+        metadata = {
+            "model_id": self.model_name,
+            "hidden_dim": hidden_dim,
+            "n_layers": num_layers,
+            "n_components": n_components,
+            "n_samples": n_samples,
+            "signals": signals,
+        }
+
+        coords = {
+            "sample_id": all_coord_sample_id,
+            "layer": all_coord_layer,
+            "token_pos": all_coord_token_pos,
+            "signal": all_coord_signal,
+        }
+
+        return (
+            metadata,
+            final_bases,
+            all_projections,
+            coords,
+            token_ids_per_sample,
+            seq_lengths,
+            all_attention_mask,
+            signal_dims,
+        )
+
+    def project_forward(
+        self,
+        prompt: str,
+        bases: dict[str, np.ndarray],
+        signals: list[str],
+        include_logits: bool = True,
+    ) -> tuple[np.ndarray, list[int], torch.Tensor | None]:
+        """Run a single-prompt forward pass, projecting deltas onto stored bases.
+
+        Parameters
+        ----------
+        prompt : str
+            The prompt to forward-pass.
+        bases : dict[str, np.ndarray]
+            Maps signal name to basis [n_layers, dim, k_eff].
+        signals : list[str]
+            Signal names in order.
+        include_logits : bool
+            Whether to compute logits for surprise strip.
+
+        Returns
+        -------
+        tuple
+            (projections, token_ids, logits)
+            - projections: [seq_len, n_layers, n_signals, max_k] float32
+            - token_ids: list of int token IDs (unpadded)
+            - logits: [1, seq_len, vocab_size] or None
+        """
+        import gc
+
+        import numpy as np
+
+        from .activation_types import detect_moe_info
+
+        ctx = self._prepare_chunked_pass([prompt])
+        hidden_states = ctx["hidden_states"]
+        model = ctx["model"]
+        device = ctx["device"]
+        decoder_layers = ctx["decoder_layers"]
+        num_layers = ctx["num_layers"]
+        chunk_size = ctx["chunk_size"]
+        causal_mask = ctx["causal_mask"]
+        position_ids = ctx["position_ids"]
+        cache_position = ctx["cache_position"]
+        position_embeddings = ctx["position_embeddings"]
+        layer_types = ctx["layer_types"]
+        attention_mask_2d = ctx["attention_mask_2d"]
+        input_ids = ctx["input_ids"]
+
+        seq_len = input_ids.shape[1]
+        real_len = int(attention_mask_2d[0].sum().item())
+        token_ids = input_ids[0, :real_len].tolist()
+
+        # Find max k across all signal bases
+        max_k = max(b.shape[2] for b in bases.values())
+        n_signals = len(signals)
+        projections = np.zeros(
+            (seq_len, num_layers, n_signals, max_k), dtype=np.float32,
+        )
+
+        # Convert bases to torch
+        bases_torch = {
+            sig: torch.from_numpy(b).float() for sig, b in bases.items()
+        }
+
+        # Router template for router_logits
+        router_module_template: str | None = None
+        if "router_logits" in signals:
+            try:
+                moe_info = detect_moe_info(self.model_name)
+                if moe_info is not None:
+                    router_module_template = moe_info.router_module_template
+            except Exception:
+                pass
+
+        for chunk_start in range(0, num_layers, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, num_layers)
+
+            for i in range(chunk_start, chunk_end):
+                decoder_layers[i].to(device)
+
+            hs = hidden_states.to(device)
+            mask_dev = causal_mask.to(device)
+            pos_dev = position_ids.to(device)
+            pe_dev = self._pe_to_device(position_embeddings, device)
+
+            with torch.no_grad():
+                for layer_idx in range(chunk_start, chunk_end):
+                    layer_module = decoder_layers[layer_idx]
+
+                    hook_list, capture_residual = self._resolve_signal_hooks(
+                        signals, layer_module, layer_idx,
+                        router_module_template, model,
+                    )
+
+                    layer_kwargs = self._build_layer_kwargs(
+                        mask_dev, pos_dev, cache_position,
+                        pe_dev, layer_types, layer_idx, device,
+                    )
+
+                    output = layer_module(hs, **layer_kwargs)
+                    hs = output[0] if isinstance(output, tuple) else output
+
+                    # Project hooked signals
+                    for sig_name, handle, buf in hook_list:
+                        handle.remove()
+                        if buf and sig_name in bases_torch:
+                            sig_idx = signals.index(sig_name)
+                            delta = buf[0][0].float()  # [seq_len, dim]
+                            b = bases_torch[sig_name][layer_idx]  # [dim, k]
+                            k = b.shape[1]
+                            proj = (delta @ b).numpy()
+                            projections[:, layer_idx, sig_idx, :k] = proj
+
+                    # Project residual
+                    if capture_residual and "residual" in bases_torch:
+                        sig_idx = signals.index("residual")
+                        delta = hs[0].cpu().float()
+                        b = bases_torch["residual"][layer_idx]
+                        k = b.shape[1]
+                        proj = (delta @ b).numpy()
+                        projections[:, layer_idx, sig_idx, :k] = proj
+
+            hidden_states = hs.cpu()
+            del hs, mask_dev, pos_dev, pe_dev
+
+            for i in range(chunk_start, chunk_end):
+                decoder_layers[i].to("cpu")
+            gc.collect()
+            if torch.cuda.is_available() and device != "cpu":
+                torch.cuda.empty_cache()
+
+        logits = None
+        if include_logits:
+            logits = self._compute_logits(model, hidden_states, device)
+
+        return projections, token_ids, logits
 
     # --- ExtractionBackend interface ---
 

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -2765,7 +2765,6 @@ class DiskOffloadBackend(ExtractionBackend):
         limited CPU memory.
         """
         import gc
-        import math
 
         import numpy as np
         from sklearn.decomposition import PCA
@@ -2799,7 +2798,6 @@ class DiskOffloadBackend(ExtractionBackend):
             )
 
         n_samples = len(prompts)
-        n_batches = math.ceil(n_samples / batch_size)
         batches = [
             (s, min(s + batch_size, n_samples))
             for s in range(0, n_samples, batch_size)
@@ -3090,7 +3088,6 @@ class DiskOffloadBackend(ExtractionBackend):
         layer weights from safetensors instead of keeping the model in RAM.
         """
         import gc
-        import math
 
         config = self._get_config()
         model = self._get_model_skeleton()

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1427,7 +1427,9 @@ class ChunkedLocalBackend(ExtractionBackend):
         final_norm.to(device)
         lm_head.to(device)
         with torch.no_grad():
-            logits = lm_head(final_norm(hidden_states.to(device))).cpu()
+            logits: torch.Tensor = lm_head(
+                final_norm(hidden_states.to(device)),
+            ).cpu()
         final_norm.to("cpu")
         lm_head.to("cpu")
         return logits

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -982,6 +982,12 @@ class ChunkedLocalBackend(ExtractionBackend):
         Model dtype — ``torch.bfloat16`` recommended for large models.
     chunk_size : int or ``"auto"``
         Number of layers per chunk. ``"auto"`` estimates from available VRAM.
+    attn_implementation : str
+        Attention implementation passed to ``from_pretrained`` (``"sdpa"``,
+        ``"eager"``, ``"flash_attention_2"``). Default ``"sdpa"`` — avoids
+        materializing the full ``[B, H, T, T]`` attention matrix, which is
+        the usual OOM culprit on long sequences. Use ``"eager"`` only if a
+        custom signal hook needs the materialized attention weights.
     """
 
     def __init__(
@@ -990,10 +996,12 @@ class ChunkedLocalBackend(ExtractionBackend):
         device: str = "cpu",
         dtype: torch.dtype = torch.bfloat16,
         chunk_size: int | str = "auto",
+        attn_implementation: str = "sdpa",
     ):
         super().__init__(model_name, device)
         self.dtype = dtype
         self._chunk_size = chunk_size
+        self._attn_implementation = attn_implementation
         self._tokenizer: PreTrainedTokenizerBase | None = None
         self._config: Any = None
         self._num_layers: int | None = None
@@ -1042,12 +1050,18 @@ class ChunkedLocalBackend(ExtractionBackend):
         return self._num_layers
 
     def _load_full_model_cpu(self) -> Any:
-        """Load the full model on CPU with eager attention.
+        """Load the full model on CPU.
 
         For the chunked backend, the model is always loaded fully on CPU.
         The chunking benefit comes from only moving subset of layers to
         GPU at a time — for outsized models, CPU RAM is sufficient to
         hold the full weights while GPU VRAM is not.
+
+        Uses ``self._attn_implementation`` (default ``"sdpa"``) for the
+        attention kernel. ``"sdpa"`` avoids materializing the full
+        ``[B, H, T, T]`` softmax tensor, eliminating the usual OOM on
+        long sequences. Pass ``attn_implementation="eager"`` at construction
+        time if a custom signal hook needs the materialized attention weights.
         """
         if not hasattr(self, "_full_model"):
             from transformers import AutoConfig, AutoModelForCausalLM
@@ -1063,13 +1077,13 @@ class ChunkedLocalBackend(ExtractionBackend):
                 self._full_model = AutoModelForImageTextToText.from_pretrained(
                     self.model_name,
                     torch_dtype=self.dtype,
-                    attn_implementation="eager",
+                    attn_implementation=self._attn_implementation,
                 )
             else:
                 self._full_model = AutoModelForCausalLM.from_pretrained(
                     self.model_name,
                     torch_dtype=self.dtype,
-                    attn_implementation="eager",
+                    attn_implementation=self._attn_implementation,
                 )
             self._full_model.eval()
         return self._full_model
@@ -1683,23 +1697,23 @@ class ChunkedLocalBackend(ExtractionBackend):
                 getattr(model, "config", None),
             )
             layer_types_cfg = getattr(text_cfg, "layer_types", None)
-            if layer_types_cfg is not None:
+            # Use a single sample's pos_ids so cos/sin broadcast to any batch size
+            pe_hs = batch_hidden_states[0][:1].to(device)
+            pe_pos = batch_pos_ids[0][:1].to(device)
+
+            unique_types = set(layer_types_cfg) if layer_types_cfg is not None else set()
+            if len(unique_types) > 1:
                 layer_types = list(layer_types_cfg)
                 position_embeddings = {}
                 with torch.no_grad():
-                    for lt in set(layer_types):
-                        pe = rotary_mod(
-                            batch_hidden_states[0].to(device),
-                            batch_pos_ids[0].to(device),
-                            layer_type=lt,
-                        )
+                    for lt in unique_types:
+                        pe = rotary_mod(pe_hs, pe_pos, layer_type=lt)
                         position_embeddings[lt] = tuple(t.cpu() for t in pe)
             else:
+                if layer_types_cfg is not None:
+                    layer_types = list(layer_types_cfg)
                 with torch.no_grad():
-                    pe = rotary_mod(
-                        batch_hidden_states[0].to(device),
-                        batch_pos_ids[0].to(device),
-                    )
+                    pe = rotary_mod(pe_hs, pe_pos)
                     if isinstance(pe, tuple):
                         position_embeddings = tuple(t.cpu() for t in pe)
                     else:
@@ -2722,6 +2736,558 @@ class DiskOffloadBackend(ExtractionBackend):
             router_logits=captured_router if captured_router else None,
             hidden_per_layer=captured_hidden if captured_hidden else None,
         )
+
+    # --- Scan: full-dataset layer-by-layer with PCA ---
+
+    def scan_forward(
+        self,
+        prompts: list[str],
+        signals: list[str] | None = None,
+        n_components: int = 64,
+        batch_size: int = 4,
+        generative_masks: list[np.ndarray] | None = None,
+        external_bases: dict[str, np.ndarray] | None = None,
+    ) -> tuple[
+        dict[str, Any],                # metadata
+        dict[str, np.ndarray],          # bases
+        np.ndarray,                     # projections [N_total, 1, k]
+        dict[str, list],                # coords
+        list[list[int]],                # token_ids per sample
+        list[int],                      # seq_lengths per sample
+        torch.Tensor,                   # attention_mask
+        dict[str, int],                 # signal_dims
+    ]:
+        """Run a full scan forward pass, loading layers from disk.
+
+        Same interface as ChunkedLocalBackend.scan_forward but loads each
+        layer's weights from safetensors files instead of keeping the full
+        model in CPU RAM. Enables scanning 70B+ models on machines with
+        limited CPU memory.
+        """
+        import gc
+        import math
+
+        import numpy as np
+        from sklearn.decomposition import PCA
+        from tqdm import tqdm
+
+        if signals is None:
+            signals = ["attn_delta", "mlp_delta"]
+
+        config = self._get_config()
+        model = self._get_model_skeleton()
+        layer_map, non_layer = self._get_shard_map()
+        device = self.device
+        num_layers = config.num_hidden_layers
+        hidden_dim: int | None = None
+
+        # --- Tokenize ---
+        tokenized = self.tokenizer(
+            prompts, return_tensors="pt", padding=True,
+        )
+        all_input_ids = tokenized["input_ids"]
+        all_attention_mask = tokenized["attention_mask"]
+
+        token_ids_per_sample: list[list[int]] = []
+        seq_lengths: list[int] = []
+        for i in range(len(prompts)):
+            mask_i = all_attention_mask[i]
+            real_len = int(mask_i.sum().item())
+            seq_lengths.append(real_len)
+            token_ids_per_sample.append(
+                all_input_ids[i, :real_len].tolist()
+            )
+
+        n_samples = len(prompts)
+        n_batches = math.ceil(n_samples / batch_size)
+        batches = [
+            (s, min(s + batch_size, n_samples))
+            for s in range(0, n_samples, batch_size)
+        ]
+
+        # --- Phase 1: Embedding ---
+        embed_tensors = [(n, f) for n, f in non_layer if "embed_tokens" in n]
+        embed_weights = self._load_tensors(embed_tensors, device)
+        embed = _get_embedding_module(model)
+        _materialize_module(embed, embed_weights, "model.embed_tokens.", device)
+        del embed_weights
+
+        batch_hidden_states: list[torch.Tensor] = []
+        batch_pos_ids: list[torch.Tensor] = []
+        batch_causal_masks: list[torch.Tensor] = []
+        batch_cache_positions: list[torch.Tensor] = []
+
+        with torch.no_grad():
+            for start, end in batches:
+                ids = all_input_ids[start:end]
+                mask = all_attention_mask[start:end]
+                hs = embed(ids.to(device)).cpu()
+                batch_hidden_states.append(hs)
+
+                seq_len = ids.shape[1]
+                pos_ids = mask.long().cumsum(-1) - 1
+                pos_ids.masked_fill_(mask == 0, 1)
+                batch_pos_ids.append(pos_ids)
+                batch_causal_masks.append(_make_causal_mask(mask, self.dtype))
+                batch_cache_positions.append(torch.arange(seq_len))
+
+                if hidden_dim is None:
+                    hidden_dim = hs.shape[-1]
+
+        _free_module(embed)
+        torch.cuda.empty_cache()
+
+        # --- Rotary embeddings ---
+        position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | dict | None = None
+        layer_types: list[str] | None = None
+        rotary_name = ChunkedLocalBackend._find_rotary_embedding_name(model)
+        if rotary_name is not None:
+            rotary_mod = model
+            for part in rotary_name.split("."):
+                rotary_mod = getattr(rotary_mod, part)
+
+            # Re-initialize rotary from config
+            text_cfg = getattr(config, "text_config", config)
+            dim = getattr(text_cfg, "qk_rope_head_dim", None)
+            if dim is None:
+                head_dim = text_cfg.hidden_size // text_cfg.num_attention_heads
+                dim = head_dim
+            base = getattr(text_cfg, "rope_theta", 10000.0)
+            inv_freq = 1.0 / (
+                base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+            )
+            rotary_mod.to_empty(device=device)
+            rotary_mod.inv_freq = inv_freq
+
+            layer_types_cfg = getattr(text_cfg, "layer_types", None)
+            # Only use per-layer-type PE if there are actually different types
+            # (e.g. Gemma has sliding_window + global). If all the same, skip.
+            # Use a single sample's pos_ids so cos/sin broadcast to any batch size
+            pe_hs = batch_hidden_states[0][:1].to(device)
+            pe_pos = batch_pos_ids[0][:1].to(device)
+
+            unique_types = set(layer_types_cfg) if layer_types_cfg else set()
+            if len(unique_types) > 1:
+                layer_types = list(layer_types_cfg)
+                position_embeddings = {}
+                with torch.no_grad():
+                    for lt in unique_types:
+                        pe = rotary_mod(pe_hs, pe_pos, layer_type=lt)
+                        position_embeddings[lt] = tuple(t.cpu() for t in pe)
+            else:
+                if layer_types_cfg is not None:
+                    layer_types = list(layer_types_cfg)
+                with torch.no_grad():
+                    pe = rotary_mod(pe_hs, pe_pos)
+                    if isinstance(pe, tuple):
+                        position_embeddings = tuple(t.cpu() for t in pe)
+                    else:
+                        position_embeddings = pe.cpu()
+
+            _free_module(rotary_mod)
+            torch.cuda.empty_cache()
+
+        assert hidden_dim is not None
+        decoder_layers = _get_decoder_layers(model)
+
+        # Accumulators
+        signal_bases: dict[str, list[np.ndarray | None]] = {
+            sig: [None] * num_layers for sig in signals
+        }
+        signal_dims: dict[str, int] = {}
+        all_proj_chunks: list[np.ndarray] = []
+        all_coord_sample_id: list[int] = []
+        all_coord_layer: list[int] = []
+        all_coord_token_pos: list[int] = []
+        all_coord_signal: list[int] = []
+
+        # --- Phase 2: Layer-by-layer ---
+        layer_pbar = tqdm(range(num_layers), desc="Scan: layers")
+        for layer_idx in layer_pbar:
+            layer_pbar.set_postfix(layer=layer_idx)
+
+            # Load layer weights from disk to GPU
+            layer_weights = self._load_tensors(layer_map[layer_idx], "cpu")
+            prefix = f"model.layers.{layer_idx}."
+            layer_module = decoder_layers[layer_idx]
+            _materialize_module(layer_module, layer_weights, prefix, device)
+            del layer_weights
+
+            per_signal_captures: dict[str, list[torch.Tensor]] = {
+                sig: [] for sig in signals
+            }
+
+            for batch_idx, (start, end) in enumerate(batches):
+                hs = batch_hidden_states[batch_idx].to(device)
+                mask_dev = batch_causal_masks[batch_idx].to(device)
+                pos_dev = batch_pos_ids[batch_idx].to(device)
+                pe_dev = ChunkedLocalBackend._pe_to_device(position_embeddings, device)
+
+                with torch.no_grad():
+                    # Set up signal hooks
+                    hooks: list[tuple[str, Any, list[torch.Tensor]]] = []
+                    capture_residual = False
+                    for sig in signals:
+                        if sig == "residual":
+                            capture_residual = True
+                            continue
+                        buf: list[torch.Tensor] = []
+                        def _hook(
+                            _mod: Any, _inp: Any, out: Any,
+                            _buf: list = buf,
+                        ) -> None:
+                            delta = out[0] if isinstance(out, tuple) else out
+                            _buf.append(delta.detach().cpu())
+                        if sig == "attn_delta":
+                            mod = _get_attn_submodule(layer_module)
+                            h = mod.register_forward_hook(_hook)
+                            hooks.append((sig, h, buf))
+                        elif sig == "mlp_delta":
+                            mod = _get_mlp_submodule(layer_module)
+                            h = mod.register_forward_hook(_hook)
+                            hooks.append((sig, h, buf))
+
+                    layer_kwargs = ChunkedLocalBackend._build_layer_kwargs(
+                        mask_dev, pos_dev, batch_cache_positions[batch_idx],
+                        pe_dev, layer_types, layer_idx, device,
+                    )
+
+                    output = layer_module(hs, **layer_kwargs)
+                    hs = output[0] if isinstance(output, tuple) else output
+
+                    for sig_name, handle, hook_buf in hooks:
+                        handle.remove()
+                        if hook_buf:
+                            per_signal_captures[sig_name].append(hook_buf[0])
+
+                    if capture_residual:
+                        per_signal_captures["residual"].append(hs.detach().cpu())
+
+                batch_hidden_states[batch_idx] = hs.cpu()
+                del hs, mask_dev, pos_dev, pe_dev
+
+            # Free layer weights
+            _free_module(layer_module)
+            gc.collect()
+            torch.cuda.empty_cache()
+
+            # --- PCA for this layer ---
+            for sig_idx, sig_name in enumerate(signals):
+                captures = per_signal_captures[sig_name]
+                if not captures:
+                    continue
+
+                stacked = torch.cat(captures, dim=0)  # [B_total, S, dim]
+                B_total, S, dim = stacked.shape
+                flat = stacked.reshape(-1, dim).float().numpy()
+
+                if sig_name not in signal_dims:
+                    signal_dims[sig_name] = dim
+
+                if external_bases is not None and sig_name in external_bases:
+                    basis = external_bases[sig_name][layer_idx]
+                    signal_bases[sig_name][layer_idx] = basis
+                    k = basis.shape[1]
+                    projected = (flat @ basis.astype(np.float32)).astype(np.float16)
+                else:
+                    if generative_masks is not None:
+                        fit_mask_parts = []
+                        for sid in range(B_total):
+                            if sid < len(generative_masks) and generative_masks[sid] is not None:
+                                gmask = generative_masks[sid]
+                                padded_mask = np.zeros(S, dtype=bool)
+                                padded_mask[:min(len(gmask), S)] = gmask[:S]
+                                fit_mask_parts.append(padded_mask)
+                            else:
+                                fit_mask_parts.append(np.ones(S, dtype=bool))
+                        fit_mask = np.concatenate(fit_mask_parts)
+                        flat_fit = flat[fit_mask]
+                    else:
+                        flat_fit = flat
+
+                    k = min(n_components, flat_fit.shape[0] - 1, dim)
+                    pca = PCA(n_components=k)
+                    pca.fit(flat_fit)
+
+                    basis = pca.components_.T.astype(np.float16)
+                    signal_bases[sig_name][layer_idx] = basis
+                    projected = pca.transform(flat).astype(np.float16)
+
+                if k < n_components:
+                    padded = np.zeros(
+                        (projected.shape[0], n_components), dtype=np.float16,
+                    )
+                    padded[:, :k] = projected
+                    projected = padded
+
+                all_proj_chunks.append(projected)
+
+                for sample_idx in range(B_total):
+                    for tok in range(S):
+                        all_coord_sample_id.append(sample_idx)
+                        all_coord_layer.append(layer_idx)
+                        all_coord_token_pos.append(tok)
+                        all_coord_signal.append(sig_idx)
+
+                del stacked, flat, projected
+
+            del per_signal_captures
+            gc.collect()
+
+        # Assemble bases
+        final_bases: dict[str, np.ndarray] = {}
+        for sig_name in signals:
+            dim = signal_dims.get(sig_name, hidden_dim)
+            k_eff = min(n_components, dim)
+            basis_arr = np.zeros((num_layers, dim, k_eff), dtype=np.float16)
+            for L in range(num_layers):
+                layer_basis = signal_bases[sig_name][L]
+                if layer_basis is not None:
+                    actual_k = layer_basis.shape[1]
+                    basis_arr[L, :, :actual_k] = layer_basis
+            final_bases[sig_name] = basis_arr
+
+        all_projections = np.concatenate(all_proj_chunks, axis=0)
+        all_projections = all_projections[:, np.newaxis, :]
+
+        metadata = {
+            "model_id": self.model_name,
+            "hidden_dim": hidden_dim,
+            "n_layers": num_layers,
+            "n_components": n_components,
+            "n_samples": n_samples,
+            "signals": signals,
+        }
+
+        coords = {
+            "sample_id": all_coord_sample_id,
+            "layer": all_coord_layer,
+            "token_pos": all_coord_token_pos,
+            "signal": all_coord_signal,
+        }
+
+        return (
+            metadata,
+            final_bases,
+            all_projections,
+            coords,
+            token_ids_per_sample,
+            seq_lengths,
+            all_attention_mask,
+            signal_dims,
+        )
+
+    def project_forward(
+        self,
+        prompt: str,
+        bases: dict[str, np.ndarray],
+        signals: list[str],
+        include_logits: bool = True,
+    ) -> tuple[np.ndarray, list[int], torch.Tensor | None]:
+        """Run a single-prompt forward pass from disk, projecting deltas onto bases.
+
+        Same interface as ChunkedLocalBackend.project_forward but loads
+        layer weights from safetensors instead of keeping the model in RAM.
+        """
+        import gc
+        import math
+
+        config = self._get_config()
+        model = self._get_model_skeleton()
+        layer_map, non_layer = self._get_shard_map()
+        device = self.device
+        num_layers = config.num_hidden_layers
+
+        # Tokenize
+        tokenized = self.tokenizer(
+            [prompt], return_tensors="pt", padding=True,
+        )
+        input_ids = tokenized["input_ids"]
+        attention_mask = tokenized["attention_mask"]
+
+        seq_len = input_ids.shape[1]
+        real_len = int(attention_mask[0].sum().item())
+        token_ids = input_ids[0, :real_len].tolist()
+
+        # Embedding
+        embed_tensors = [(n, f) for n, f in non_layer if "embed_tokens" in n]
+        embed_weights = self._load_tensors(embed_tensors, device)
+        embed = _get_embedding_module(model)
+        _materialize_module(embed, embed_weights, "model.embed_tokens.", device)
+        del embed_weights
+
+        with torch.no_grad():
+            hidden_states = embed(input_ids.to(device)).cpu()
+
+        _free_module(embed)
+        torch.cuda.empty_cache()
+
+        # Position setup
+        position_ids = attention_mask.long().cumsum(-1) - 1
+        position_ids.masked_fill_(attention_mask == 0, 1)
+        cache_position = torch.arange(seq_len)
+
+        # Rotary embeddings
+        position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | dict | None = None
+        layer_types: list[str] | None = None
+        rotary_name = ChunkedLocalBackend._find_rotary_embedding_name(model)
+        if rotary_name is not None:
+            rotary_mod = model
+            for part in rotary_name.split("."):
+                rotary_mod = getattr(rotary_mod, part)
+
+            text_cfg = getattr(config, "text_config", config)
+            dim = getattr(text_cfg, "qk_rope_head_dim", None)
+            if dim is None:
+                head_dim = text_cfg.hidden_size // text_cfg.num_attention_heads
+                dim = head_dim
+            base = getattr(text_cfg, "rope_theta", 10000.0)
+            inv_freq = 1.0 / (
+                base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+            )
+            rotary_mod.to_empty(device=device)
+            rotary_mod.inv_freq = inv_freq
+
+            layer_types_cfg = getattr(text_cfg, "layer_types", None)
+            unique_types = set(layer_types_cfg) if layer_types_cfg else set()
+            if len(unique_types) > 1:
+                layer_types = list(layer_types_cfg)
+                position_embeddings = {}
+                with torch.no_grad():
+                    for lt in unique_types:
+                        pe = rotary_mod(
+                            hidden_states.to(device),
+                            position_ids.to(device),
+                            layer_type=lt,
+                        )
+                        position_embeddings[lt] = tuple(t.cpu() for t in pe)
+            else:
+                with torch.no_grad():
+                    pe = rotary_mod(
+                        hidden_states.to(device),
+                        position_ids.to(device),
+                    )
+                    if isinstance(pe, tuple):
+                        position_embeddings = tuple(t.cpu() for t in pe)
+                    else:
+                        position_embeddings = pe.cpu()
+
+            _free_module(rotary_mod)
+            torch.cuda.empty_cache()
+
+        decoder_layers = _get_decoder_layers(model)
+
+        # Projection setup
+        max_k = max(b.shape[2] for b in bases.values())
+        n_signals = len(signals)
+        projections = np.zeros(
+            (seq_len, num_layers, n_signals, max_k), dtype=np.float32,
+        )
+        bases_torch = {
+            sig: torch.from_numpy(b).float() for sig, b in bases.items()
+        }
+
+        causal_mask = _make_causal_mask(attention_mask, self.dtype)
+
+        # Layer-by-layer
+        for layer_idx in range(num_layers):
+            layer_weights = self._load_tensors(layer_map[layer_idx], "cpu")
+            prefix = f"model.layers.{layer_idx}."
+            layer_module = decoder_layers[layer_idx]
+            _materialize_module(layer_module, layer_weights, prefix, device)
+            del layer_weights
+
+            # Signal hooks
+            hooks: list[tuple[str, Any, list[torch.Tensor]]] = []
+            capture_residual = False
+            for sig in signals:
+                if sig == "residual":
+                    capture_residual = True
+                    continue
+                buf: list[torch.Tensor] = []
+                def _hook(
+                    _mod: Any, _inp: Any, out: Any,
+                    _buf: list = buf,
+                ) -> None:
+                    delta = out[0] if isinstance(out, tuple) else out
+                    _buf.append(delta.detach().cpu())
+                if sig == "attn_delta":
+                    mod = _get_attn_submodule(layer_module)
+                    h = mod.register_forward_hook(_hook)
+                    hooks.append((sig, h, buf))
+                elif sig == "mlp_delta":
+                    mod = _get_mlp_submodule(layer_module)
+                    h = mod.register_forward_hook(_hook)
+                    hooks.append((sig, h, buf))
+
+            hs = hidden_states.to(device)
+            mask_dev = causal_mask.to(device)
+            pos_dev = position_ids.to(device)
+            pe_dev = ChunkedLocalBackend._pe_to_device(position_embeddings, device)
+
+            layer_kwargs = ChunkedLocalBackend._build_layer_kwargs(
+                mask_dev, pos_dev, cache_position,
+                pe_dev, layer_types, layer_idx, device,
+            )
+
+            with torch.no_grad():
+                output = layer_module(hs, **layer_kwargs)
+                hs = output[0] if isinstance(output, tuple) else output
+
+            for sig_name, handle, hook_buf in hooks:
+                handle.remove()
+                if hook_buf and sig_name in bases_torch:
+                    sig_idx = signals.index(sig_name)
+                    delta = hook_buf[0][0].float()  # [seq_len, dim]
+                    b = bases_torch[sig_name][layer_idx]
+                    k = b.shape[1]
+                    proj = (delta @ b).numpy()
+                    projections[:, layer_idx, sig_idx, :k] = proj
+
+            if capture_residual and "residual" in bases_torch:
+                sig_idx = signals.index("residual")
+                delta = hs[0].cpu().float()
+                b = bases_torch["residual"][layer_idx]
+                k = b.shape[1]
+                proj = (delta @ b).numpy()
+                projections[:, layer_idx, sig_idx, :k] = proj
+
+            hidden_states = hs.cpu()
+            del hs, mask_dev, pos_dev, pe_dev
+
+            _free_module(layer_module)
+            gc.collect()
+            torch.cuda.empty_cache()
+
+        # Logits
+        logits = None
+        if include_logits:
+            norm_tensors = [
+                (n, f) for n, f in non_layer
+                if "norm" in n and "layer" not in n
+            ]
+            head_tensors = [(n, f) for n, f in non_layer if "lm_head" in n]
+
+            norm_w = self._load_tensors(norm_tensors, device)
+            final_norm = _get_final_norm(model)
+            _materialize_module(final_norm, norm_w, "model.norm.", device)
+            del norm_w
+
+            head_w = self._load_tensors(head_tensors, device)
+            lm_head = _get_lm_head(model)
+            _materialize_module(lm_head, head_w, "lm_head.", device)
+            del head_w
+
+            with torch.no_grad():
+                logits = lm_head(
+                    final_norm(hidden_states.to(device)),
+                ).cpu()
+
+            _free_module(final_norm)
+            _free_module(lm_head)
+            torch.cuda.empty_cache()
+
+        return projections, token_ids, logits
 
     # --- Standard ExtractionBackend interface ---
 

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1547,6 +1547,7 @@ class ChunkedLocalBackend(ExtractionBackend):
         n_components: int = 64,
         batch_size: int = 4,
         generative_masks: list[np.ndarray] | None = None,
+        external_bases: dict[str, np.ndarray] | None = None,
     ) -> tuple[
         dict[str, Any],                # metadata
         dict[str, np.ndarray],          # bases: {signal_name: [n_layers, dim, k_eff]}
@@ -1575,6 +1576,11 @@ class ChunkedLocalBackend(ExtractionBackend):
             generative (assistant) token. If provided, PCA is fit only
             on generative tokens to avoid prompt leakage. All tokens
             are still projected through the basis.
+        external_bases : dict of {signal_name: np.ndarray} or None
+            Pre-trained PCA bases to project through instead of fitting
+            new ones. Shape [n_layers, dim, k] per signal. When provided,
+            PCA fitting is skipped entirely — enables fast batched
+            projection through an existing scan's basis.
 
         Returns all data needed to write a SampleScan to disk.
         """
@@ -1802,34 +1808,38 @@ class ChunkedLocalBackend(ExtractionBackend):
                 if sig_name not in signal_dims:
                     signal_dims[sig_name] = dim
 
-                # Build PCA fit data — filter to generative tokens if mask provided
-                if generative_masks is not None:
-                    # Build a flat boolean mask matching the [B_total * S] rows
-                    fit_mask_parts = []
-                    for sid in range(B_total):
-                        if sid < len(generative_masks) and generative_masks[sid] is not None:
-                            gmask = generative_masks[sid]
-                            # Pad or truncate to S (padded sequence length)
-                            padded_mask = np.zeros(S, dtype=bool)
-                            padded_mask[:min(len(gmask), S)] = gmask[:S]
-                            fit_mask_parts.append(padded_mask)
-                        else:
-                            fit_mask_parts.append(np.ones(S, dtype=bool))
-                    fit_mask = np.concatenate(fit_mask_parts)
-                    flat_fit = flat[fit_mask]
+                if external_bases is not None and sig_name in external_bases:
+                    # Use pre-trained basis — skip PCA fitting
+                    basis = external_bases[sig_name][layer_idx]  # [dim, k]
+                    signal_bases[sig_name][layer_idx] = basis
+                    k = basis.shape[1]
+                    projected = (flat @ basis.astype(np.float32)).astype(np.float16)
                 else:
-                    flat_fit = flat
+                    # Build PCA fit data — filter to generative tokens if mask provided
+                    if generative_masks is not None:
+                        fit_mask_parts = []
+                        for sid in range(B_total):
+                            if sid < len(generative_masks) and generative_masks[sid] is not None:
+                                gmask = generative_masks[sid]
+                                padded_mask = np.zeros(S, dtype=bool)
+                                padded_mask[:min(len(gmask), S)] = gmask[:S]
+                                fit_mask_parts.append(padded_mask)
+                            else:
+                                fit_mask_parts.append(np.ones(S, dtype=bool))
+                        fit_mask = np.concatenate(fit_mask_parts)
+                        flat_fit = flat[fit_mask]
+                    else:
+                        flat_fit = flat
 
-                k = min(n_components, flat_fit.shape[0] - 1, dim)
-                pca = PCA(n_components=k)
-                pca.fit(flat_fit)
+                    k = min(n_components, flat_fit.shape[0] - 1, dim)
+                    pca = PCA(n_components=k)
+                    pca.fit(flat_fit)
 
-                # Store basis: components_ is [k, dim], we store [dim, k]
-                basis = pca.components_.T.astype(np.float16)
-                signal_bases[sig_name][layer_idx] = basis
+                    basis = pca.components_.T.astype(np.float16)
+                    signal_bases[sig_name][layer_idx] = basis
 
-                # Project ALL tokens (not just generative) through the basis
-                projected = pca.transform(flat).astype(np.float16)
+                    # Project ALL tokens through the basis
+                    projected = pca.transform(flat).astype(np.float16)
                 if k < n_components:
                     padded = np.zeros(
                         (projected.shape[0], n_components), dtype=np.float16,

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1533,6 +1533,7 @@ class ChunkedLocalBackend(ExtractionBackend):
         signals: list[str] | None = None,
         n_components: int = 64,
         batch_size: int = 4,
+        generative_masks: list[np.ndarray] | None = None,
     ) -> tuple[
         dict[str, Any],                # metadata
         dict[str, np.ndarray],          # bases: {signal_name: [n_layers, dim, k_eff]}
@@ -1556,6 +1557,11 @@ class ChunkedLocalBackend(ExtractionBackend):
             Max PCA components per (layer, signal).
         batch_size : int
             Prompts per batch.
+        generative_masks : list of np.ndarray or None
+            Per-sample boolean masks, shape [seq_len_i] each. True =
+            generative (assistant) token. If provided, PCA is fit only
+            on generative tokens to avoid prompt leakage. All tokens
+            are still projected through the basis.
 
         Returns all data needed to write a SampleScan to disk.
         """
@@ -1784,15 +1790,33 @@ class ChunkedLocalBackend(ExtractionBackend):
                 if sig_name not in signal_dims:
                     signal_dims[sig_name] = dim
 
-                k = min(n_components, flat.shape[0] - 1, dim)
+                # Build PCA fit data — filter to generative tokens if mask provided
+                if generative_masks is not None:
+                    # Build a flat boolean mask matching the [B_total * S] rows
+                    fit_mask_parts = []
+                    for sid in range(B_total):
+                        if sid < len(generative_masks) and generative_masks[sid] is not None:
+                            gmask = generative_masks[sid]
+                            # Pad or truncate to S (padded sequence length)
+                            padded_mask = np.zeros(S, dtype=bool)
+                            padded_mask[:min(len(gmask), S)] = gmask[:S]
+                            fit_mask_parts.append(padded_mask)
+                        else:
+                            fit_mask_parts.append(np.ones(S, dtype=bool))
+                    fit_mask = np.concatenate(fit_mask_parts)
+                    flat_fit = flat[fit_mask]
+                else:
+                    flat_fit = flat
+
+                k = min(n_components, flat_fit.shape[0] - 1, dim)
                 pca = PCA(n_components=k)
-                pca.fit(flat)
+                pca.fit(flat_fit)
 
                 # Store basis: components_ is [k, dim], we store [dim, k]
                 basis = pca.components_.T.astype(np.float16)
                 signal_bases[sig_name][layer_idx] = basis
 
-                # Project
+                # Project ALL tokens (not just generative) through the basis
                 projected = pca.transform(flat).astype(np.float16)
                 if k < n_components:
                     padded = np.zeros(

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1702,7 +1702,7 @@ class ChunkedLocalBackend(ExtractionBackend):
             pe_pos = batch_pos_ids[0][:1].to(device)
 
             unique_types = set(layer_types_cfg) if layer_types_cfg is not None else set()
-            if len(unique_types) > 1:
+            if layer_types_cfg is not None and len(unique_types) > 1:
                 layer_types = list(layer_types_cfg)
                 position_embeddings = {}
                 with torch.no_grad():
@@ -2865,7 +2865,7 @@ class DiskOffloadBackend(ExtractionBackend):
             pe_pos = batch_pos_ids[0][:1].to(device)
 
             unique_types = set(layer_types_cfg) if layer_types_cfg else set()
-            if len(unique_types) > 1:
+            if layer_types_cfg and len(unique_types) > 1:
                 layer_types = list(layer_types_cfg)
                 position_embeddings = {}
                 with torch.no_grad():
@@ -3147,7 +3147,7 @@ class DiskOffloadBackend(ExtractionBackend):
 
             layer_types_cfg = getattr(text_cfg, "layer_types", None)
             unique_types = set(layer_types_cfg) if layer_types_cfg else set()
-            if len(unique_types) > 1:
+            if layer_types_cfg and len(unique_types) > 1:
                 layer_types = list(layer_types_cfg)
                 position_embeddings = {}
                 with torch.no_grad():

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -80,6 +80,7 @@ class SampleScan:
         dtype: Any = None,
         batch_size: int = 4,
         chunk_size: int | str = "auto",
+        generative_masks: list[np.ndarray] | None = None,
     ) -> SampleScan:
         """Fit a scan on a corpus and write results to disk.
 
@@ -106,6 +107,10 @@ class SampleScan:
             Number of prompts per forward-pass batch.
         chunk_size : int or str
             Layers per GPU chunk ("auto" or explicit int).
+        generative_masks : list of np.ndarray or None
+            Per-sample boolean masks, shape [seq_len_i]. True = generative
+            (assistant) token. PCA is fit only on generative tokens to
+            avoid prompt leakage. All tokens are still projected.
 
         Returns
         -------
@@ -149,6 +154,7 @@ class SampleScan:
             signals=signals,
             n_components=n_components,
             batch_size=batch_size,
+            generative_masks=generative_masks,
         )
 
         actual_signals = metadata_dict["signals"]
@@ -314,11 +320,12 @@ class SampleScan:
         self,
         labels: np.ndarray | list[int] | None = None,
         signal: str | None = None,
+        token_positions: np.ndarray | list[int] | None = None,
     ) -> np.ndarray:
         """Compute per-(layer, signal) separability scores.
 
-        Uses last-token projections for each sample and computes
-        max-over-PCs AUROC for binary separation.
+        Uses one token position per sample and computes max-over-PCs
+        AUROC for binary separation.
 
         Parameters
         ----------
@@ -326,6 +333,12 @@ class SampleScan:
             Binary labels per sample. If None, uses stored labels.
         signal : str or None
             If given, only compute for this signal.
+        token_positions : array-like or None
+            Per-sample token position to use for the separability
+            computation. Shape [n_samples]. If None, uses the last
+            token of each sample (seq_length - 1). Use this to
+            restrict analysis to specific regions (e.g. last token
+            of the assistant turn) and avoid prompt leakage.
 
         Returns
         -------
@@ -350,6 +363,11 @@ class SampleScan:
 
         seq_lengths = self._samples_table.column("seq_length").to_numpy()
 
+        if token_positions is not None:
+            tok_pos_per_sample = np.asarray(token_positions, dtype=np.int64)
+        else:
+            tok_pos_per_sample = seq_lengths - 1
+
         coords = self._coords_table
         sample_ids_col = coords.column("sample_id").to_numpy()
         layers_col = coords.column("layer").to_numpy()
@@ -363,11 +381,11 @@ class SampleScan:
                 sample_vecs = np.zeros((n_samples, k), dtype=np.float32)
 
                 for sid in range(n_samples):
-                    last_tok = seq_lengths[sid] - 1
+                    target_tok = int(tok_pos_per_sample[sid])
                     mask = (
                         (sample_ids_col == sid)
                         & (layers_col == layer_idx)
-                        & (token_pos_col == last_tok)
+                        & (token_pos_col == target_tok)
                         & (signal_col == sig_idx)
                     )
                     rows = self._projections[mask]
@@ -467,6 +485,7 @@ class SampleScan:
         show_stats: bool = True,
         figsize: tuple[float, float] | None = None,
         title: str = "",
+        generative_mask: np.ndarray | None = None,
     ) -> matplotlib.figure.Figure:
         """Render the hero figure for a prompt under this scan's lens.
 
@@ -484,6 +503,9 @@ class SampleScan:
             Figure size (width, height) in inches.
         title : str
             Optional figure title.
+        generative_mask : np.ndarray or None
+            Boolean mask shape [seq_len]. True = assistant/generative
+            token, False = prompt token. Prompt tokens are grayed out.
 
         Returns
         -------
@@ -509,4 +531,5 @@ class SampleScan:
             layer_stats=layer_stats if show_stats else None,
             figsize=figsize,
             title=title,
+            generative_mask=generative_mask,
         )

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -408,7 +408,62 @@ class SampleScan:
 
         return result
 
-    # --- Projection ---
+    # --- Batch Projection ---
+
+    def batch_project(
+        self,
+        prompts: list[str],
+        signal: str | None = None,
+        batch_size: int = 4,
+    ) -> tuple[np.ndarray, list[list[int]], list[int]]:
+        """Project multiple prompts through the scan basis in a single
+        batched forward pass. Much faster than looping project_prompt().
+
+        Parameters
+        ----------
+        prompts : list[str]
+            Prompts to project.
+        signal : str or None
+            If given, only project this signal.
+        batch_size : int
+            Prompts per forward-pass batch.
+
+        Returns
+        -------
+        tuple
+            (projections_values, token_ids_per_sample, seq_lengths)
+            - projections_values: np.ndarray [N_total, 1, k]
+            - token_ids_per_sample: list of token ID lists
+            - seq_lengths: list of int
+        Also writes projections to a temporary scan dir, but the
+        returned coords can be used to reconstruct per-sample arrays.
+        """
+        import tempfile
+
+        backend = self._get_backend()
+        proj_signals = [signal] if signal else self.signals
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (
+                _metadata,
+                _bases,
+                projections,
+                coords,
+                token_ids_per_sample,
+                seq_lengths,
+                _attention_mask,
+                _signal_dims,
+            ) = backend.scan_forward(
+                prompts,
+                signals=proj_signals,
+                n_components=self._metadata.n_components,
+                batch_size=batch_size,
+                external_bases=self._bases,
+            )
+
+        return projections, coords, token_ids_per_sample, seq_lengths
+
+    # --- Single Projection ---
 
     def _get_backend(self) -> Any:
         """Lazy-load the ChunkedLocalBackend for projection."""

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -82,6 +82,8 @@ class SampleScan:
         batch_size: int = 4,
         chunk_size: int | str = "auto",
         generative_masks: list[np.ndarray] | None = None,
+        backend: str = "chunked",
+        attn_implementation: str = "sdpa",
     ) -> SampleScan:
         """Fit a scan on a corpus and write results to disk.
 
@@ -112,6 +114,15 @@ class SampleScan:
             Per-sample boolean masks, shape [seq_len_i]. True = generative
             (assistant) token. PCA is fit only on generative tokens to
             avoid prompt leakage. All tokens are still projected.
+        backend : str
+            Backend to use: "chunked" (loads full model on CPU, streams
+            layers through GPU) or "disk_offload" (loads layer weights
+            directly from safetensors to GPU — for models exceeding CPU RAM).
+        attn_implementation : str
+            Attention kernel passed to ``from_pretrained`` for the chunked
+            backend. Default ``"sdpa"``. Use ``"eager"`` only if a custom
+            signal hook needs materialized ``[B, H, T, T]`` attention weights.
+            Ignored by the ``disk_offload`` backend.
 
         Returns
         -------
@@ -121,7 +132,6 @@ class SampleScan:
         import torch
 
         from . import scan_storage
-        from .backends import ChunkedLocalBackend
 
         if dtype is None:
             dtype = torch.bfloat16
@@ -131,14 +141,24 @@ class SampleScan:
 
         scan_dir = Path(scan_dir)
 
-        backend_kwargs: dict[str, Any] = {
-            "model_name": model_name,
-            "device": device,
-            "dtype": dtype,
-        }
-        if chunk_size != "auto":
-            backend_kwargs["chunk_size"] = chunk_size
-        backend = ChunkedLocalBackend(**backend_kwargs)
+        if backend == "disk_offload":
+            from .backends import DiskOffloadBackend
+            backend_obj = DiskOffloadBackend(
+                model_name=model_name,
+                device=device,
+                dtype=dtype,
+            )
+        else:
+            from .backends import ChunkedLocalBackend
+            backend_kwargs: dict[str, Any] = {
+                "model_name": model_name,
+                "device": device,
+                "dtype": dtype,
+                "attn_implementation": attn_implementation,
+            }
+            if chunk_size != "auto":
+                backend_kwargs["chunk_size"] = chunk_size
+            backend_obj = ChunkedLocalBackend(**backend_kwargs)
 
         # Run the scan forward pass
         (
@@ -150,7 +170,7 @@ class SampleScan:
             seq_lengths,
             _attention_mask,
             signal_dims,
-        ) = backend.scan_forward(
+        ) = backend_obj.scan_forward(
             prompts,
             signals=signals,
             n_components=n_components,
@@ -463,19 +483,39 @@ class SampleScan:
     # --- Single Projection ---
 
     def _get_backend(self) -> Any:
-        """Lazy-load the ChunkedLocalBackend for projection."""
+        """Lazy-load a backend for projection.
+
+        Uses DiskOffloadBackend for models whose weights exceed ~80% of
+        available CPU RAM; otherwise uses ChunkedLocalBackend.
+        """
         if self._backend is None:
             import torch
 
-            from .backends import ChunkedLocalBackend
-
             device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
-            self._backend = ChunkedLocalBackend(
-                model_name=self._metadata.model_id,
-                device=device,
-                dtype=torch.bfloat16,
-            )
+            # Estimate model weight size from hidden_dim and n_layers
+            # Rough heuristic: 2 bytes/param (bf16), ~12*hidden^2 params/layer
+            est_bytes = self._metadata.n_layers * 12 * (self._metadata.hidden_dim ** 2) * 2
+            try:
+                import os
+                mem_avail = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+            except (ValueError, OSError):
+                mem_avail = float("inf")
+
+            if est_bytes > 0.8 * mem_avail:
+                from .backends import DiskOffloadBackend
+                self._backend = DiskOffloadBackend(
+                    model_name=self._metadata.model_id,
+                    device=device,
+                    dtype=torch.bfloat16,
+                )
+            else:
+                from .backends import ChunkedLocalBackend
+                self._backend = ChunkedLocalBackend(
+                    model_name=self._metadata.model_id,
+                    device=device,
+                    dtype=torch.bfloat16,
+                )
         return self._backend
 
     def project_prompt(

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -1,0 +1,512 @@
+"""SampleScan: Breadth-first activation indexing for language models.
+
+A SampleScan captures configurable signals (attention deltas, MLP deltas,
+residual stream, router logits) at every layer during a forward pass, fits
+PCA on a corpus (the "sample"), and stores a compressed basis per signal.
+The basis is a reusable lens: any prompt can be projected through it and
+visualized as a 2D RGB image showing what the model is doing at each
+(token, layer) coordinate.
+
+Example
+-------
+>>> from lmprobe import SampleScan
+>>>
+>>> scan = SampleScan.run(
+...     prompts=corpus_prompts,
+...     labels=corpus_labels,
+...     model_name="Qwen/Qwen2.5-7B-Instruct",
+...     scan_dir="./my_scan",
+...     signals=["residual", "attn_delta", "mlp_delta"],
+... )
+>>>
+>>> fig = scan.plot("The capital of France is Paris.", signal="attn_delta")
+>>> fig.savefig("scan_view.png")
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import matplotlib.figure
+
+
+class SampleScan:
+    """A compressed activation scan — a reusable PCA basis fit on a corpus.
+
+    The scan stores PCA basis vectors for each (layer, signal) pair,
+    plus pre-computed projections for all corpus prompts. The basis can
+    be applied to any prompt to produce a per-token, per-layer RGB
+    visualization of model internals.
+
+    Parameters
+    ----------
+    scan_dir : str or Path
+        Path to an existing scan directory on disk.
+    """
+
+    def __init__(self, scan_dir: str | Path) -> None:
+        from . import scan_storage
+
+        self._scan_dir = Path(scan_dir)
+        self._metadata = scan_storage.read_metadata(self._scan_dir)
+        self._bases = scan_storage.read_basis(self._scan_dir, "0_global")
+        assert isinstance(self._bases, dict)
+        self._channel_config = scan_storage.read_channel_config(
+            self._scan_dir, "0_global",
+        )
+        self._samples_table = scan_storage.read_samples(self._scan_dir)
+        self._projections: np.memmap | None = None
+        self._coords_table: Any = None
+
+        # Backend for projection forward passes (lazy-loaded)
+        self._backend: Any = None
+
+    @classmethod
+    def run(
+        cls,
+        prompts: list[str],
+        labels: list[int],
+        model_name: str,
+        scan_dir: str | Path,
+        *,
+        signals: list[str] | None = None,
+        n_components: int = 64,
+        device: str = "auto",
+        dtype: Any = None,
+        batch_size: int = 4,
+        chunk_size: int | str = "auto",
+    ) -> SampleScan:
+        """Fit a scan on a corpus and write results to disk.
+
+        Parameters
+        ----------
+        prompts : list[str]
+            Corpus prompts to fit the PCA basis on.
+        labels : list[int]
+            Per-prompt labels (e.g. 0/1 for binary contrast).
+        model_name : str
+            HuggingFace model ID.
+        scan_dir : str or Path
+            Directory to write scan artifacts to.
+        signals : list[str] or None
+            Signals to capture. Defaults to ["attn_delta", "mlp_delta"].
+            Valid: "residual", "attn_delta", "mlp_delta", "router_logits".
+        n_components : int
+            Max PCA components per (layer, signal).
+        device : str
+            Compute device ("auto", "cpu", "cuda:0", etc.).
+        dtype : torch.dtype or None
+            Model dtype. Defaults to bfloat16.
+        batch_size : int
+            Number of prompts per forward-pass batch.
+        chunk_size : int or str
+            Layers per GPU chunk ("auto" or explicit int).
+
+        Returns
+        -------
+        SampleScan
+            The fitted scan, loaded from disk.
+        """
+        import torch
+
+        from . import scan_storage
+        from .backends import ChunkedLocalBackend
+
+        if dtype is None:
+            dtype = torch.bfloat16
+
+        if device == "auto":
+            device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+        scan_dir = Path(scan_dir)
+
+        backend_kwargs: dict[str, Any] = {
+            "model_name": model_name,
+            "device": device,
+            "dtype": dtype,
+        }
+        if chunk_size != "auto":
+            backend_kwargs["chunk_size"] = chunk_size
+        backend = ChunkedLocalBackend(**backend_kwargs)
+
+        # Run the scan forward pass
+        (
+            metadata_dict,
+            bases,
+            projections,
+            coords,
+            token_ids_per_sample,
+            seq_lengths,
+            _attention_mask,
+            signal_dims,
+        ) = backend.scan_forward(
+            prompts,
+            signals=signals,
+            n_components=n_components,
+            batch_size=batch_size,
+        )
+
+        actual_signals = metadata_dict["signals"]
+        creation_date = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        scan_storage.write_metadata(
+            scan_dir,
+            scan_storage.ScanMetadata(
+                model_id=metadata_dict["model_id"],
+                hidden_dim=metadata_dict["hidden_dim"],
+                n_layers=metadata_dict["n_layers"],
+                n_components=metadata_dict["n_components"],
+                n_samples=metadata_dict["n_samples"],
+                creation_date=creation_date,
+                signals=actual_signals,
+            ),
+        )
+
+        scan_storage.write_samples(
+            scan_dir,
+            sample_ids=list(range(len(prompts))),
+            prompts=prompts,
+            labels=labels,
+            token_ids_list=token_ids_per_sample,
+            seq_lengths=seq_lengths,
+        )
+
+        # Build signal info for channel config
+        signal_info = []
+        for sig in actual_signals:
+            dim = signal_dims.get(sig, metadata_dict["hidden_dim"])
+            k_eff = min(n_components, dim)
+            signal_info.append({
+                "name": sig,
+                "dim": dim,
+                "k_effective": k_eff,
+            })
+
+        scan_storage.write_channel(
+            scan_dir,
+            channel_name="0_global",
+            bases=bases,
+            config={
+                "name": "global",
+                "k": n_components,
+                "fit_method": "pca",
+                "signals": signal_info,
+            },
+        )
+
+        scan_storage.write_projections(
+            scan_dir,
+            values=projections,
+            coords_sample_id=np.array(coords["sample_id"], dtype=np.int32),
+            coords_layer=np.array(coords["layer"], dtype=np.int16),
+            coords_token_pos=np.array(coords["token_pos"], dtype=np.int16),
+            coords_signal=np.array(coords["signal"], dtype=np.int8),
+        )
+
+        return cls(scan_dir)
+
+    # --- Properties ---
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Scan metadata as a dict."""
+        from dataclasses import asdict
+
+        return asdict(self._metadata)
+
+    @property
+    def n_layers(self) -> int:
+        return self._metadata.n_layers
+
+    @property
+    def n_samples(self) -> int:
+        return self._metadata.n_samples
+
+    @property
+    def n_components(self) -> int:
+        return self._metadata.n_components
+
+    @property
+    def signals(self) -> list[str]:
+        """List of signal names in this scan."""
+        return self._metadata.signals
+
+    @property
+    def bases(self) -> dict[str, np.ndarray]:
+        """PCA bases per signal. {signal_name: [n_layers, dim, k_eff]}."""
+        return self._bases
+
+    @property
+    def samples(self) -> Any:
+        """Samples table (pyarrow Table)."""
+        return self._samples_table
+
+    # --- Lazy-loaded projection data ---
+
+    def _load_projections(self) -> None:
+        if self._projections is None:
+            from . import scan_storage
+
+            self._projections = scan_storage.open_projections(self._scan_dir)
+            self._coords_table = scan_storage.read_coords(self._scan_dir)
+
+    # --- Query API ---
+
+    def get_projections(
+        self,
+        sample_id: int,
+        signal: str | None = None,
+    ) -> np.ndarray:
+        """Get stored projections for a corpus sample.
+
+        Parameters
+        ----------
+        sample_id : int
+            Index of the sample in the corpus.
+        signal : str or None
+            If given, filter to this signal only.
+
+        Returns
+        -------
+        np.ndarray
+            Shape [seq_len, n_layers, n_signals, k].
+        """
+        self._load_projections()
+        assert self._projections is not None
+        assert self._coords_table is not None
+
+        coords = self._coords_table
+        sample_ids = coords.column("sample_id").to_numpy()
+        coord_mask = sample_ids == sample_id
+
+        if signal is not None:
+            sig_idx = self.signals.index(signal)
+            signal_col = coords.column("signal").to_numpy()
+            coord_mask = coord_mask & (signal_col == sig_idx)
+
+        rows = self._projections[coord_mask]  # [N_matching, 1, k]
+        values = rows[:, 0, :]  # [N_matching, k]
+
+        layers = coords.column("layer").to_numpy()[coord_mask]
+        token_pos = coords.column("token_pos").to_numpy()[coord_mask]
+        signal_col = coords.column("signal").to_numpy()[coord_mask]
+
+        n_layers = self._metadata.n_layers
+        n_signals = len(self.signals) if signal is None else 1
+        seq_len = int(token_pos.max()) + 1 if len(token_pos) > 0 else 0
+        k = values.shape[1] if len(values) > 0 else self._metadata.n_components
+
+        if signal is not None:
+            result = np.zeros((seq_len, n_layers, 1, k), dtype=np.float32)
+            result[token_pos, layers, 0, :] = values.astype(np.float32)
+        else:
+            result = np.zeros((seq_len, n_layers, n_signals, k), dtype=np.float32)
+            result[token_pos, layers, signal_col, :] = values.astype(np.float32)
+
+        return result
+
+    def separability_map(
+        self,
+        labels: np.ndarray | list[int] | None = None,
+        signal: str | None = None,
+    ) -> np.ndarray:
+        """Compute per-(layer, signal) separability scores.
+
+        Uses last-token projections for each sample and computes
+        max-over-PCs AUROC for binary separation.
+
+        Parameters
+        ----------
+        labels : array-like or None
+            Binary labels per sample. If None, uses stored labels.
+        signal : str or None
+            If given, only compute for this signal.
+
+        Returns
+        -------
+        np.ndarray
+            Shape [n_layers, n_signals] of AUROC scores.
+        """
+        from sklearn.metrics import roc_auc_score
+
+        if labels is None:
+            labels = self._samples_table.column("label").to_numpy()
+        labels = np.asarray(labels)
+
+        self._load_projections()
+        assert self._projections is not None
+        assert self._coords_table is not None
+
+        n_layers = self._metadata.n_layers
+        k = self._metadata.n_components
+        n_samples = self._metadata.n_samples
+        sigs = [signal] if signal else self.signals
+        sig_indices = [self.signals.index(s) for s in sigs]
+
+        seq_lengths = self._samples_table.column("seq_length").to_numpy()
+
+        coords = self._coords_table
+        sample_ids_col = coords.column("sample_id").to_numpy()
+        layers_col = coords.column("layer").to_numpy()
+        token_pos_col = coords.column("token_pos").to_numpy()
+        signal_col = coords.column("signal").to_numpy()
+
+        result = np.zeros((n_layers, len(sigs)), dtype=np.float64)
+
+        for out_idx, sig_idx in enumerate(sig_indices):
+            for layer_idx in range(n_layers):
+                sample_vecs = np.zeros((n_samples, k), dtype=np.float32)
+
+                for sid in range(n_samples):
+                    last_tok = seq_lengths[sid] - 1
+                    mask = (
+                        (sample_ids_col == sid)
+                        & (layers_col == layer_idx)
+                        & (token_pos_col == last_tok)
+                        & (signal_col == sig_idx)
+                    )
+                    rows = self._projections[mask]
+                    if len(rows) > 0:
+                        sample_vecs[sid] = rows[0, 0, :k].astype(np.float32)
+
+                max_auroc = 0.5
+                for pc in range(min(k, sample_vecs.shape[1])):
+                    pc_vals = sample_vecs[:, pc]
+                    if np.std(pc_vals) < 1e-10:
+                        continue
+                    try:
+                        auroc = roc_auc_score(labels, pc_vals)
+                        auroc = max(auroc, 1.0 - auroc)
+                        max_auroc = max(max_auroc, auroc)
+                    except ValueError:
+                        continue
+
+                result[layer_idx, out_idx] = max_auroc
+
+        return result
+
+    # --- Projection ---
+
+    def _get_backend(self) -> Any:
+        """Lazy-load the ChunkedLocalBackend for projection."""
+        if self._backend is None:
+            import torch
+
+            from .backends import ChunkedLocalBackend
+
+            device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+            self._backend = ChunkedLocalBackend(
+                model_name=self._metadata.model_id,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+        return self._backend
+
+    def project_prompt(
+        self,
+        prompt: str,
+        signal: str | None = None,
+    ) -> tuple[np.ndarray, list[str], np.ndarray | None]:
+        """Run a forward pass on a prompt and project through the scan basis.
+
+        Parameters
+        ----------
+        prompt : str
+            The prompt to visualize.
+        signal : str or None
+            If given, only project this signal. Otherwise all signals.
+
+        Returns
+        -------
+        tuple
+            (projections, tokens, log_probs)
+            - projections: [seq_len, n_layers, n_signals, max_k] float32
+            - tokens: list of decoded token strings
+            - log_probs: [seq_len] float32 next-token log-probs, or None
+        """
+        import torch
+
+        backend = self._get_backend()
+        proj_signals = [signal] if signal else self.signals
+        proj_bases = {s: self._bases[s] for s in proj_signals if s in self._bases}
+
+        projections, token_ids, logits = backend.project_forward(
+            prompt, proj_bases, proj_signals, include_logits=True,
+        )
+
+        tokens = [backend.tokenizer.decode(tid) for tid in token_ids]
+
+        log_probs = None
+        if logits is not None:
+            probs = torch.nn.functional.log_softmax(logits[0].float(), dim=-1)
+            input_ids = backend.tokenizer.encode(prompt, return_tensors="pt")[0]
+            seq_len = min(len(input_ids), probs.shape[0])
+
+            lp = np.full(seq_len, np.nan, dtype=np.float32)
+            for i in range(seq_len - 1):
+                next_token = input_ids[i + 1].item()
+                lp[i] = probs[i, next_token].item()
+            log_probs = lp[:len(token_ids)]
+
+        return projections[:len(token_ids)], tokens, log_probs
+
+    # --- Visualization ---
+
+    def plot(
+        self,
+        prompt: str,
+        *,
+        signal: str | None = None,
+        show_surprise: bool = True,
+        show_stats: bool = True,
+        figsize: tuple[float, float] | None = None,
+        title: str = "",
+    ) -> matplotlib.figure.Figure:
+        """Render the hero figure for a prompt under this scan's lens.
+
+        Parameters
+        ----------
+        prompt : str
+            The prompt to visualize.
+        signal : str or None
+            Which signal to plot. If None, plots all signals stacked.
+        show_surprise : bool
+            Show the log-probability surprise strip.
+        show_stats : bool
+            Show per-layer statistics on the right edge.
+        figsize : tuple or None
+            Figure size (width, height) in inches.
+        title : str
+            Optional figure title.
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+        """
+        from .scan_plot import render_scan_figure
+
+        projections, tokens, log_probs = self.project_prompt(prompt, signal)
+
+        # Layer stats: mean energy across tokens per (layer, signal)
+        layer_stats = np.sqrt(
+            (projections ** 2).sum(axis=3).mean(axis=0)
+        )  # [n_layers, n_signals]
+
+        # Determine which signals to show
+        show_signals = [signal] if signal else self.signals
+
+        return render_scan_figure(
+            projections=projections,
+            tokens=tokens,
+            signal_names=show_signals,
+            log_probs=log_probs if show_surprise else None,
+            layer_stats=layer_stats if show_stats else None,
+            figsize=figsize,
+            title=title,
+        )

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -435,31 +435,27 @@ class SampleScan:
             - projections_values: np.ndarray [N_total, 1, k]
             - token_ids_per_sample: list of token ID lists
             - seq_lengths: list of int
-        Also writes projections to a temporary scan dir, but the
-        returned coords can be used to reconstruct per-sample arrays.
+        The returned coords can be used to reconstruct per-sample arrays.
         """
-        import tempfile
-
         backend = self._get_backend()
         proj_signals = [signal] if signal else self.signals
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            (
-                _metadata,
-                _bases,
-                projections,
-                coords,
-                token_ids_per_sample,
-                seq_lengths,
-                _attention_mask,
-                _signal_dims,
-            ) = backend.scan_forward(
-                prompts,
-                signals=proj_signals,
-                n_components=self._metadata.n_components,
-                batch_size=batch_size,
-                external_bases=self._bases,
-            )
+        (
+            _metadata,
+            _bases,
+            projections,
+            coords,
+            token_ids_per_sample,
+            seq_lengths,
+            _attention_mask,
+            _signal_dims,
+        ) = backend.scan_forward(
+            prompts,
+            signals=proj_signals,
+            n_components=self._metadata.n_components,
+            batch_size=batch_size,
+            external_bases=self._bases,
+        )
 
         return projections, coords, token_ids_per_sample, seq_lengths
 

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -141,6 +141,7 @@ class SampleScan:
 
         scan_dir = Path(scan_dir)
 
+        backend_obj: Any
         if backend == "disk_offload":
             from .backends import DiskOffloadBackend
             backend_obj = DiskOffloadBackend(
@@ -496,6 +497,7 @@ class SampleScan:
             # Estimate model weight size from hidden_dim and n_layers
             # Rough heuristic: 2 bytes/param (bf16), ~12*hidden^2 params/layer
             est_bytes = self._metadata.n_layers * 12 * (self._metadata.hidden_dim ** 2) * 2
+            mem_avail: float
             try:
                 import os
                 mem_avail = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -54,8 +54,9 @@ class SampleScan:
 
         self._scan_dir = Path(scan_dir)
         self._metadata = scan_storage.read_metadata(self._scan_dir)
-        self._bases = scan_storage.read_basis(self._scan_dir, "0_global")
-        assert isinstance(self._bases, dict)
+        bases_loaded = scan_storage.read_basis(self._scan_dir, "0_global")
+        assert isinstance(bases_loaded, dict)
+        self._bases: dict[str, np.ndarray] = bases_loaded
         self._channel_config = scan_storage.read_channel_config(
             self._scan_dir, "0_global",
         )
@@ -415,7 +416,7 @@ class SampleScan:
         prompts: list[str],
         signal: str | None = None,
         batch_size: int = 4,
-    ) -> tuple[np.ndarray, list[list[int]], list[int]]:
+    ) -> tuple[np.ndarray, dict[str, list[Any]], list[list[int]], list[int]]:
         """Project multiple prompts through the scan basis in a single
         batched forward pass. Much faster than looping project_prompt().
 
@@ -431,11 +432,11 @@ class SampleScan:
         Returns
         -------
         tuple
-            (projections_values, token_ids_per_sample, seq_lengths)
-            - projections_values: np.ndarray [N_total, 1, k]
+            (projections, coords, token_ids_per_sample, seq_lengths)
+            - projections: np.ndarray [N_total, 1, k]
+            - coords: dict with keys sample_id, layer, token_pos, signal
             - token_ids_per_sample: list of token ID lists
             - seq_lengths: list of int
-        The returned coords can be used to reconstruct per-sample arrays.
         """
         backend = self._get_backend()
         proj_signals = [signal] if signal else self.signals

--- a/src/lmprobe/scan_plot.py
+++ b/src/lmprobe/scan_plot.py
@@ -37,6 +37,7 @@ def render_scan_figure(
     *,
     figsize: tuple[float, float] | None = None,
     title: str = "",
+    generative_mask: np.ndarray | None = None,
 ) -> matplotlib.figure.Figure:
     """Render the hero scan figure.
 
@@ -56,6 +57,9 @@ def render_scan_figure(
         (width, height) in inches.
     title : str
         Optional figure title.
+    generative_mask : np.ndarray or None
+        Boolean mask shape [seq_len]. True = generative (assistant) token,
+        False = prompt token. Prompt tokens are grayed out in the figure.
 
     Returns
     -------
@@ -72,6 +76,13 @@ def render_scan_figure(
     for sig_idx in range(n_signals):
         rgb = _normalize_rgb(projections[:, :, sig_idx, :3])  # [seq_len, n_layers, 3]
         rgb = rgb.transpose(1, 0, 2)  # [n_layers, seq_len, 3]
+        # Gray out non-generative (prompt) tokens
+        if generative_mask is not None:
+            prompt_cols = ~generative_mask  # [seq_len]
+            gray = rgb[..., :1].mean(axis=-1, keepdims=True)  # luminance
+            gray = np.broadcast_to(gray, rgb.shape).copy()
+            # Desaturate + dim prompt tokens
+            rgb[:, prompt_cols, :] = gray[:, prompt_cols, :] * 0.4 + 0.3
         signal_rgbs.append(rgb)
 
     show_surprise = log_probs is not None
@@ -177,7 +188,10 @@ def render_scan_figure(
         # Layer stats on the right
         if show_stats_col and layer_stats is not None:
             ax_stats = fig.add_subplot(gs[row, 1])
-            stats = layer_stats[:, grid_idx] if grid_idx < layer_stats.shape[1] else np.zeros(n_layers)
+            if grid_idx < layer_stats.shape[1]:
+                stats = layer_stats[:, grid_idx]
+            else:
+                stats = np.zeros(n_layers)
             ax_stats.barh(
                 range(n_layers), stats,
                 color="steelblue", alpha=0.7, height=0.8,

--- a/src/lmprobe/scan_plot.py
+++ b/src/lmprobe/scan_plot.py
@@ -99,10 +99,10 @@ def render_scan_figure(
             gray = rgb[..., :1].mean(axis=-1, keepdims=True)
             gray = np.broadcast_to(gray, rgb.shape).copy()
             rgb[:, prompt_cols, :] = gray[:, prompt_cols, :] * 0.4 + 0.3
-        # Prepend surprise row
+        # Append surprise row at bottom (after final layer)
         if show_surprise and log_probs is not None:
             surprise_rgb = _logprob_to_rgb(log_probs)[np.newaxis, :, :]  # [1, seq_len, 3]
-            rgb = np.concatenate([surprise_rgb, rgb], axis=0)  # [n_layers+1, seq_len, 3]
+            rgb = np.concatenate([rgb, surprise_rgb], axis=0)  # [n_layers+1, seq_len, 3]
         signal_rgbs.append(rgb)
 
     total_rows = n_layers + (1 if show_surprise else 0)
@@ -132,10 +132,10 @@ def render_scan_figure(
         wspace=0.05,
     )
 
-    # Y-tick labels: "surprise" row + layer numbers
+    # Y-tick labels: layer numbers + "S" at bottom
     if show_surprise:
         ytick_positions = list(range(total_rows))
-        ytick_labels = ["S"] + [str(i) if i % 4 == 0 else "" for i in range(n_layers)]
+        ytick_labels = [str(i) if i % 4 == 0 else "" for i in range(n_layers)] + ["S"]
     else:
         ytick_positions = list(range(0, n_layers, max(1, n_layers // 16)))
         ytick_labels = [str(i) for i in ytick_positions]
@@ -151,19 +151,9 @@ def render_scan_figure(
         ax.set_yticks(ytick_positions)
         ax.set_yticklabels(ytick_labels, fontsize=6)
 
-        # Token text on x-axis (top for first grid, bottom for last)
+        # Token text on x-axis (always bottom)
         ax.set_xticks(range(seq_len))
-        if grid_idx == 0:
-            ax.set_xticklabels(
-                tokens,
-                rotation=60,
-                ha="right",
-                fontsize=token_fontsize,
-                fontfamily="monospace",
-            )
-            ax.xaxis.set_ticks_position("top")
-            ax.xaxis.set_label_position("top")
-        elif grid_idx == len(signal_rgbs) - 1:
+        if grid_idx == len(signal_rgbs) - 1 or n_grids == 1:
             ax.set_xticklabels(
                 tokens,
                 rotation=60,
@@ -181,10 +171,9 @@ def render_scan_figure(
                 stats = layer_stats[:, grid_idx]
             else:
                 stats = np.zeros(n_layers)
-            # Offset by 1 if surprise row is present
-            y_offset = 1 if show_surprise else 0
+            # No offset needed — surprise is at the bottom now
             ax_stats.barh(
-                np.arange(n_layers) + y_offset, stats,
+                np.arange(n_layers), stats,
                 color="steelblue", alpha=0.7, height=0.8,
             )
             ax_stats.set_ylim(-0.5, total_rows - 0.5)

--- a/src/lmprobe/scan_plot.py
+++ b/src/lmprobe/scan_plot.py
@@ -2,7 +2,8 @@
 
 Renders a 2D RGB image of a model forward pass on a single prompt:
 tokens on x-axis, layers on y-axis, RGB channels from top-3 PCA
-components of each signal at that coordinate.
+components of each signal at that coordinate. Surprise (log-prob)
+is appended as a top row in the heatmap.
 """
 
 from __future__ import annotations
@@ -26,6 +27,18 @@ def _normalize_rgb(arr: np.ndarray) -> np.ndarray:
         else:
             result[..., c] = 0.5
     return result
+
+
+def _logprob_to_rgb(log_probs: np.ndarray) -> np.ndarray:
+    """Convert log-prob values to RGB using RdYlGn colormap."""
+    import matplotlib.pyplot as plt
+
+    cmap = plt.get_cmap("RdYlGn")
+    # Normalize: clip to [-10, 0] range, map to [0, 1]
+    normed = np.clip(log_probs, -10, 0) / -10  # 0 = high prob, 1 = low prob
+    normed = 1 - normed  # flip so green = high prob
+    rgba = cmap(normed)
+    return rgba[:, :3].astype(np.float32)  # drop alpha
 
 
 def render_scan_figure(
@@ -70,28 +83,33 @@ def render_scan_figure(
 
     seq_len, n_layers, n_signals, k = projections.shape
     n_grids = n_signals
+    show_surprise = log_probs is not None
+    show_stats_col = layer_stats is not None
 
     # Build RGB image per signal: [n_layers, seq_len, 3]
+    # If surprise is shown, prepend a surprise row: [n_layers+1, seq_len, 3]
     signal_rgbs = []
     for sig_idx in range(n_signals):
         rgb = _normalize_rgb(projections[:, :, sig_idx, :3])  # [seq_len, n_layers, 3]
         rgb = rgb.transpose(1, 0, 2)  # [n_layers, seq_len, 3]
         # Gray out non-generative (prompt) tokens
         if generative_mask is not None:
-            prompt_cols = ~generative_mask  # [seq_len]
-            gray = rgb[..., :1].mean(axis=-1, keepdims=True)  # luminance
+            prompt_cols = ~generative_mask
+            gray = rgb[..., :1].mean(axis=-1, keepdims=True)
             gray = np.broadcast_to(gray, rgb.shape).copy()
-            # Desaturate + dim prompt tokens
             rgb[:, prompt_cols, :] = gray[:, prompt_cols, :] * 0.4 + 0.3
+        # Prepend surprise row
+        if show_surprise and log_probs is not None:
+            surprise_rgb = _logprob_to_rgb(log_probs)[np.newaxis, :, :]  # [1, seq_len, 3]
+            rgb = np.concatenate([surprise_rgb, rgb], axis=0)  # [n_layers+1, seq_len, 3]
         signal_rgbs.append(rgb)
 
-    show_surprise = log_probs is not None
-    show_stats_col = layer_stats is not None
+    total_rows = n_layers + (1 if show_surprise else 0)
 
     # Figure sizing
     if figsize is None:
         width = max(8, seq_len * 0.35 + (2 if show_stats_col else 0))
-        height_per_grid = max(3, n_layers * 0.15)
+        height_per_grid = max(3, total_rows * 0.15)
         height = (
             1.5
             + height_per_grid * n_grids
@@ -102,107 +120,77 @@ def render_scan_figure(
 
     fig = plt.figure(figsize=figsize)
 
-    n_rows = n_grids + (1 if show_surprise else 0)
-    height_ratios = []
-    if show_surprise:
-        height_ratios.append(1)
-    for _ in range(n_grids):
-        height_ratios.append(n_layers)
-
     n_cols = 2 if show_stats_col else 1
     width_ratios = [seq_len, max(2, seq_len // 10)] if show_stats_col else [1]
 
     gs = GridSpec(
-        n_rows, n_cols,
+        n_grids, n_cols,
         figure=fig,
-        height_ratios=height_ratios,
         width_ratios=width_ratios,
         hspace=0.3,
         wspace=0.05,
     )
 
-    row = 0
+    # Y-tick labels: "surprise" row + layer numbers
+    if show_surprise:
+        ytick_positions = list(range(total_rows))
+        ytick_labels = ["S"] + [str(i) if i % 4 == 0 else "" for i in range(n_layers)]
+    else:
+        ytick_positions = list(range(0, n_layers, max(1, n_layers // 16)))
+        ytick_labels = [str(i) for i in ytick_positions]
 
-    # --- Surprise strip ---
-    if show_surprise and log_probs is not None:
-        ax_surprise = fig.add_subplot(gs[row, 0])
-        lp_display = log_probs[np.newaxis, :]
-        ax_surprise.imshow(
-            lp_display,
-            aspect="auto",
-            cmap="RdYlGn",
-            interpolation="nearest",
-        )
-        ax_surprise.set_yticks([])
-        ax_surprise.set_ylabel("surprise", fontsize=8, rotation=0, labelpad=40)
+    # Token text for x-axis
+    token_fontsize = max(4, min(8, 200 // max(seq_len, 1)))
 
-        ax_surprise.set_xticks(range(seq_len))
-        ax_surprise.set_xticklabels(
-            tokens,
-            rotation=60,
-            ha="right",
-            fontsize=max(5, min(8, 200 // max(seq_len, 1))),
-            fontfamily="monospace",
-        )
-        ax_surprise.xaxis.set_ticks_position("top")
-        ax_surprise.xaxis.set_label_position("top")
-
-        if show_stats_col:
-            ax_empty = fig.add_subplot(gs[row, 1])
-            ax_empty.axis("off")
-
-        row += 1
-
-    # --- Signal grids ---
     for grid_idx, (rgb, sig_name) in enumerate(zip(signal_rgbs, signal_names)):
-        ax = fig.add_subplot(gs[row, 0])
+        ax = fig.add_subplot(gs[grid_idx, 0])
         ax.imshow(rgb, aspect="auto", interpolation="nearest")
         ax.set_ylabel(sig_name, fontsize=9, rotation=0, labelpad=60)
 
-        if n_layers <= 64:
-            ax.set_yticks(range(0, n_layers, max(1, n_layers // 16)))
-        else:
-            ax.set_yticks(range(0, n_layers, n_layers // 8))
+        ax.set_yticks(ytick_positions)
+        ax.set_yticklabels(ytick_labels, fontsize=6)
 
-        # Token labels on first grid if no surprise strip
-        if not show_surprise and grid_idx == 0:
-            ax.set_xticks(range(seq_len))
+        # Token text on x-axis (top for first grid, bottom for last)
+        ax.set_xticks(range(seq_len))
+        if grid_idx == 0:
             ax.set_xticklabels(
                 tokens,
                 rotation=60,
                 ha="right",
-                fontsize=max(5, min(8, 200 // max(seq_len, 1))),
+                fontsize=token_fontsize,
                 fontfamily="monospace",
             )
             ax.xaxis.set_ticks_position("top")
             ax.xaxis.set_label_position("top")
         elif grid_idx == len(signal_rgbs) - 1:
-            ax.set_xticks(range(seq_len))
             ax.set_xticklabels(
-                [str(i) for i in range(seq_len)],
-                fontsize=6,
+                tokens,
+                rotation=60,
+                ha="right",
+                fontsize=token_fontsize,
+                fontfamily="monospace",
             )
         else:
-            ax.set_xticks([])
+            ax.set_xticklabels([])
 
         # Layer stats on the right
         if show_stats_col and layer_stats is not None:
-            ax_stats = fig.add_subplot(gs[row, 1])
+            ax_stats = fig.add_subplot(gs[grid_idx, 1])
             if grid_idx < layer_stats.shape[1]:
                 stats = layer_stats[:, grid_idx]
             else:
                 stats = np.zeros(n_layers)
+            # Offset by 1 if surprise row is present
+            y_offset = 1 if show_surprise else 0
             ax_stats.barh(
-                range(n_layers), stats,
+                np.arange(n_layers) + y_offset, stats,
                 color="steelblue", alpha=0.7, height=0.8,
             )
-            ax_stats.set_ylim(-0.5, n_layers - 0.5)
+            ax_stats.set_ylim(-0.5, total_rows - 0.5)
             ax_stats.invert_yaxis()
             ax_stats.set_yticks([])
             ax_stats.set_xlabel("energy", fontsize=7)
             ax_stats.tick_params(axis="x", labelsize=6)
-
-        row += 1
 
     if title:
         fig.suptitle(title, fontsize=12, y=0.98)

--- a/src/lmprobe/scan_plot.py
+++ b/src/lmprobe/scan_plot.py
@@ -1,0 +1,196 @@
+"""Hero figure renderer for SampleScan.
+
+Renders a 2D RGB image of a model forward pass on a single prompt:
+tokens on x-axis, layers on y-axis, RGB channels from top-3 PCA
+components of each signal at that coordinate.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import matplotlib.figure
+
+
+def _normalize_rgb(arr: np.ndarray) -> np.ndarray:
+    """Normalize a 3-channel array to [0, 1] per channel across the full image."""
+    result = np.zeros_like(arr, dtype=np.float32)
+    for c in range(min(3, arr.shape[-1])):
+        channel = arr[..., c].astype(np.float32)
+        cmin, cmax = channel.min(), channel.max()
+        if cmax - cmin > 1e-10:
+            result[..., c] = (channel - cmin) / (cmax - cmin)
+        else:
+            result[..., c] = 0.5
+    return result
+
+
+def render_scan_figure(
+    projections: np.ndarray,
+    tokens: list[str],
+    signal_names: list[str],
+    log_probs: np.ndarray | None = None,
+    layer_stats: np.ndarray | None = None,
+    *,
+    figsize: tuple[float, float] | None = None,
+    title: str = "",
+) -> matplotlib.figure.Figure:
+    """Render the hero scan figure.
+
+    Parameters
+    ----------
+    projections : np.ndarray
+        Shape [seq_len, n_layers, n_signals, k] where k >= 3.
+    tokens : list[str]
+        Decoded token strings, one per sequence position.
+    signal_names : list[str]
+        Names of signals, one per projections dim 2.
+    log_probs : np.ndarray or None
+        Shape [seq_len] next-token log-probabilities.
+    layer_stats : np.ndarray or None
+        Shape [n_layers, n_signals] per-layer statistics.
+    figsize : tuple or None
+        (width, height) in inches.
+    title : str
+        Optional figure title.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    import matplotlib.pyplot as plt
+    from matplotlib.gridspec import GridSpec
+
+    seq_len, n_layers, n_signals, k = projections.shape
+    n_grids = n_signals
+
+    # Build RGB image per signal: [n_layers, seq_len, 3]
+    signal_rgbs = []
+    for sig_idx in range(n_signals):
+        rgb = _normalize_rgb(projections[:, :, sig_idx, :3])  # [seq_len, n_layers, 3]
+        rgb = rgb.transpose(1, 0, 2)  # [n_layers, seq_len, 3]
+        signal_rgbs.append(rgb)
+
+    show_surprise = log_probs is not None
+    show_stats_col = layer_stats is not None
+
+    # Figure sizing
+    if figsize is None:
+        width = max(8, seq_len * 0.35 + (2 if show_stats_col else 0))
+        height_per_grid = max(3, n_layers * 0.15)
+        height = (
+            1.5
+            + height_per_grid * n_grids
+            + 0.5 * max(0, n_grids - 1)
+            + (0.5 if title else 0)
+        )
+        figsize = (min(width, 40), min(height, 30))
+
+    fig = plt.figure(figsize=figsize)
+
+    n_rows = n_grids + (1 if show_surprise else 0)
+    height_ratios = []
+    if show_surprise:
+        height_ratios.append(1)
+    for _ in range(n_grids):
+        height_ratios.append(n_layers)
+
+    n_cols = 2 if show_stats_col else 1
+    width_ratios = [seq_len, max(2, seq_len // 10)] if show_stats_col else [1]
+
+    gs = GridSpec(
+        n_rows, n_cols,
+        figure=fig,
+        height_ratios=height_ratios,
+        width_ratios=width_ratios,
+        hspace=0.3,
+        wspace=0.05,
+    )
+
+    row = 0
+
+    # --- Surprise strip ---
+    if show_surprise and log_probs is not None:
+        ax_surprise = fig.add_subplot(gs[row, 0])
+        lp_display = log_probs[np.newaxis, :]
+        ax_surprise.imshow(
+            lp_display,
+            aspect="auto",
+            cmap="RdYlGn",
+            interpolation="nearest",
+        )
+        ax_surprise.set_yticks([])
+        ax_surprise.set_ylabel("surprise", fontsize=8, rotation=0, labelpad=40)
+
+        ax_surprise.set_xticks(range(seq_len))
+        ax_surprise.set_xticklabels(
+            tokens,
+            rotation=60,
+            ha="right",
+            fontsize=max(5, min(8, 200 // max(seq_len, 1))),
+            fontfamily="monospace",
+        )
+        ax_surprise.xaxis.set_ticks_position("top")
+        ax_surprise.xaxis.set_label_position("top")
+
+        if show_stats_col:
+            ax_empty = fig.add_subplot(gs[row, 1])
+            ax_empty.axis("off")
+
+        row += 1
+
+    # --- Signal grids ---
+    for grid_idx, (rgb, sig_name) in enumerate(zip(signal_rgbs, signal_names)):
+        ax = fig.add_subplot(gs[row, 0])
+        ax.imshow(rgb, aspect="auto", interpolation="nearest")
+        ax.set_ylabel(sig_name, fontsize=9, rotation=0, labelpad=60)
+
+        if n_layers <= 64:
+            ax.set_yticks(range(0, n_layers, max(1, n_layers // 16)))
+        else:
+            ax.set_yticks(range(0, n_layers, n_layers // 8))
+
+        # Token labels on first grid if no surprise strip
+        if not show_surprise and grid_idx == 0:
+            ax.set_xticks(range(seq_len))
+            ax.set_xticklabels(
+                tokens,
+                rotation=60,
+                ha="right",
+                fontsize=max(5, min(8, 200 // max(seq_len, 1))),
+                fontfamily="monospace",
+            )
+            ax.xaxis.set_ticks_position("top")
+            ax.xaxis.set_label_position("top")
+        elif grid_idx == len(signal_rgbs) - 1:
+            ax.set_xticks(range(seq_len))
+            ax.set_xticklabels(
+                [str(i) for i in range(seq_len)],
+                fontsize=6,
+            )
+        else:
+            ax.set_xticks([])
+
+        # Layer stats on the right
+        if show_stats_col and layer_stats is not None:
+            ax_stats = fig.add_subplot(gs[row, 1])
+            stats = layer_stats[:, grid_idx] if grid_idx < layer_stats.shape[1] else np.zeros(n_layers)
+            ax_stats.barh(
+                range(n_layers), stats,
+                color="steelblue", alpha=0.7, height=0.8,
+            )
+            ax_stats.set_ylim(-0.5, n_layers - 0.5)
+            ax_stats.invert_yaxis()
+            ax_stats.set_yticks([])
+            ax_stats.set_xlabel("energy", fontsize=7)
+            ax_stats.tick_params(axis="x", labelsize=6)
+
+        row += 1
+
+    if title:
+        fig.suptitle(title, fontsize=12, y=0.98)
+
+    return fig

--- a/src/lmprobe/scan_plot.py
+++ b/src/lmprobe/scan_plot.py
@@ -38,7 +38,8 @@ def _logprob_to_rgb(log_probs: np.ndarray) -> np.ndarray:
     normed = np.clip(log_probs, -10, 0) / -10  # 0 = high prob, 1 = low prob
     normed = 1 - normed  # flip so green = high prob
     rgba = cmap(normed)
-    return rgba[:, :3].astype(np.float32)  # drop alpha
+    result: np.ndarray = rgba[:, :3].astype(np.float32)  # drop alpha
+    return result
 
 
 def render_scan_figure(

--- a/src/lmprobe/scan_storage.py
+++ b/src/lmprobe/scan_storage.py
@@ -151,10 +151,11 @@ def read_basis(
     channel_dir = scan_dir / "channels" / channel
 
     if signal is not None:
-        return np.load(channel_dir / f"basis_{signal}.npy")
+        result: np.ndarray = np.load(channel_dir / f"basis_{signal}.npy")
+        return result
 
     # Load all signal bases
-    bases = {}
+    bases: dict[str, np.ndarray] = {}
     for path in sorted(channel_dir.glob("basis_*.npy")):
         # Extract signal name from "basis_attn_delta.npy" -> "attn_delta"
         sig_name = path.stem[len("basis_"):]
@@ -165,7 +166,8 @@ def read_basis(
 def read_channel_config(scan_dir: Path, channel: str = "0_global") -> dict[str, Any]:
     """Read channel config."""
     with open(scan_dir / "channels" / channel / "config.json") as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
 def write_projections(
@@ -210,9 +212,10 @@ def open_projections(scan_dir: Path) -> np.memmap:
 
     Returns memmap of shape [N_total, n_channels, k].
     """
-    return np.load(
+    result: np.memmap = np.load(
         scan_dir / "projections" / "values.npy", mmap_mode="r"
     )
+    return result
 
 
 def read_coords(scan_dir: Path) -> Any:

--- a/src/lmprobe/scan_storage.py
+++ b/src/lmprobe/scan_storage.py
@@ -1,0 +1,223 @@
+"""Storage I/O for SampleScan artifacts.
+
+Handles reading and writing the scan directory structure:
+
+    scan_dir/
+      metadata.json
+      samples/samples.parquet
+      channels/<channel_name>/
+        config.json
+        basis_{signal}.npy       # [n_layers, signal_dim, k_eff] float16
+      projections/
+        values.npy               # [N_total, n_channels, k] float16
+        coords.parquet           # sample_id, layer, token_pos, signal
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _require_pyarrow() -> Any:
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq  # noqa: F401
+
+        return pa
+    except ImportError:
+        raise ImportError(
+            "pyarrow is required for SampleScan storage. "
+            "Install it with: pip install 'lmprobe[scan]'"
+        )
+
+
+@dataclass
+class SignalInfo:
+    """Metadata for a single signal type."""
+
+    name: str
+    dim: int          # hidden_dim for activations, n_experts for router_logits
+    k_effective: int  # min(n_components, dim) — actual PCA components stored
+
+
+@dataclass
+class ScanMetadata:
+    """Metadata for a SampleScan artifact."""
+
+    model_id: str
+    hidden_dim: int
+    n_layers: int
+    n_components: int
+    n_samples: int
+    creation_date: str
+    signals: list[str] = field(default_factory=lambda: ["attn_delta", "mlp_delta"])
+
+
+def write_metadata(scan_dir: Path, metadata: ScanMetadata) -> None:
+    """Write metadata.json to scan directory."""
+    scan_dir.mkdir(parents=True, exist_ok=True)
+    with open(scan_dir / "metadata.json", "w") as f:
+        json.dump(asdict(metadata), f, indent=2)
+
+
+def read_metadata(scan_dir: Path) -> ScanMetadata:
+    """Read metadata.json from scan directory."""
+    with open(scan_dir / "metadata.json") as f:
+        data = json.load(f)
+    # Handle scans created before signals field existed
+    if "signals" not in data:
+        data["signals"] = ["attn_delta", "mlp_delta"]
+    return ScanMetadata(**data)
+
+
+def write_samples(
+    scan_dir: Path,
+    sample_ids: list[int],
+    prompts: list[str],
+    labels: list[int],
+    token_ids_list: list[list[int]],
+    seq_lengths: list[int],
+) -> None:
+    """Write samples parquet."""
+    pa = _require_pyarrow()
+    import pyarrow.parquet as pq
+
+    samples_dir = scan_dir / "samples"
+    samples_dir.mkdir(parents=True, exist_ok=True)
+
+    table = pa.table(
+        {
+            "sample_id": pa.array(sample_ids, type=pa.int32()),
+            "prompt_text": pa.array(prompts, type=pa.utf8()),
+            "label": pa.array(labels, type=pa.int32()),
+            "token_ids": pa.array(token_ids_list, type=pa.list_(pa.int32())),
+            "seq_length": pa.array(seq_lengths, type=pa.int32()),
+        }
+    )
+    pq.write_table(table, samples_dir / "samples.parquet")
+
+
+def read_samples(scan_dir: Path) -> Any:
+    """Read samples parquet. Returns pyarrow Table."""
+    _require_pyarrow()
+    import pyarrow.parquet as pq
+
+    return pq.read_table(scan_dir / "samples" / "samples.parquet")
+
+
+def write_channel(
+    scan_dir: Path,
+    channel_name: str,
+    bases: dict[str, np.ndarray],
+    config: dict[str, Any],
+) -> None:
+    """Write a channel's per-signal bases and config.
+
+    Parameters
+    ----------
+    bases : dict[str, np.ndarray]
+        Maps signal name to basis array of shape [n_layers, signal_dim, k_eff].
+    config : dict
+        Channel configuration (name, k, fit_method, signals info, etc.).
+    """
+    channel_dir = scan_dir / "channels" / channel_name
+    channel_dir.mkdir(parents=True, exist_ok=True)
+
+    for signal_name, basis in bases.items():
+        np.save(channel_dir / f"basis_{signal_name}.npy", basis)
+
+    with open(channel_dir / "config.json", "w") as f:
+        json.dump(config, f, indent=2)
+
+
+def read_basis(
+    scan_dir: Path,
+    channel: str = "0_global",
+    signal: str | None = None,
+) -> np.ndarray | dict[str, np.ndarray]:
+    """Read basis vectors for a channel.
+
+    Parameters
+    ----------
+    signal : str or None
+        If given, return basis for that signal only: [n_layers, dim, k].
+        If None, return dict mapping signal name to basis array.
+    """
+    channel_dir = scan_dir / "channels" / channel
+
+    if signal is not None:
+        return np.load(channel_dir / f"basis_{signal}.npy")
+
+    # Load all signal bases
+    bases = {}
+    for path in sorted(channel_dir.glob("basis_*.npy")):
+        # Extract signal name from "basis_attn_delta.npy" -> "attn_delta"
+        sig_name = path.stem[len("basis_"):]
+        bases[sig_name] = np.load(path)
+    return bases
+
+
+def read_channel_config(scan_dir: Path, channel: str = "0_global") -> dict[str, Any]:
+    """Read channel config."""
+    with open(scan_dir / "channels" / channel / "config.json") as f:
+        return json.load(f)
+
+
+def write_projections(
+    scan_dir: Path,
+    values: np.ndarray,
+    coords_sample_id: np.ndarray,
+    coords_layer: np.ndarray,
+    coords_token_pos: np.ndarray,
+    coords_signal: np.ndarray,
+) -> None:
+    """Write projections (values + coordinates).
+
+    Parameters
+    ----------
+    values : np.ndarray
+        Shape [N_total, n_channels, k] float16. k is padded to the max
+        across all signals.
+    coords_signal : np.ndarray
+        Signal index (int8), indexing into metadata.signals.
+    """
+    pa = _require_pyarrow()
+    import pyarrow.parquet as pq
+
+    proj_dir = scan_dir / "projections"
+    proj_dir.mkdir(parents=True, exist_ok=True)
+
+    np.save(proj_dir / "values.npy", values)
+
+    table = pa.table(
+        {
+            "sample_id": pa.array(coords_sample_id, type=pa.int32()),
+            "layer": pa.array(coords_layer, type=pa.int16()),
+            "token_pos": pa.array(coords_token_pos, type=pa.int16()),
+            "signal": pa.array(coords_signal, type=pa.int8()),
+        }
+    )
+    pq.write_table(table, proj_dir / "coords.parquet")
+
+
+def open_projections(scan_dir: Path) -> np.memmap:
+    """Memory-map the projections values array.
+
+    Returns memmap of shape [N_total, n_channels, k].
+    """
+    return np.load(
+        scan_dir / "projections" / "values.npy", mmap_mode="r"
+    )
+
+
+def read_coords(scan_dir: Path) -> Any:
+    """Read coordinates parquet. Returns pyarrow Table."""
+    _require_pyarrow()
+    import pyarrow.parquet as pq
+
+    return pq.read_table(scan_dir / "projections" / "coords.parquet")

--- a/tests/test_chunked_backend.py
+++ b/tests/test_chunked_backend.py
@@ -61,6 +61,26 @@ class TestChunkedBackendInterface:
         assert backend.tokenizer is not None
         assert backend.tokenizer.pad_token is not None
 
+    def test_attn_implementation_default_is_sdpa(self, tiny_model):
+        backend = ChunkedLocalBackend(tiny_model, "cpu", chunk_size=1)
+        assert backend._attn_implementation == "sdpa"
+
+    def test_attn_implementation_override(self, tiny_model):
+        backend = ChunkedLocalBackend(
+            tiny_model, "cpu", chunk_size=1, attn_implementation="eager",
+        )
+        assert backend._attn_implementation == "eager"
+
+    def test_attn_implementation_propagates_to_loaded_model(self, tiny_model):
+        backend = ChunkedLocalBackend(
+            tiny_model, "cpu", chunk_size=1, attn_implementation="eager",
+        )
+        model = backend._load_full_model_cpu()
+        # Most transformers models expose the resolved attention impl on
+        # config._attn_implementation after load.
+        resolved = getattr(model.config, "_attn_implementation", None)
+        assert resolved == "eager", f"expected eager, got {resolved!r}"
+
 
 # ── Correctness: chunked matches local ──────────────────────────────────────
 

--- a/tests/test_sample_scan.py
+++ b/tests/test_sample_scan.py
@@ -1,0 +1,513 @@
+"""Tests for SampleScan feature.
+
+Verifies storage I/O, delta capture, scan pipeline, projection,
+visualization, and separability queries using synthetic data and
+the tiny-random-llama-2 model.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from tests.conftest import NEGATIVE_PROMPTS, POSITIVE_PROMPTS, TEST_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Storage tests (no model needed)
+# ---------------------------------------------------------------------------
+
+
+class TestStorage:
+    """Roundtrip write/read tests with synthetic data."""
+
+    def test_write_read_metadata_roundtrip(self, tmp_path):
+        from lmprobe.scan_storage import ScanMetadata, read_metadata, write_metadata
+
+        meta = ScanMetadata(
+            model_id="test-model",
+            hidden_dim=64,
+            n_layers=4,
+            n_components=8,
+            n_samples=10,
+            creation_date="2026-04-15T00:00:00Z",
+            signals=["attn_delta", "mlp_delta"],
+        )
+        write_metadata(tmp_path, meta)
+        loaded = read_metadata(tmp_path)
+        assert loaded.model_id == "test-model"
+        assert loaded.hidden_dim == 64
+        assert loaded.n_layers == 4
+        assert loaded.n_components == 8
+        assert loaded.signals == ["attn_delta", "mlp_delta"]
+
+    def test_write_read_samples_roundtrip(self, tmp_path):
+        from lmprobe.scan_storage import read_samples, write_samples
+
+        write_samples(
+            tmp_path,
+            sample_ids=[0, 1, 2],
+            prompts=["a", "b", "c"],
+            labels=[0, 1, 0],
+            token_ids_list=[[1, 2], [3, 4, 5], [6]],
+            seq_lengths=[2, 3, 1],
+        )
+        table = read_samples(tmp_path)
+        assert table.num_rows == 3
+        assert table.column("prompt_text").to_pylist() == ["a", "b", "c"]
+        assert table.column("label").to_pylist() == [0, 1, 0]
+
+    def test_write_read_basis_roundtrip(self, tmp_path):
+        from lmprobe.scan_storage import read_basis, write_channel
+
+        bases = {
+            "attn_delta": np.random.randn(4, 64, 8).astype(np.float16),
+            "mlp_delta": np.random.randn(4, 64, 8).astype(np.float16),
+        }
+        write_channel(
+            tmp_path,
+            channel_name="0_global",
+            bases=bases,
+            config={"name": "global", "k": 8, "fit_method": "pca"},
+        )
+        loaded = read_basis(tmp_path, "0_global")
+        assert isinstance(loaded, dict)
+        assert set(loaded.keys()) == {"attn_delta", "mlp_delta"}
+        np.testing.assert_array_equal(loaded["attn_delta"], bases["attn_delta"])
+
+    def test_read_single_signal_basis(self, tmp_path):
+        from lmprobe.scan_storage import read_basis, write_channel
+
+        bases = {
+            "attn_delta": np.random.randn(4, 64, 8).astype(np.float16),
+        }
+        write_channel(tmp_path, "0_global", bases, {"name": "global"})
+        loaded = read_basis(tmp_path, "0_global", signal="attn_delta")
+        assert isinstance(loaded, np.ndarray)
+        np.testing.assert_array_equal(loaded, bases["attn_delta"])
+
+    def test_write_read_channel_config(self, tmp_path):
+        from lmprobe.scan_storage import read_channel_config, write_channel
+
+        bases = {"attn_delta": np.zeros((4, 64, 8), dtype=np.float16)}
+        config = {"name": "global", "k": 8, "fit_method": "pca"}
+        write_channel(tmp_path, "0_global", bases, config)
+        loaded = read_channel_config(tmp_path, "0_global")
+        assert loaded["name"] == "global"
+        assert loaded["k"] == 8
+
+    def test_projections_roundtrip(self, tmp_path):
+        from lmprobe.scan_storage import (
+            open_projections,
+            read_coords,
+            write_projections,
+        )
+
+        N = 100
+        k = 8
+        values = np.random.randn(N, 1, k).astype(np.float16)
+        sample_ids = np.zeros(N, dtype=np.int32)
+        layers = np.repeat(np.arange(4), 25).astype(np.int16)
+        token_pos = np.tile(np.arange(25), 4).astype(np.int16)
+        signal_idx = np.zeros(N, dtype=np.int8)
+
+        write_projections(
+            tmp_path, values, sample_ids, layers, token_pos, signal_idx,
+        )
+
+        loaded_values = open_projections(tmp_path)
+        assert loaded_values.shape == (N, 1, k)
+        np.testing.assert_array_equal(loaded_values, values)
+
+        coords = read_coords(tmp_path)
+        assert coords.num_rows == N
+        assert "signal" in coords.column_names
+
+    def test_projections_memmap(self, tmp_path):
+        from lmprobe.scan_storage import open_projections, write_projections
+
+        N = 50
+        values = np.random.randn(N, 1, 4).astype(np.float16)
+        write_projections(
+            tmp_path, values,
+            np.zeros(N, dtype=np.int32),
+            np.zeros(N, dtype=np.int16),
+            np.zeros(N, dtype=np.int16),
+            np.zeros(N, dtype=np.int8),
+        )
+        mm = open_projections(tmp_path)
+        assert isinstance(mm, np.memmap) or isinstance(mm, np.ndarray)
+        assert mm.shape == (N, 1, 4)
+
+
+# ---------------------------------------------------------------------------
+# Delta capture tests (requires tiny model)
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaCapture:
+    """Test that hooks capture attention and MLP deltas correctly."""
+
+    def test_attn_submodule_found(self, tiny_model):
+        from transformers import AutoModelForCausalLM
+
+        from lmprobe.backends import _get_attn_submodule, _get_decoder_layers
+
+        model = AutoModelForCausalLM.from_pretrained(tiny_model)
+        layers = _get_decoder_layers(model)
+        attn = _get_attn_submodule(layers[0])
+        assert attn is not None
+
+    def test_mlp_submodule_found(self, tiny_model):
+        from transformers import AutoModelForCausalLM
+
+        from lmprobe.backends import _get_decoder_layers, _get_mlp_submodule
+
+        model = AutoModelForCausalLM.from_pretrained(tiny_model)
+        layers = _get_decoder_layers(model)
+        mlp = _get_mlp_submodule(layers[0])
+        assert mlp is not None
+
+    def test_hook_captures_tensor(self, tiny_model):
+        """Verify forward hooks on self_attn and mlp capture tensors."""
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        from lmprobe.backends import (
+            _get_attn_submodule,
+            _get_decoder_layers,
+            _get_mlp_submodule,
+        )
+
+        model = AutoModelForCausalLM.from_pretrained(tiny_model)
+        tokenizer = AutoTokenizer.from_pretrained(tiny_model)
+        model.eval()
+
+        tokens = tokenizer("Hello world", return_tensors="pt")
+        layers = _get_decoder_layers(model)
+        layer0 = layers[0]
+
+        attn_buf: list[torch.Tensor] = []
+        mlp_buf: list[torch.Tensor] = []
+
+        def _attn_hook(_mod, _inp, out, _buf=attn_buf):
+            delta = out[0] if isinstance(out, tuple) else out
+            _buf.append(delta.detach())
+
+        def _mlp_hook(_mod, _inp, out, _buf=mlp_buf):
+            delta = out[0] if isinstance(out, tuple) else out
+            _buf.append(delta.detach())
+
+        h1 = _get_attn_submodule(layer0).register_forward_hook(_attn_hook)
+        h2 = _get_mlp_submodule(layer0).register_forward_hook(_mlp_hook)
+
+        with torch.no_grad():
+            model(**tokens)
+
+        h1.remove()
+        h2.remove()
+
+        assert len(attn_buf) == 1
+        assert len(mlp_buf) == 1
+        assert attn_buf[0].ndim == 3
+        assert mlp_buf[0].ndim == 3
+        assert attn_buf[0].shape == mlp_buf[0].shape
+
+
+# ---------------------------------------------------------------------------
+# SampleScan.run() integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestScanRun:
+    """End-to-end tests for SampleScan.run() with tiny model."""
+
+    @pytest.fixture
+    def scan(self, tmp_path):
+        """Run a scan and return (scan, scan_dir)."""
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+        labels = [1, 1, 1, 0, 0, 0]
+
+        scan = SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "test_scan",
+            signals=["attn_delta", "mlp_delta"],
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+        return scan, tmp_path / "test_scan"
+
+    def test_creates_directory_structure(self, scan):
+        _, scan_dir = scan
+        assert (scan_dir / "metadata.json").exists()
+        assert (scan_dir / "samples" / "samples.parquet").exists()
+        assert (scan_dir / "channels" / "0_global" / "basis_attn_delta.npy").exists()
+        assert (scan_dir / "channels" / "0_global" / "basis_mlp_delta.npy").exists()
+        assert (scan_dir / "channels" / "0_global" / "config.json").exists()
+        assert (scan_dir / "projections" / "values.npy").exists()
+        assert (scan_dir / "projections" / "coords.parquet").exists()
+
+    def test_metadata_correct(self, scan):
+        scan_obj, scan_dir = scan
+        with open(scan_dir / "metadata.json") as f:
+            meta = json.load(f)
+        assert meta["model_id"] == TEST_MODEL
+        assert meta["n_samples"] == 6
+        assert meta["n_components"] == 4
+        assert meta["n_layers"] > 0
+        assert meta["hidden_dim"] > 0
+        assert meta["signals"] == ["attn_delta", "mlp_delta"]
+
+    def test_signals_property(self, scan):
+        scan_obj, _ = scan
+        assert scan_obj.signals == ["attn_delta", "mlp_delta"]
+
+    def test_bases_per_signal(self, scan):
+        scan_obj, _ = scan
+        bases = scan_obj.bases
+        assert isinstance(bases, dict)
+        assert "attn_delta" in bases
+        assert "mlp_delta" in bases
+        # [n_layers, hidden_dim, k_eff]
+        for sig, basis in bases.items():
+            assert basis.ndim == 3
+            assert basis.shape[0] == scan_obj.n_layers
+
+    def test_projections_shape(self, scan):
+        _, scan_dir = scan
+        from lmprobe.scan_storage import open_projections
+
+        values = open_projections(scan_dir)
+        assert values.ndim == 3
+        assert values.shape[1] == 1
+
+    def test_coords_match_projections(self, scan):
+        _, scan_dir = scan
+        from lmprobe.scan_storage import open_projections, read_coords
+
+        values = open_projections(scan_dir)
+        coords = read_coords(scan_dir)
+        assert coords.num_rows == values.shape[0]
+        assert "signal" in coords.column_names
+
+    def test_load_from_disk(self, scan):
+        from lmprobe.sample_scan import SampleScan
+
+        _, scan_dir = scan
+        loaded = SampleScan(scan_dir)
+        assert loaded.n_samples == 6
+        assert loaded.n_layers > 0
+        assert loaded.signals == ["attn_delta", "mlp_delta"]
+
+
+class TestScanWithResidual:
+    """Test scan with residual signal."""
+
+    def test_residual_signal(self, tmp_path):
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:2] + NEGATIVE_PROMPTS[:2]
+        labels = [1, 1, 0, 0]
+
+        scan = SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "res_scan",
+            signals=["residual"],
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+        assert scan.signals == ["residual"]
+        assert "residual" in scan.bases
+
+
+# ---------------------------------------------------------------------------
+# Projection tests
+# ---------------------------------------------------------------------------
+
+
+class TestProjectPrompt:
+    """Test projecting a new prompt onto an existing scan basis."""
+
+    @pytest.fixture
+    def scan(self, tmp_path):
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+        labels = [1, 1, 1, 0, 0, 0]
+
+        return SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "proj_scan",
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+
+    def test_project_shape(self, scan):
+        projections, tokens, log_probs = scan.project_prompt("Hello world")
+        # [seq_len, n_layers, n_signals, k]
+        assert projections.ndim == 4
+        assert projections.shape[1] == scan.n_layers
+        assert projections.shape[2] == len(scan.signals)
+        assert len(tokens) == projections.shape[0]
+
+    def test_project_single_signal(self, scan):
+        projections, tokens, _ = scan.project_prompt("Hello world", signal="attn_delta")
+        assert projections.shape[2] == 1  # single signal
+
+    def test_project_has_log_probs(self, scan):
+        _, _, log_probs = scan.project_prompt("Hello world")
+        assert log_probs is not None
+        assert log_probs.ndim == 1
+
+    def test_project_differs_between_prompts(self, scan):
+        proj1, _, _ = scan.project_prompt("The dog barked loudly at the mailman")
+        proj2, _, _ = scan.project_prompt("Quantum mechanics is fundamentally strange")
+        min_len = min(proj1.shape[0], proj2.shape[0])
+        assert not np.allclose(
+            proj1[:min_len, -1, :, :], proj2[:min_len, -1, :, :],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Get projections from stored corpus data
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjections:
+    """Test retrieval of stored projections for corpus samples."""
+
+    @pytest.fixture
+    def scan(self, tmp_path):
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+        labels = [1, 1, 1, 0, 0, 0]
+
+        return SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "get_proj_scan",
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+
+    def test_get_projections_shape(self, scan):
+        proj = scan.get_projections(sample_id=0)
+        # [seq_len, n_layers, n_signals, k]
+        assert proj.ndim == 4
+        assert proj.shape[1] == scan.n_layers
+        assert proj.shape[2] == len(scan.signals)
+
+    def test_get_projections_single_signal(self, scan):
+        proj = scan.get_projections(sample_id=0, signal="attn_delta")
+        assert proj.shape[2] == 1
+
+
+# ---------------------------------------------------------------------------
+# Plot tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlot:
+    """Verify the hero figure renders without error."""
+
+    @pytest.fixture
+    def scan(self, tmp_path):
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+        labels = [1, 1, 1, 0, 0, 0]
+
+        return SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "plot_scan",
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+
+    def test_plot_returns_figure(self, scan):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.figure
+
+        fig = scan.plot("Hello world")
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_plot_single_signal(self, scan):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        fig = scan.plot("Hello world", signal="attn_delta")
+        assert fig is not None
+
+    def test_plot_all_signals(self, scan):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        fig = scan.plot("Hello world")  # default: all signals
+        assert fig is not None
+
+    def test_plot_no_surprise(self, scan):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        fig = scan.plot("Hello world", show_surprise=False)
+        assert fig is not None
+
+
+# ---------------------------------------------------------------------------
+# Separability tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeparability:
+    """Test separability_map query API."""
+
+    @pytest.fixture
+    def scan(self, tmp_path):
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+        labels = [1, 1, 1, 0, 0, 0]
+
+        return SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "sep_scan",
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+
+    def test_separability_map_shape(self, scan):
+        result = scan.separability_map()
+        assert result.shape == (scan.n_layers, len(scan.signals))
+
+    def test_separability_values_bounded(self, scan):
+        result = scan.separability_map()
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_separability_single_signal(self, scan):
+        result = scan.separability_map(signal="mlp_delta")
+        assert result.shape == (scan.n_layers, 1)

--- a/tests/test_sample_scan.py
+++ b/tests/test_sample_scan.py
@@ -418,11 +418,18 @@ class TestGetProjections:
         assert proj.shape[2] == 1
 
 
+_has_matplotlib = True
+try:
+    import matplotlib  # noqa: F401
+except ImportError:
+    _has_matplotlib = False
+
 # ---------------------------------------------------------------------------
 # Plot tests
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not _has_matplotlib, reason="matplotlib not installed")
 class TestPlot:
     """Verify the hero figure renders without error."""
 

--- a/tests/test_sample_scan.py
+++ b/tests/test_sample_scan.py
@@ -11,8 +11,9 @@ import json
 
 import numpy as np
 import pytest
+from conftest import NEGATIVE_PROMPTS, POSITIVE_PROMPTS
 
-from tests.conftest import NEGATIVE_PROMPTS, POSITIVE_PROMPTS, TEST_MODEL
+TEST_MODEL = "stas/tiny-random-llama-2"
 
 # ---------------------------------------------------------------------------
 # Storage tests (no model needed)

--- a/tests/test_sample_scan.py
+++ b/tests/test_sample_scan.py
@@ -14,7 +14,6 @@ import pytest
 
 from tests.conftest import NEGATIVE_PROMPTS, POSITIVE_PROMPTS, TEST_MODEL
 
-
 # ---------------------------------------------------------------------------
 # Storage tests (no model needed)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

SampleScan is a new feature for compressed, full-model activation indexing:

- **Configurable signals**: capture `residual`, `attn_delta`, `mlp_delta`, and/or `router_logits` (MoE) at every layer during a single chunked forward pass
- **Between-chunk PCA**: fits PCA on accumulated deltas in the CPU idle time between GPU layer chunks — no separate fitting phase, no full-delta materialization across layers
- **Per-signal basis storage**: each signal gets its own basis `[n_layers, dim, k_eff]`, handling different dimensionalities (hidden_dim vs n_experts)
- **Hero figure**: any prompt (corpus or novel) can be projected through the stored basis and rendered as a 2D RGB image — tokens on x, layers on y, top-3 PCs as RGB
- **Flat sparse projections**: variable-length sequences stored as `values.npy` + `coords.parquet` with no padding
- **Query API**: `get_projections()`, `separability_map()` for corpus-level analysis

### New files
| File | Purpose |
|------|---------|
| `src/lmprobe/sample_scan.py` | `SampleScan` class — `run()`, `project_prompt()`, `plot()`, `separability_map()` |
| `src/lmprobe/scan_storage.py` | Storage I/O — per-signal basis, samples parquet, flat projections |
| `src/lmprobe/scan_plot.py` | Hero figure renderer (matplotlib) |
| `tests/test_sample_scan.py` | 31 tests (storage, hooks, pipeline, projection, plot, separability) |
| `docs/design/005-sample-scan.md` | Design document |

### Modified files
- `backends.py` — `scan_forward`, `project_forward`, `_resolve_signal_hooks`, helper refactors
- `__init__.py` — lazy export `SampleScan`
- `pyproject.toml` — `pyarrow` in new `[scan]` and `[dev]` optional groups

## Test plan
- [x] 31 new tests pass locally (storage, delta capture, scan run, projection, plot, separability)
- [x] All 1475 existing tests pass (no regressions)
- [ ] CI passes on Python 3.10, 3.11, 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)