### PR TITLE
Add batch_project_grouped for fused multi-group projection (spec 001)

### DIFF
--- a/specs/000-index.md
+++ b/specs/000-index.md
@@ -25,6 +25,7 @@ affects: [module names]
 |------|-------|--------|---------|
 | [001-grouped-projection.md](001-grouped-projection.md) | Grouped projection API (`batch_project_grouped`) | draft | sample_scan, backends |
 | [003-per-sample-reduced-projection.md](003-per-sample-reduced-projection.md) | Per-sample reduced projection (`batch_project_reduced`) | draft | sample_scan, backends |
+| [004-memmap-batch-hidden-states.md](004-memmap-batch-hidden-states.md) | Memmap-backed `batch_hidden_states` in `ChunkedLocalBackend` | draft | backends |
 ---
 
 ## Design docs

--- a/specs/000-index.md
+++ b/specs/000-index.md
@@ -24,6 +24,7 @@ affects: [module names]
 | File | Title | Status | Affects |
 |------|-------|--------|---------|
 | [001-grouped-projection.md](001-grouped-projection.md) | Grouped projection API (`batch_project_grouped`) | draft | sample_scan, backends |
+| [003-per-sample-reduced-projection.md](003-per-sample-reduced-projection.md) | Per-sample reduced projection (`batch_project_reduced`) | draft | sample_scan, backends |
 ---
 
 ## Design docs

--- a/specs/000-index.md
+++ b/specs/000-index.md
@@ -23,6 +23,7 @@ affects: [module names]
 
 | File | Title | Status | Affects |
 |------|-------|--------|---------|
+| [001-grouped-projection.md](001-grouped-projection.md) | Grouped projection API (`batch_project_grouped`) | draft | sample_scan, backends |
 ---
 
 ## Design docs

--- a/specs/001-grouped-projection.md
+++ b/specs/001-grouped-projection.md
@@ -1,0 +1,152 @@
+---
+status: draft
+affects: [sample_scan, backends]
+---
+
+# Spec 001: Grouped projection API
+
+## Motivation
+
+`SampleScan.batch_project(prompts)` fuses all queued prompts into one layer-streaming sweep — each model layer is moved CPU→GPU exactly once (chunked backend). This is the whole performance win of chunked extraction (same pattern as DiskOffloadBackend's `extract_all`; same pattern that took Geometry-of-Truth on DeepSeek V3 600B from an overnight run to 40 min on a single 32GB-VRAM / 128GB-RAM workstation).
+
+**The trap:** callers with multiple logical groups (datasets × splits, train + eval + control corpora) write the naive loop:
+
+```python
+for ds_name in datasets:
+    for split_name in splits:
+        projections, coords, _, seq_lens = scan.batch_project(prompts[ds, split])
+        save(ds, split, projections, coords, seq_lens)
+```
+
+Each `batch_project` call re-runs the outer layer-chunk loop. **N logical groups ⇒ N full model sweeps**, each streaming every layer CPU→GPU from scratch. On 70B-class models this turns a 40-minute run into a multi-hour one, silently.
+
+The current API gives the caller no indication that this is happening. They have to already know that `batch_project` is "full layer sweep per call" to get the fused version right.
+
+## Goal
+
+Make fusion the *default shape* of the API. Caller physically cannot write the naive loop against the recommended primitive.
+
+Secondary: emit a warning when the legacy shape is used in a way that suggests the caller has fallen into the trap.
+
+## Design
+
+### 1. New primary method: `batch_project_grouped`
+
+```python
+def batch_project_grouped(
+    self,
+    prompt_groups: Mapping[Hashable, list[str]],
+    *,
+    signal: str | None = None,
+    batch_size: int = 4,
+) -> dict[Hashable, tuple[np.ndarray, dict[str, list], list[list[int]], list[int]]]:
+    """Project multiple labeled groups of prompts in a single layer-streaming
+    sweep. Output is keyed by the same keys provided in `prompt_groups`.
+
+    Preferred over repeated `batch_project` calls when multiple groups
+    (e.g. dataset splits) need projecting: layer weights are streamed
+    CPU→GPU once for the whole union of prompts, rather than once per
+    call.
+
+    Parameters
+    ----------
+    prompt_groups : mapping of hashable key → list[str]
+        Named groups of prompts. Keys are caller-defined (strings, tuples,
+        whatever hashes). Order of iteration is preserved in the returned
+        dict (insertion order on Python 3.7+).
+    signal : str or None
+        If given, only project this signal.
+    batch_size : int
+        Microbatch size for the forward pass.
+
+    Returns
+    -------
+    dict
+        ``{key: (projections, coords, token_ids_per_sample, seq_lengths)}``.
+        Each value has the same shape/semantics as `batch_project` for
+        that group's prompts.
+    """
+```
+
+**Implementation** (~25 lines in `sample_scan.py`):
+
+1. Preserve input order: `keys = list(prompt_groups.keys())`.
+2. Flatten: `all_prompts = sum((prompt_groups[k] for k in keys), [])`; record `bounds = [(key, start, end), ...]` by cumulative length.
+3. Single underlying call: `projections, coords, token_ids_per_sample, seq_lengths = self.batch_project(all_prompts, signal=signal, batch_size=batch_size)`.
+4. Slice per group. Use `coords["sample_id"]` for the projection rows; use Python slicing for `token_ids_per_sample` and `seq_lengths`:
+   ```python
+   for key, start, end in bounds:
+       group_mask = (coord_sample >= start) & (coord_sample < end)
+       group_coords = {c: np.asarray(v)[group_mask] for c, v in coords.items()}
+       # Rebase sample_id so each group's output looks like a fresh batch_project:
+       group_coords["sample_id"] = group_coords["sample_id"] - start
+       out[key] = (
+           projections[group_mask],
+           {c: v.tolist() for c, v in group_coords.items()},
+           token_ids_per_sample[start:end],
+           seq_lengths[start:end],
+       )
+   ```
+5. Return `out`.
+
+**Key property:** each per-group tuple is indistinguishable from the tuple `batch_project` would have returned if called on that group's prompts alone. Callers can drop-in replace `{k: scan.batch_project(prompts[k]) for k in keys}` with `scan.batch_project_grouped(prompts)` and get identical per-group outputs — just much faster.
+
+### 2. Warning on repeated `batch_project` calls from the same instance
+
+In `batch_project`, keep a private counter `self._batch_project_call_count`. On the **third** call, emit a `UserWarning`:
+
+```
+SampleScan.batch_project called 3+ times on the same scan. Each call
+re-streams every model layer CPU→GPU. For multiple prompt groups
+(e.g. dataset splits), use scan.batch_project_grouped({...}) — same
+semantics, one layer sweep for the whole union.
+```
+
+- Rationale for threshold = 3: one call is the normal case. Two is borderline (train/eval). Three+ strongly suggests a loop that should be fused.
+- Warning fires at most once per SampleScan instance to avoid spam.
+- Respects `warnings.simplefilter("ignore")` via the standard mechanism.
+
+### 3. Docstring updates on `batch_project`
+
+Add a "See also" pointing to `batch_project_grouped` when projecting multiple groups. Add a one-line cost note:
+
+```
+Each call performs a full layer-streaming sweep (chunked backend) or
+full-dataset layer load (disk_offload backend). For multiple logical
+groups, prefer `batch_project_grouped` — one sweep for the whole union.
+```
+
+### 4. Example in docs/guides/large-models/
+
+Replace any guide example that loops `batch_project` with the grouped form, so the documented "right way" is the fast way by default.
+
+## Non-goals
+
+- No change to backend internals. Implementation is pure sugar over the existing `batch_project`.
+- No change to memory ceilings. If the union of groups exceeds CPU RAM (e.g. 70B × IT-length sequences × all splits), the caller still has to split into multiple fused sweeps — that's a genuine hardware limit, not something the API can hide.
+- Not deprecating `batch_project`. Single-group calls are still a valid primary use case (e.g., a single paraphrase set, a single new prompt to visualize).
+
+## Acceptance criteria
+
+1. `scan.batch_project_grouped({k: [prompt]})` returns `{k: (proj, coords, tokens, seq_lens)}` where `(proj, coords, tokens, seq_lens)` is identical, element-wise, to `scan.batch_project([prompt])`.
+2. For a dict with N groups, `batch_project_grouped` makes exactly one call to the underlying `backend.scan_forward` (verified by a test using a mock or by patching `batch_project` to count calls).
+3. Output coord sample_ids are rebased per group: in `out[k]`, `coord["sample_id"]` ranges from 0 to `len(prompt_groups[k]) - 1`.
+4. Third call to `batch_project` on the same instance emits a `UserWarning` containing the string `"batch_project_grouped"`. First and second calls are silent. Warning fires at most once.
+5. Existing `batch_project` behavior (signature, semantics, return shape) unchanged. All existing tests pass.
+6. New tests cover: single-group grouped call matches `batch_project`; multi-group matches concatenation; order preservation; warning firing threshold.
+
+## Migration
+
+Callers with existing loops over `batch_project` should migrate by:
+
+```python
+# Before
+results = {}
+for key in keys:
+    results[key] = scan.batch_project(prompts[key])
+
+# After
+results = scan.batch_project_grouped({key: prompts[key] for key in keys})
+```
+
+In `liars_bench_whitebox/experiment_pipeline.py::cache_all` this migration replaces the manual collection + slicing with a single call — simplifies the pipeline and makes the optimization self-documenting.

--- a/specs/002-stream-project-external-bases.md
+++ b/specs/002-stream-project-external-bases.md
@@ -1,0 +1,230 @@
+---
+status: draft
+affects: [backends]
+---
+
+# Spec 002: Stream-project through external bases
+
+## Motivation
+
+Both `ChunkedLocalBackend.scan_forward` and `DiskOffloadBackend.scan_forward`
+collect per-signal, per-layer deltas across **every microbatch in a chunk**
+before projecting them. The resulting flow per chunk, per signal, per layer is:
+
+```python
+for batch in batches:
+    hook appends delta.detach().cpu()          # [B, S, H] bf16
+
+# after the batch loop:
+stacked = torch.cat(captures, dim=0)            # [N, S, H] bf16  (copy)
+flat    = stacked.reshape(-1, dim).float()      # [N*S, H] fp32   (2× copy)
+projected = flat @ basis.astype(np.float32)     # [N*S, k] fp32
+```
+
+The `stacked` contiguous copy, the `.float()` upcast, and the per-signal
+capture list all coexist in CPU RAM around the point where PCA / projection
+fires. For a single chunk × single signal this is:
+
+- captures list:  `N*S*H × 2B`   (bf16)
+- stacked:         `N*S*H × 2B`   (bf16, concatenated copy)
+- flat:            `N*S*H × 4B`   (fp32)
+
+Multiplied by `|signals|` (2 in the default case: `attn_delta + mlp_delta`),
+per-chunk-per-layer CPU peak reaches `~6 × N × S × H` bytes in transient
+working set.
+
+On Mistral-Small 3.1 (H=5120) with one dataset's fused sweep (N≈500,
+S≈3500 after padding), that's ≈100 GB of transient CPU RAM per layer on top of
+the residual buffer (`batch_hidden_states`) and the model weights in
+`ChunkedLocalBackend`. On a 128 GB workstation this OOM-kills the process —
+observed repeatedly on Liar's Bench whitebox's `cache_all` flow.
+
+Crucially, **none of this accumulation is necessary when the user already has
+a fitted basis.** The current scan-fit codepath needs the full flat activation
+matrix to run PCA over it. Projection-through-a-fixed-basis does not:
+`(delta @ basis)` can be computed *immediately* on each microbatch's GPU
+tensor, producing a `[B, S, k]` output that is ~H/k (typically 64–128×)
+smaller than the input.
+
+## Goal
+
+When `external_bases` is provided to `scan_forward`, avoid materializing the
+per-signal, per-layer activation tensor anywhere. Project each microbatch's
+delta on GPU as it is captured, and only keep the tiny `[B, S, k]` projection
+on CPU.
+
+Outcome: drop per-chunk CPU RAM peak from `~6 × N × S × H` to
+`~N × S × H` (just the residual buffer, unchanged) plus `~1 × B × S × H` on
+GPU during the forward (also unchanged from today). For the Mistral sweep
+above, that is a 5–6× memory-headroom improvement — enough to keep the run
+inside 128 GB.
+
+## Non-goals
+
+- **PCA-fit path unchanged.** `external_bases is None` continues to use the
+  accumulate → stack → fp32 flat → PCA path. Fitting genuinely needs the full
+  flat matrix. Bases are fit once per model in `fit_basis.py`; only projection
+  is in the hot loop for downstream analysis (`experiment_pipeline.cache_all`,
+  paraphrase sweeps, new-prompt visualizations, etc.).
+
+- **No output-shape changes.** Every callsite receiving
+  `(projections, coords, token_ids_per_sample, seq_lengths, attention_mask,
+  signal_dims)` from `scan_forward` must observe identical values (modulo the
+  expected bf16/fp16 GPU-vs-CPU matmul tolerance). `SampleScan.batch_project`,
+  `batch_project_grouped`, and `scan_storage` all consume this tuple.
+
+- **No change to `extract_all`** (the older activation-extraction API on
+  `DiskOffloadBackend`). It already has a per-layer, per-N capture pattern
+  that is appropriate for raw-activation consumers and does not share the
+  projection-only opportunity. If that path needs memory work it gets a
+  separate spec.
+
+## Design
+
+### Pre-load bases to GPU once
+
+Before the chunk/layer loop, upcast `external_bases[sig]` to `float32` on
+the device:
+
+```python
+basis_gpu: dict[str, torch.Tensor] = {}
+if external_bases is not None:
+    for sig, arr in external_bases.items():
+        # arr: np.ndarray [n_layers, dim, k]  fp16
+        basis_gpu[sig] = torch.from_numpy(arr).to(
+            device=device, dtype=torch.float32,
+        )
+```
+
+Cost: `n_layers × dim × k × 4B` per signal. For a 70B model
+(n_layers≈80, dim≈8192, k=64): `≈160 MB × 2 signals = 320 MB` VRAM, one-time.
+
+Rationale for fp32 on GPU: matches the legacy CPU `.float()` path, preserves
+numerical parity with scans produced before this spec. The delta is upcast
+per-microbatch on GPU (`delta.float()`), multiplied, then cast back to fp16
+before the CPU roundtrip.
+
+### Hook keeps tensors on GPU
+
+`_resolve_signal_hooks` (chunked backend) and the inline hook builder
+(disk_offload backend) gain a `capture_device: str = "cpu"` parameter. When
+`external_bases` is in play, callers pass `capture_device="gpu"`. The hook
+appends `delta.detach()` (still on device) instead of `delta.detach().cpu()`.
+
+### Per-microbatch projection
+
+Inside the batch loop, replace the
+`per_layer_captures[...][sig].append(buf[0])` line with: if
+`external_bases is not None`, immediately project:
+
+```python
+for sig_name, handle, hook_buf in hooks:
+    handle.remove()
+    if not hook_buf:
+        continue
+    delta_gpu = hook_buf[0]           # [B, S, H] bf16 on device
+    if external_bases is not None and sig_name in external_bases:
+        B, S, H = delta_gpu.shape
+        basis = basis_gpu[sig_name][layer_idx]          # [H, k] fp32
+        flat = delta_gpu.reshape(-1, H).to(torch.float32)
+        projected = (flat @ basis)                       # [B*S, k] fp32
+        projected = projected.reshape(B, S, -1).to(torch.float16)
+        per_layer_projected[layer_idx][sig_name].append(
+            projected.cpu().numpy()
+        )
+        if sig_name not in signal_dims:
+            signal_dims[sig_name] = H
+    else:
+        per_layer_captures[layer_idx][sig_name].append(
+            delta_gpu.cpu()
+        )
+```
+
+The residual branch (`capture_residual`) gets the same treatment: if
+`external_bases` has `"residual"`, project `hs` in-place; otherwise fall back
+to the old `.cpu()` append.
+
+### End-of-chunk assembly
+
+Split the existing `pca_items` loop into two branches:
+
+- **External-basis branch**: concatenate the per-batch projections along dim 0,
+  flatten `[N, S, k] → [N*S, k]`, append to `all_proj_chunks`, emit coords in
+  the existing `(sample_id, layer, token_pos, signal)` order. Copy the basis
+  slice into `signal_bases[sig][layer_idx]` for the returned `final_bases`.
+
+- **PCA-fit branch**: unchanged. Legacy captures → stacked → flat → PCA →
+  project path remains.
+
+### Output ordering parity
+
+The per-`(layer, signal)` row order in the legacy path is:
+`(batch0_sample0_tok0..tokS-1, batch0_sample1_*, ..., batch_last_sampleN_*)`.
+Concatenating the stream-project list along dim 0 before flattening preserves
+this exact order — the outer dim of each list entry is "batch samples" in the
+same sequence. `sample_id` is regenerated in the outer `range(B_total)` loop,
+identical to today's code.
+
+### API surface
+
+Internal-only. No public signature changes.
+
+- `_resolve_signal_hooks` gains a keyword-only `capture_device` param
+  (default `"cpu"`, preserving today's behavior).
+- Disk-offload's inline hook gains the same.
+- `scan_forward` signature is unchanged in both backends.
+
+### Implementation footprint
+
+- `ChunkedLocalBackend._resolve_signal_hooks`: +1 param, +1 branch (~5 lines).
+- `ChunkedLocalBackend.scan_forward`: new `per_layer_projected` dict, new
+  stream-project block inside the batch loop, new external-basis branch in
+  the per-chunk assembly (~40 lines added, ~0 removed — the PCA path stays).
+- `DiskOffloadBackend.scan_forward`: mirror (~40 lines).
+- No change to callers, storage format, or `SampleScan` API.
+
+## Acceptance criteria
+
+1. **Numerical parity.** For a small model (gpt2, 2 layers) and a pre-fit
+   basis, `scan_forward(..., external_bases=basis)` run with the new
+   stream-project path produces the same `projections` array as the
+   legacy path (existing path on a branch without this change), within
+   `atol=1e-2` in fp16 space. `coords`, `token_ids_per_sample`,
+   `seq_lengths`, and `signal_dims` match bit-for-bit.
+
+2. **Memory reduction.** Under the stream-project path with
+   `external_bases` provided, there is no reachable Python object that holds
+   a `[N_total, S, H]` activation tensor at any point during the chunk
+   loop. Verified via a test that mocks the hook and asserts the capture
+   list length stays at 1 (the current batch only) through the inner loop.
+
+3. **PCA-fit path unchanged.** All existing tests for scan-fit pass
+   unmodified.
+
+4. **No API break.** `SampleScan.batch_project`,
+   `SampleScan.batch_project_grouped`, and `SampleScan.project_prompt`
+   return identical shapes and semantics. Existing `scans/` on disk remain
+   loadable.
+
+5. **Both backends updated.** ChunkedLocalBackend and DiskOffloadBackend
+   both implement the stream-project path symmetrically.
+
+## Migration
+
+Purely internal. Downstream code (including
+`liars_bench_whitebox/experiment_pipeline.py::cache_all`) picks up the
+speedup and memory fix automatically via `scan.batch_project_grouped(...)`.
+
+## Risk
+
+- **fp32-on-GPU vs fp32-on-CPU matmul**: hardware matmul kernels may produce
+  slightly different results (tensor cores round differently than Eigen).
+  Parity test uses a fp16 tolerance (`atol=1e-2`) rather than exact equality.
+  Numerical-analysis users who rely on the legacy path can still fit without
+  external bases; the delta only appears for the frozen-basis projection
+  path.
+
+- **GPU VRAM footprint**: stream-project adds `basis_gpu` (a few hundred MB at
+  most for a 70B × 2-signal setup), plus a per-microbatch fp32 upcast of the
+  delta (`B × S × H × 4B`). For `B=2, S=4000, H=8192` this is 256 MB
+  transient VRAM — negligible next to layer weights.

--- a/specs/003-per-sample-reduced-projection.md
+++ b/specs/003-per-sample-reduced-projection.md
@@ -1,0 +1,373 @@
+---
+status: draft
+affects: [sample_scan, backends]
+---
+
+# Spec 003: Per-sample reduced projection output
+
+## Motivation
+
+A `SampleScan` PCA basis compresses hidden-state deltas from `H` dims to
+`k` dims — typically 5120→64, an 80× ratio. That compression is the whole
+point: a PCA projection is meant to be a **compact, searchable summary**
+of the forward pass at that (layer, signal). It's what makes latent-scan
+a data product rather than a debugging trace.
+
+But today, `batch_project` / `batch_project_grouped` / `scan_forward`
+emit projections at **per-token** granularity: an
+`[N_samples × max_seq_len × n_layers × n_signals, k]` row-block plus
+per-row coordinate metadata. For a 1067-sample fused sweep at `S=3500` on
+a 40-layer 2-signal model, that's ~17 GB of per-token projection data
+generated **per chunk**, accumulated across chunks, and concatenated at
+the end. Spec 002 already removed the pre-projection `[N, S, H]`
+captures; this spec removes the post-projection `[N, S, k]` rubble that
+remains.
+
+The caller (e.g. `experiment_pipeline.py::cache_all`) doesn't actually
+*use* per-token data. It reduces every microbatch of per-token
+projections to three per-sample summaries immediately:
+
+- **last_token** — projection at the last assistant token.
+- **mean_asst** — mean over assistant tokens.
+- **mean_excl5** — mean over assistant tokens, excluding the last 5.
+
+The final cached data product is
+`[N_samples, n_layers, n_signals, k]` per reducer. For the same
+workload that's ~10 MB total, **independent of sequence length and
+chunk count**.
+
+So the current pipeline inflates transient CPU RAM by ~1700× versus what
+semantically needs to exist. On Mistral-24B × 1067 samples this inflation
+has OOM-killed three separate attempts at 120+ GB CPU RAM, with the
+failure tracking whichever buffer happens to be the largest at the moment
+(pre-computed masks → `per_layer_captures` → `per_layer_projected` →
+`all_proj_chunks`). Each patch unblocks the next bottleneck by a factor
+of 2–5×, but the ceiling stays proportional to per-token data. This
+pattern doesn't scale: 70B with 80 layers would hit the ceiling
+immediately, 600B even harder.
+
+The fix that honors the design is: **reduce inside the scan, never
+emit per-token projections across chunks.**
+
+## Design philosophy
+
+A PCA-projected latent scan is a compact, searchable data product over
+the *entire* forward pass — **breadth over depth.** It summarizes what's
+happening at every layer for every sample at per-sample granularity, on
+a space small enough to fit in RAM, cache to disk trivially, and compare
+across inputs without I/O overhead.
+
+Two invariants deliver that shape:
+
+1. **Full-hydration latents are transient.** Per-microbatch, per-layer
+   `[B, S, H]` activations exist only long enough to project to
+   `[B, S, k]`, apply all reducers, and free. They never cross a chunk
+   boundary, never accumulate, never hit disk.
+2. **Only the compressed summary persists.** Cross-chunk accumulators
+   hold exclusively per-sample `[N, L, n_sig, k]` reducer outputs —
+   small enough that disk caching is trivial and in-memory search is
+   instant.
+
+Anything held between chunks that exceeds
+`O(N × L × n_sig × k) + O(residuals needed for next chunk)` is waste.
+
+## Goal
+
+A new method on `SampleScan`:
+
+```python
+scan.batch_project_reduced(
+    prompt_groups: Mapping[Hashable, list[str]],
+    *,
+    reducers: Mapping[str, Reducer],
+    batch_size: int = 4,
+) -> dict[Hashable, dict[str, np.ndarray]]
+```
+
+Returns, for each input group key, a dict of reducer-name →
+`[N_group, n_layers, n_signals, k]` array. Per-token projections never
+materialize beyond one microbatch × one layer × one signal (`[B, S, k]`
+transient).
+
+## Reducer interface
+
+```python
+class Reducer(Protocol):
+    """Reduce per-token projections to per-sample vectors.
+
+    Applied per (layer, signal) on each microbatch as projections are
+    produced inside the chunk loop. Owns its own per-sample masks
+    (passed at construction) and running state (e.g. token counts).
+    """
+
+    def init_state(
+        self,
+        n_samples: int,
+        n_layers: int,
+        n_signals: int,
+        k: int,
+    ) -> Any:
+        """Allocate accumulator + bookkeeping. Returned object is passed
+        to update/finalize. Typically `{"out": np.zeros([N,L,S,k], f32),
+        "count": np.zeros(N, int)}` or similar."""
+
+    def update(
+        self,
+        state: Any,
+        proj: np.ndarray,         # [B, S_pad, k] fp16 — microbatch projection
+        sample_ids: Sequence[int],  # [B] — sample indices in the N axis
+        layer_idx: int,
+        sig_idx: int,
+    ) -> None:
+        """Update accumulator with one microbatch's contribution. Called
+        once per (layer, signal) per microbatch — i.e. very often. Must
+        be cheap."""
+
+    def finalize(self, state: Any) -> np.ndarray:
+        """Post-process (e.g. divide running sums by counts) and return
+        the [N, L, n_sig, k] output."""
+```
+
+### Built-in reducers
+
+Three, covering `experiment_pipeline.cache_all`'s needs:
+
+- **`LastTokenReducer(masks_per_sample)`** — selects projection at the
+  last True-in-mask token per sample. Mask is a list of `[seq_len_i]`
+  bool arrays; lmprobe pads to each microbatch's padded length.
+- **`MeanReducer(masks_per_sample)`** — mean over True-in-mask tokens
+  per sample. Accumulates sum in fp32, tracks per-sample True-count,
+  divides in `finalize`.
+- **`MeanExclLastNReducer(masks_per_sample, n=5)`** — mean over
+  True-in-mask tokens excluding the last `n` True positions per sample.
+  Falls back to `MeanReducer` semantics if a sample has ≤ `n` True
+  tokens. Pre-computes per-sample "excluded positions" from the mask;
+  behaves like `MeanReducer` over a derived mask at update time.
+
+Custom reducers (any `Reducer` implementation) are accepted.
+
+### Mask convention
+
+`masks_per_sample: list[np.ndarray]` — one bool array per sample, shape
+`[seq_len_i]`, where `True` marks positions of interest (e.g. assistant
+tokens). Length `seq_len_i` can be less than the tokenizer's padded
+length; lmprobe extends with `False` for padding positions. Masks are
+carried inside the reducer — `batch_project_reduced` doesn't need a
+separate mask argument.
+
+## Implementation plan
+
+### 1. Module layout
+
+New file `src/lmprobe/reducers.py` with `Reducer` protocol +
+`LastTokenReducer`, `MeanReducer`, `MeanExclLastNReducer`.
+
+### 2. Backend threading
+
+`ChunkedLocalBackend.scan_forward` and
+`DiskOffloadBackend.scan_forward` gain an optional parameter:
+
+```python
+reducers: Mapping[str, ReducerBound] | None = None
+```
+
+where `ReducerBound` is the reducer paired with its already-initialized
+state. When non-`None`:
+
+- Skip the `per_layer_captures` / `per_layer_projected` accumulators and
+  the per-chunk assembly loop.
+- In the per-layer, per-signal stream-project block (spec 002), replace
+  the "append to per_layer_projected" step with "dispatch each microbatch's
+  projection through every reducer's `update`":
+  ```python
+  proj_cpu = _stream_project(delta, sig_name, layer_idx)  # [B, S, k] fp16
+  for name, (reducer, state) in reducers.items():
+      reducer.update(
+          state, proj_cpu,
+          sample_ids=np.arange(start, end),
+          layer_idx=layer_idx, sig_idx=sig_idx,
+      )
+  del proj_cpu
+  ```
+- Return an empty projection array and coord dict; reducers own the
+  output.
+
+### 3. `SampleScan` API
+
+```python
+def batch_project_reduced(
+    self,
+    prompt_groups: Mapping[Hashable, list[str]],
+    *,
+    reducers: Mapping[str, Reducer],
+    batch_size: int = 4,
+) -> dict[Hashable, dict[str, np.ndarray]]:
+    """Project groups through the scan basis and reduce per-sample
+    in-chunk.
+
+    Fused layer-streaming sweep over the union of all prompts (same
+    pattern as :meth:`batch_project_grouped`). Per-token projections
+    are applied to each reducer as microbatches complete, then freed —
+    they never accumulate across chunks. Returns per-group,
+    per-reducer [N, n_layers, n_signals, k] arrays.
+
+    See spec 003 in the repository for the design philosophy and memory
+    accounting.
+    """
+```
+
+Internally:
+
+1. Flatten `prompt_groups` into one `all_prompts` list, record per-group
+   `(start, end)` bounds (as in spec 001).
+2. For each reducer, build a **global** state covering all prompts
+   (N = total). The reducer's internal masks must align to this flat
+   ordering; the caller may either pass masks per-group or lmprobe may
+   offer a thin adapter that flattens them.
+   - Cleaner option: accept `reducers` **already carrying flat
+     masks** matching the union ordering. Caller prepares them. Keeps
+     lmprobe reducer-agnostic.
+3. Call `scan_forward(all_prompts, reducers=bound_reducers, external_bases=self._bases)`.
+4. `finalize` each reducer; slice per-group along the N axis:
+   ```python
+   out = {k: {} for k in keys}
+   for name, (reducer, state) in bound_reducers.items():
+       full = reducer.finalize(state)  # [N_total, L, n_sig, k]
+       for key, start, end in bounds:
+           out[key][name] = full[start:end]
+   ```
+
+### 4. Helper for masks
+
+`experiment_pipeline.cache_all` already has per-group `boundaries_groups`
+(lists of assistant-turn boundary tuples per sample). A small helper
+inside `batch_project_reduced` — or exposed separately — constructs bool
+masks from boundaries:
+
+```python
+def asst_mask_from_boundaries(boundaries: list[tuple[int,int]], seq_len: int) -> np.ndarray:
+    mask = np.zeros(seq_len, dtype=bool)
+    for s, e in boundaries:
+        mask[s:min(e, seq_len)] = True
+    return mask
+```
+
+Not strictly part of this spec, but recommended as a utility.
+
+## Memory accounting
+
+Working set, per chunk:
+
+| item                                  | size (Mistral, N=1067, S=3500, L=40, n_sig=2, k=64) |
+|---------------------------------------|:---------------------------------------------------:|
+| Residuals (`batch_hidden_states`)     | 38 GB    (unchanged — needed by next chunk)         |
+| Per-microbatch projection (transient) | 448 KB   (freed after reducer dispatch)             |
+| Reducer accumulators (3 reducers)     | 3 × N×L×n_sig×k × 4B ≈ **66 MB**                    |
+| Reducer bookkeeping (counts)          | 3 × N × 4B ≈ 12 KB                                  |
+
+Total cross-chunk steady state: **~38 GB** (all residuals). Down from
+the ~120 GB observed under the per-token output path.
+**Independent of `n_chunks` and `n_layers`**.
+
+70B sanity check (80 layers, N=1000, S=3000, k=64):
+- Residuals ≈ 31 GB (or per-call-dependent).
+- Accumulators ≈ 3 × 1000 × 80 × 2 × 64 × 4B ≈ 120 MB.
+- Fits well inside 128 GB.
+
+This is the whole point: reducer output size is a constant function of
+`(n_prompts, n_layers, n_signals, k, n_reducers)`. It has no
+sequence-length or chunk-count factor.
+
+## Non-goals
+
+- **Not deprecating `batch_project` / `batch_project_grouped`**.
+  Per-token output remains the right primitive for small workloads
+  (paraphrase sets, single-prompt visualizations, token-level
+  separability plots) where `N × S` is small.
+- **No built-in disk persistence**. The output is standard numpy
+  arrays; the caller persists them (`experiment_pipeline.py::cache_all`
+  already has this plumbing).
+- **No change to PCA-fit path** (`SampleScan.run`). Fitting runs once
+  per model and doesn't hit the per-token OOM pattern — the fit already
+  consumes its own flat tensor and discards.
+- **Residual buffer** (`batch_hidden_states`) stays in CPU RAM — it's
+  genuinely needed for the next chunk's forward. Memmap-backing it is a
+  separate concern (spec 004 if ever motivated).
+
+## Acceptance criteria
+
+1. **Numerical parity.** For `stas/tiny-random-llama-2`, for each
+   built-in reducer:
+   - Run `scan.batch_project_reduced` on a small group.
+   - Run `scan.batch_project`, then apply the reducer's Python logic
+     caller-side to the returned per-token projections.
+   - The two outputs match within `atol=1e-2` in fp16 space.
+
+2. **Working-set bound.** Under `batch_project_reduced`,
+   `per_layer_projected`, `per_layer_captures`, and `all_proj_chunks`
+   stay empty / un-appended throughout the sweep. Verified by
+   monkey-patching the backend in a test and asserting these buckets
+   aren't touched when reducers are provided.
+
+3. **One backend call for `N` groups.** Same fusion property as
+   `batch_project_grouped` — exactly one `scan_forward` invocation per
+   `batch_project_reduced` call regardless of group count.
+
+4. **No regressions.** All existing scan, backend, and spec-001/spec-002
+   tests pass.
+
+## Risks
+
+- **Reducer statefulness across chunks.** Reducer accumulators must
+  survive chunk transitions. Because `scan_forward` owns a single
+  reducer state dict for the whole sweep, this is natural — but the
+  spec must make clear reducers are not chunk-local.
+
+- **Mask alignment.** Caller-supplied masks must match the tokenization
+  lmprobe produces. If the tokenizer drifts (different template, different
+  special-token handling), reducers misalign silently. Mitigated by
+  requiring masks to be derived from the same tokenizer run (same chat
+  template, same tokenizer instance) lmprobe uses — we document this,
+  and `experiment_pipeline.cache_all` is already set up this way via
+  `_load_tokenizer`.
+
+- **Reducer numerical choice**. `MeanReducer` accumulates in fp32 to
+  avoid drift over long mean-pools. Custom reducers are the caller's
+  responsibility.
+
+- **API surface creep.** Adding a third projection method (alongside
+  `batch_project` and `batch_project_grouped`) risks discoverability
+  confusion. Mitigation: point `batch_project_grouped`'s docstring to
+  `batch_project_reduced` for aggregation workloads, and emit a warning
+  from `batch_project` (already there after spec 001) and
+  `batch_project_grouped` when called on very large `N × S` sweeps with
+  obvious aggregation patterns. Out of scope to auto-detect; just make
+  the right primitive easy to find.
+
+## Downstream migration
+
+`liars_bench_whitebox/experiment_pipeline.py::cache_all` today:
+
+```
+cache_all → _fused_sweep_and_cache → scan.batch_project_grouped(...)
+  → _aggregate_group_projections(projections, coords, boundaries, ...)
+  → write three per-sample reducer outputs to .npz
+```
+
+After this spec:
+
+```
+cache_all → build three Reducer instances per group with flat
+  assistant-boundary masks → scan.batch_project_reduced(
+      prompt_groups, reducers={
+          "last_token": LastTokenReducer(flat_masks),
+          "mean_asst":  MeanReducer(flat_masks),
+          "mean_excl5": MeanExclLastNReducer(flat_masks, n=5),
+      })
+  → write directly to .npz (shapes already match cache format)
+```
+
+`_aggregate_group_projections` goes away. The cached
+`last_token.npz` / `mean_asst.npz` / `mean_excl5.npz` bytes are
+bit-equivalent to today's (within fp16 accumulation tolerance of the
+parity test).

--- a/specs/004-memmap-batch-hidden-states.md
+++ b/specs/004-memmap-batch-hidden-states.md
@@ -1,0 +1,103 @@
+---
+status: draft
+affects: [backends]
+---
+
+# Spec 004: Memmap-backed `batch_hidden_states` in `ChunkedLocalBackend`
+
+## Motivation
+
+`ChunkedLocalBackend.scan_forward` keeps every batch's chunk-boundary
+hidden state resident on CPU via
+`batch_hidden_states: list[torch.Tensor]`. Each entry is
+`[batch_size, S_max, hidden_dim]` in bf16. Aggregate CPU residency scales
+as `N_samples × S_max × hidden_dim × 2 bytes`.
+
+For a mid-size run — 9260 samples × 574 tokens × 5120 hidden × 2 bytes =
+**54 GB** — this list alone dominates the CPU footprint. Combined with
+the full model on CPU (~48 GB for a 24B-param bf16 checkpoint), the
+baseline is ~102 GB before any forward-pass activations. On a 128 GB box,
+GC + fragmentation pushes chunk-2 forward over the edge → OOM-kill.
+
+Observed on RTX 5090 / 128 GB / Mistral-Small-3.1-24B, chunked backend,
+`batch_project_reduced` over ~9k samples. Same pattern will bite every
+70B+ scan at even modest sample counts.
+
+## Design
+
+Back `batch_hidden_states` with a single `np.memmap`'d binary file of
+shape `[N_total, S_max, hidden_dim]`. Between chunks each batch reads its
+slice from the memmap, runs through the chunk's layers on GPU, writes
+the updated slice back. Linux's page cache handles residency — we only
+pay for what's touched in the current chunk, not the whole list.
+
+Symmetric with the pre-allocated `all_projections` / coord-array pattern
+already used for the scan output: one giant array backed by disk rather
+than list-grows.
+
+### Dtype handling
+
+`np.memmap` has no native `bfloat16` dtype. Store bytes as `uint16`
+(same width, 2 bytes) and reinterpret via `torch.Tensor.view(torch.bfloat16)`
+on read and `.view(torch.uint16)` on write. For `fp16` / `fp32` /
+`fp64` the native numpy dtype is used directly.
+
+### File lifecycle
+
+- File created inside a `tempfile.TemporaryDirectory()` scoped to
+  `scan_forward`. Auto-removed on return or exception.
+- Mode `'w+'`: allocates the file and maps it writable.
+- The three small sibling lists (`batch_pos_ids`, `batch_cache_positions`)
+  stay as lists — they're `O(N_total × S_max)` int tensors, two orders of
+  magnitude smaller than the hidden-state buffer.
+
+### Write path (embedding phase)
+
+For each batch `(start, end)`:
+```
+hs = embed(ids.to(device)).cpu()   # [B, S, H]
+hs_bytes = hs.view(torch.uint16)   # or hs.numpy() for fp16/fp32
+mmap[start:end] = hs_bytes.numpy()
+```
+
+### Read / write-back path (chunk phase)
+
+```
+slice_np = mmap[start:end]                        # no copy
+slice_t  = torch.from_numpy(slice_np.copy())      # detach from mmap
+hs       = slice_t.view(self.dtype).to(device)
+# ... run chunk's layers ...
+updated  = hs.cpu().contiguous()
+mmap[start:end] = updated.view(torch.uint16).numpy()
+```
+
+The `.copy()` in the read step is intentional: the downstream GPU upload
+holds a reference, and we don't want that reference to pin memmap pages.
+
+## Scope
+
+Only `ChunkedLocalBackend.scan_forward`. Not `DiskOffloadBackend`:
+it already loads layer weights on demand and has a different
+memory profile (`batch_hidden_states` is not the dominant pressure
+there). The change may be ported to the disk-offload backend later
+if benchmarks show it needed.
+
+## Acceptance criteria
+
+- [ ] `batch_hidden_states` is an `np.memmap` of shape
+      `[N_total, S_max, hidden_dim]` (or equivalent byte layout), not a
+      `list[torch.Tensor]`.
+- [ ] Backing file lives under a `TemporaryDirectory` and is cleaned up
+      when `scan_forward` returns (normal or exceptional).
+- [ ] Multi-chunk scan with `batch_size < N_total` and
+      `chunk_size < n_layers` produces identical bases and projections
+      to the pre-refactor list implementation on a tiny model.
+- [ ] Works for `dtype in {torch.bfloat16, torch.float16, torch.float32}`.
+- [ ] No new top-level dependencies.
+
+## Non-goals
+
+- Optimizing memmap access pattern (e.g. prefetching next chunk's slice
+  while current chunk computes). The OS page cache already handles the
+  common case well; prefetching is a future optimization.
+- Applying the same treatment to `DiskOffloadBackend`.

--- a/src/lmprobe/__init__.py
+++ b/src/lmprobe/__init__.py
@@ -88,6 +88,10 @@ __all__ = [
     "set_cache_limit",
     "set_max_threads",
     "SampleScan",
+    "LastTokenReducer",
+    "MeanReducer",
+    "MeanExclLastNReducer",
+    "Reducer",
     "set_profiling",
     "is_profiling",
     "cuml_available",
@@ -121,6 +125,20 @@ def __getattr__(name: str) -> Any:
         from .sample_scan import SampleScan
 
         return SampleScan
+    if name in ("LastTokenReducer", "MeanReducer", "MeanExclLastNReducer", "Reducer"):
+        from .reducers import (
+            LastTokenReducer,
+            MeanExclLastNReducer,
+            MeanReducer,
+            Reducer,
+        )
+
+        return {
+            "LastTokenReducer": LastTokenReducer,
+            "MeanReducer": MeanReducer,
+            "MeanExclLastNReducer": MeanExclLastNReducer,
+            "Reducer": Reducer,
+        }[name]
     if name == "cuml_available":
         from .classifiers import cuml_available
 

--- a/src/lmprobe/_tokenizer_utils.py
+++ b/src/lmprobe/_tokenizer_utils.py
@@ -1,0 +1,35 @@
+"""Internal tokenizer loading utilities.
+
+Centralizes ``AutoTokenizer.from_pretrained`` calls so model-specific
+workarounds (e.g. the Mistral regex bug) apply everywhere by default.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
+
+# Mistral checkpoints with a tokenizer regex bug in transformers. For
+# these, ``AutoTokenizer.from_pretrained`` needs ``fix_mistral_regex=True``
+# to produce correct token boundaries. Add new entries here as more
+# affected checkpoints surface.
+MISTRAL_MODELS_WITH_REGEX_BUG = [
+    "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+    "mistralai/Mistral-Large",
+]
+
+
+def load_tokenizer(model_name: str, **kwargs: Any) -> PreTrainedTokenizerBase:
+    """Load a tokenizer with per-model workarounds applied.
+
+    Wraps ``AutoTokenizer.from_pretrained`` and injects
+    ``fix_mistral_regex=True`` for checkpoints listed in
+    :data:`MISTRAL_MODELS_WITH_REGEX_BUG`.
+    """
+    from transformers import AutoTokenizer
+
+    if any(m in model_name for m in MISTRAL_MODELS_WITH_REGEX_BUG):
+        kwargs.setdefault("fix_mistral_regex", True)
+    return AutoTokenizer.from_pretrained(model_name, **kwargs)

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -13,6 +13,7 @@ This module defines the ExtractionBackend ABC and provides implementations:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from transformers import PreTrainedTokenizerBase
 
     from .activation_types import ExtractedBatch, ExtractionSpec
+    from .reducers import Reducer
 
 
 class ExtractionBackend(ABC):
@@ -1582,6 +1584,7 @@ class ChunkedLocalBackend(ExtractionBackend):
         batch_size: int = 4,
         generative_masks: list[np.ndarray] | None = None,
         external_bases: dict[str, np.ndarray] | None = None,
+        reducers: Mapping[str, tuple[Reducer, Any]] | None = None,
     ) -> tuple[
         dict[str, Any],                # metadata
         dict[str, np.ndarray],          # bases: {signal_name: [n_layers, dim, k_eff]}
@@ -1615,6 +1618,13 @@ class ChunkedLocalBackend(ExtractionBackend):
             new ones. Shape [n_layers, dim, k] per signal. When provided,
             PCA fitting is skipped entirely — enables fast batched
             projection through an existing scan's basis.
+        reducers : mapping of {name: (Reducer, state)} or None
+            Spec 003. When provided, per-microbatch projections are
+            dispatched to each reducer's ``update`` immediately after
+            ``_stream_project`` and then freed. Per-token projections
+            never accumulate across chunks, and the returned projection
+            array is empty — reducers own the output. Requires
+            ``external_bases`` to cover every signal in ``signals``.
 
         Returns all data needed to write a SampleScan to disk.
         """
@@ -1628,6 +1638,19 @@ class ChunkedLocalBackend(ExtractionBackend):
 
         if signals is None:
             signals = ["attn_delta", "mlp_delta"]
+
+        if reducers is not None:
+            if external_bases is None:
+                raise ValueError(
+                    "scan_forward: reducers=... requires external_bases=... "
+                    "(reducers only operate on stream-projected signals)."
+                )
+            missing = [s for s in signals if s not in external_bases]
+            if missing:
+                raise ValueError(
+                    "scan_forward: reducers=... requires external_bases to "
+                    f"cover every signal; missing {missing}."
+                )
 
         num_layers = self._get_num_layers()
         model = self._load_full_model_cpu()
@@ -1781,6 +1804,39 @@ class ChunkedLocalBackend(ExtractionBackend):
             del flat, proj
             return out
 
+        # Spec 003: when reducers are supplied, preload signal_bases from
+        # external_bases so the final_bases assembly loop doesn't rely on
+        # per_layer_projected being populated (it won't be — reducers own
+        # the output and the per-token path is skipped).
+        signal_to_idx = {s: i for i, s in enumerate(signals)}
+        if reducers is not None and external_bases is not None:
+            for sig in stream_signals:
+                for layer_idx_pre in range(num_layers):
+                    signal_bases[sig][layer_idx_pre] = (
+                        external_bases[sig][layer_idx_pre]
+                    )
+                signal_dims.setdefault(sig, external_bases[sig].shape[1])
+
+        def _dispatch_reducers(
+            proj_cpu: np.ndarray,
+            sig_name: str,
+            layer_idx: int,
+            start: int,
+            end: int,
+        ) -> None:
+            """Spec 003: feed one microbatch's projection to every reducer."""
+            assert reducers is not None
+            sample_ids_batch = np.arange(start, end)
+            mask_batch_np = (
+                all_attention_mask[start:end].cpu().numpy().astype(bool)
+            )
+            sig_idx = signal_to_idx[sig_name]
+            for _name, (red, state) in reducers.items():
+                red.update(
+                    state, proj_cpu, sample_ids_batch,
+                    layer_idx, sig_idx, mask_batch_np,
+                )
+
         # --- Layer chunk loop ---
         n_chunks = (num_layers + chunk_size - 1) // chunk_size
         chunk_pbar = tqdm(
@@ -1854,9 +1910,19 @@ class ChunkedLocalBackend(ExtractionBackend):
                                 delta_gpu = buf[0]
                                 if sig_name not in signal_dims:
                                     signal_dims[sig_name] = delta_gpu.shape[-1]
-                                per_layer_projected[layer_idx][sig_name].append(
-                                    _stream_project(delta_gpu, sig_name, layer_idx),
+                                proj_cpu = _stream_project(
+                                    delta_gpu, sig_name, layer_idx,
                                 )
+                                if reducers is not None:
+                                    _dispatch_reducers(
+                                        proj_cpu, sig_name, layer_idx,
+                                        start, end,
+                                    )
+                                    del proj_cpu
+                                else:
+                                    per_layer_projected[layer_idx][sig_name].append(
+                                        proj_cpu,
+                                    )
                                 del delta_gpu
                             else:
                                 per_layer_captures[layer_idx][sig_name].append(buf[0])
@@ -1866,9 +1932,19 @@ class ChunkedLocalBackend(ExtractionBackend):
                             if "residual" in stream_signals:
                                 if "residual" not in signal_dims:
                                     signal_dims["residual"] = hs.shape[-1]
-                                per_layer_projected[layer_idx]["residual"].append(
-                                    _stream_project(hs.detach(), "residual", layer_idx),
+                                proj_cpu = _stream_project(
+                                    hs.detach(), "residual", layer_idx,
                                 )
+                                if reducers is not None:
+                                    _dispatch_reducers(
+                                        proj_cpu, "residual", layer_idx,
+                                        start, end,
+                                    )
+                                    del proj_cpu
+                                else:
+                                    per_layer_projected[layer_idx]["residual"].append(
+                                        proj_cpu,
+                                    )
                             else:
                                 per_layer_captures[layer_idx]["residual"].append(
                                     hs.detach().cpu()
@@ -1994,9 +2070,16 @@ class ChunkedLocalBackend(ExtractionBackend):
                     basis_arr[L, :, :actual_k] = layer_basis
             final_bases[sig_name] = basis_arr
 
-        # Stack projections
-        all_projections = np.concatenate(all_proj_chunks, axis=0)
-        all_projections = all_projections[:, np.newaxis, :]  # [N_total, 1, k]
+        # Stack projections. Empty under the reducers path (spec 003) —
+        # reducers own the output; the returned projection array is
+        # intentionally shape (0, 1, n_components).
+        if all_proj_chunks:
+            all_projections = np.concatenate(all_proj_chunks, axis=0)
+            all_projections = all_projections[:, np.newaxis, :]  # [N_total, 1, k]
+        else:
+            all_projections = np.zeros(
+                (0, 1, n_components), dtype=np.float16,
+            )
 
         metadata = {
             "model_id": self.model_name,
@@ -2851,6 +2934,7 @@ class DiskOffloadBackend(ExtractionBackend):
         batch_size: int = 4,
         generative_masks: list[np.ndarray] | None = None,
         external_bases: dict[str, np.ndarray] | None = None,
+        reducers: Mapping[str, tuple[Reducer, Any]] | None = None,
     ) -> tuple[
         dict[str, Any],                # metadata
         dict[str, np.ndarray],          # bases
@@ -2867,6 +2951,11 @@ class DiskOffloadBackend(ExtractionBackend):
         layer's weights from safetensors files instead of keeping the full
         model in CPU RAM. Enables scanning 70B+ models on machines with
         limited CPU memory.
+
+        The ``reducers`` parameter (spec 003) has the same semantics as in
+        :meth:`ChunkedLocalBackend.scan_forward`: when provided, per-token
+        projections never accumulate across layers and the returned
+        projection array is empty.
         """
         import gc
 
@@ -2876,6 +2965,19 @@ class DiskOffloadBackend(ExtractionBackend):
 
         if signals is None:
             signals = ["attn_delta", "mlp_delta"]
+
+        if reducers is not None:
+            if external_bases is None:
+                raise ValueError(
+                    "scan_forward: reducers=... requires external_bases=... "
+                    "(reducers only operate on stream-projected signals)."
+                )
+            missing = [s for s in signals if s not in external_bases]
+            if missing:
+                raise ValueError(
+                    "scan_forward: reducers=... requires external_bases to "
+                    f"cover every signal; missing {missing}."
+                )
 
         config = self._get_config()
         model = self._get_model_skeleton()
@@ -3027,6 +3129,37 @@ class DiskOffloadBackend(ExtractionBackend):
             del flat, proj
             return out
 
+        # Spec 003: preload signal_bases / signal_dims from external_bases
+        # for the reducers path, since the per-layer assembly loop (which
+        # normally populates these for the stream path) is skipped for
+        # signals whose chunks list is empty.
+        signal_to_idx = {s: i for i, s in enumerate(signals)}
+        if reducers is not None and external_bases is not None:
+            for sig, arr in external_bases.items():
+                for L in range(num_layers):
+                    signal_bases[sig][L] = arr[L]
+                signal_dims.setdefault(sig, arr.shape[1])
+
+        def _dispatch_reducers(
+            proj_cpu: np.ndarray,
+            sig_name: str,
+            layer_idx: int,
+            start: int,
+            end: int,
+        ) -> None:
+            """Spec 003: feed one microbatch's projection to every reducer."""
+            assert reducers is not None
+            sample_ids_batch = np.arange(start, end)
+            mask_batch_np = (
+                all_attention_mask[start:end].cpu().numpy().astype(bool)
+            )
+            sig_idx = signal_to_idx[sig_name]
+            for _name, (red, state) in reducers.items():
+                red.update(
+                    state, proj_cpu, sample_ids_batch,
+                    layer_idx, sig_idx, mask_batch_np,
+                )
+
         # --- Phase 2: Layer-by-layer ---
         layer_pbar = tqdm(range(num_layers), desc="Scan: layers")
         for layer_idx in layer_pbar:
@@ -3111,9 +3244,17 @@ class DiskOffloadBackend(ExtractionBackend):
                             delta_gpu = hook_buf[0]
                             if sig_name not in signal_dims:
                                 signal_dims[sig_name] = delta_gpu.shape[-1]
-                            per_signal_projected[sig_name].append(
-                                _stream_project(delta_gpu, sig_name, layer_idx),
+                            proj_cpu = _stream_project(
+                                delta_gpu, sig_name, layer_idx,
                             )
+                            if reducers is not None:
+                                _dispatch_reducers(
+                                    proj_cpu, sig_name, layer_idx,
+                                    start, end,
+                                )
+                                del proj_cpu
+                            else:
+                                per_signal_projected[sig_name].append(proj_cpu)
                             del delta_gpu
                         else:
                             per_signal_captures[sig_name].append(hook_buf[0])
@@ -3125,11 +3266,17 @@ class DiskOffloadBackend(ExtractionBackend):
                         ):
                             if "residual" not in signal_dims:
                                 signal_dims["residual"] = hs.shape[-1]
-                            per_signal_projected["residual"].append(
-                                _stream_project(
-                                    hs.detach(), "residual", layer_idx,
-                                ),
+                            proj_cpu = _stream_project(
+                                hs.detach(), "residual", layer_idx,
                             )
+                            if reducers is not None:
+                                _dispatch_reducers(
+                                    proj_cpu, "residual", layer_idx,
+                                    start, end,
+                                )
+                                del proj_cpu
+                            else:
+                                per_signal_projected["residual"].append(proj_cpu)
                         else:
                             per_signal_captures["residual"].append(
                                 hs.detach().cpu(),
@@ -3231,8 +3378,14 @@ class DiskOffloadBackend(ExtractionBackend):
                     basis_arr[L, :, :actual_k] = layer_basis
             final_bases[sig_name] = basis_arr
 
-        all_projections = np.concatenate(all_proj_chunks, axis=0)
-        all_projections = all_projections[:, np.newaxis, :]
+        # Empty under the reducers path (spec 003) — reducers own the output.
+        if all_proj_chunks:
+            all_projections = np.concatenate(all_proj_chunks, axis=0)
+            all_projections = all_projections[:, np.newaxis, :]
+        else:
+            all_projections = np.zeros(
+                (0, 1, n_components), dtype=np.float16,
+            )
 
         metadata = {
             "model_id": self.model_name,

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1672,12 +1672,16 @@ class ChunkedLocalBackend(ExtractionBackend):
             end = min(start + batch_size, n_samples)
             batches.append((start, end))
 
-        # Run embedding for each batch
+        # Run embedding for each batch. We keep residuals (`hidden_states`)
+        # on CPU — they're reused across every chunk's layer loop — but
+        # *not* the per-batch causal masks: a [B, 1, S, S] bf16 mask is
+        # ~S²·B·2 bytes, which for long sequences dominates the CPU
+        # residuals. Recomputing inside the batch loop is trivially cheap
+        # (one triu + masked_fill) compared to the forward pass.
         embed = _get_embedding_module(model)
         embed.to(device)
         batch_hidden_states: list[torch.Tensor] = []
         batch_pos_ids: list[torch.Tensor] = []
-        batch_causal_masks: list[torch.Tensor] = []
         batch_cache_positions: list[torch.Tensor] = []
 
         for start, end in batches:
@@ -1692,7 +1696,6 @@ class ChunkedLocalBackend(ExtractionBackend):
             pos_ids = mask.long().cumsum(-1) - 1
             pos_ids.masked_fill_(mask == 0, 1)
             batch_pos_ids.append(pos_ids)
-            batch_causal_masks.append(_make_causal_mask(mask, self.dtype))
             batch_cache_positions.append(torch.arange(seq_len))
 
             if hidden_dim is None:
@@ -1814,7 +1817,11 @@ class ChunkedLocalBackend(ExtractionBackend):
                     batch=f"{batch_idx+1}/{len(batches)}",
                 )
                 hs = batch_hidden_states[batch_idx].to(device)
-                mask_dev = batch_causal_masks[batch_idx].to(device)
+                # Build the causal mask on-the-fly and push straight to GPU;
+                # drop the CPU copy at batch-end so [B, 1, S, S] tensors
+                # don't persist across 1000s of batches.
+                mask_2d = all_attention_mask[start:end]
+                mask_dev = _make_causal_mask(mask_2d, self.dtype).to(device)
                 pos_dev = batch_pos_ids[batch_idx].to(device)
                 pe_dev = self._pe_to_device(position_embeddings, device)
 
@@ -1901,10 +1908,19 @@ class ChunkedLocalBackend(ExtractionBackend):
                     basis = external_bases[sig_name][layer_idx]
                     signal_bases[sig_name][layer_idx] = basis
                     k = basis.shape[1]
-                    stacked_proj = np.concatenate(chunks, axis=0)  # [B_total, S, k]
-                    B_total, S, _ = stacked_proj.shape
-                    projected = stacked_proj.reshape(-1, k)
-                    del stacked_proj
+                    # np.concatenate allocates a single contiguous buffer;
+                    # `projected` is a view of it and is the only copy kept
+                    # alive via all_proj_chunks. Clearing the per-batch
+                    # chunks list here (rather than waiting for the chunk
+                    # loop's `del per_layer_projected` at the bottom)
+                    # releases the duplicate per-batch storage progressively
+                    # across the assembly loop — up to 18 GB freed on a
+                    # 1000-sample sweep.
+                    B_total = sum(c.shape[0] for c in chunks)
+                    S = chunks[0].shape[1]
+                    projected = np.concatenate(chunks, axis=0).reshape(-1, k)
+                    per_layer_projected[layer_idx][sig_name] = []
+                    del chunks
                 else:
                     # Legacy path: stack → flat → PCA (or external project).
                     captures = per_layer_captures[layer_idx][sig_name]
@@ -2900,8 +2916,10 @@ class DiskOffloadBackend(ExtractionBackend):
 
         batch_hidden_states: list[torch.Tensor] = []
         batch_pos_ids: list[torch.Tensor] = []
-        batch_causal_masks: list[torch.Tensor] = []
         batch_cache_positions: list[torch.Tensor] = []
+        # Causal masks are *not* pre-computed: a [B, 1, S, S] bf16 mask is
+        # S²-heavy and, for 1000+ batches on long sequences, exceeds the
+        # residual buffer in CPU footprint. Built lazily per-batch below.
 
         with torch.no_grad():
             for start, end in batches:
@@ -2914,7 +2932,6 @@ class DiskOffloadBackend(ExtractionBackend):
                 pos_ids = mask.long().cumsum(-1) - 1
                 pos_ids.masked_fill_(mask == 0, 1)
                 batch_pos_ids.append(pos_ids)
-                batch_causal_masks.append(_make_causal_mask(mask, self.dtype))
                 batch_cache_positions.append(torch.arange(seq_len))
 
                 if hidden_dim is None:
@@ -3033,7 +3050,11 @@ class DiskOffloadBackend(ExtractionBackend):
 
             for batch_idx, (start, end) in enumerate(batches):
                 hs = batch_hidden_states[batch_idx].to(device)
-                mask_dev = batch_causal_masks[batch_idx].to(device)
+                # Build causal mask on-the-fly — see note at the batch
+                # pre-compute block above. Scoped locally so the CPU-side
+                # [B, 1, S, S] tensor is released as soon as the batch ends.
+                mask_2d = all_attention_mask[start:end]
+                mask_dev = _make_causal_mask(mask_2d, self.dtype).to(device)
                 pos_dev = batch_pos_ids[batch_idx].to(device)
                 pe_dev = ChunkedLocalBackend._pe_to_device(position_embeddings, device)
 

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1941,436 +1941,440 @@ class ChunkedLocalBackend(ExtractionBackend):
         batch_cache_positions: list[torch.Tensor] = []
 
         _hs_tmpdir = tempfile.TemporaryDirectory(prefix="lmprobe_scan_")
-        batch_hidden_states: np.memmap | None = None
-        _hs_N_total = int(all_input_ids.shape[0])
-        _hs_S_max = int(all_input_ids.shape[1])
+        try:
+            batch_hidden_states: np.memmap | None = None
+            _hs_N_total = int(all_input_ids.shape[0])
+            _hs_S_max = int(all_input_ids.shape[1])
 
-        for start, end in batches:
-            ids = all_input_ids[start:end]
-            mask = all_attention_mask[start:end]
+            for start, end in batches:
+                ids = all_input_ids[start:end]
+                mask = all_attention_mask[start:end]
 
-            with torch.no_grad():
-                hs = embed(ids.to(device)).cpu()
-
-            if hidden_dim is None:
-                hidden_dim = int(hs.shape[-1])
-            if batch_hidden_states is None:
-                hs_path = os.path.join(_hs_tmpdir.name, "batch_hidden_states.bin")
-                batch_hidden_states = np.memmap(
-                    hs_path,
-                    dtype=_mmap_np_dtype(self.dtype),
-                    mode="w+",
-                    shape=(_hs_N_total, _hs_S_max, hidden_dim),
-                )
-            _mmap_write_slice(batch_hidden_states, start, end, hs)
-            del hs
-
-            seq_len = ids.shape[1]
-            pos_ids = mask.long().cumsum(-1) - 1
-            pos_ids.masked_fill_(mask == 0, 1)
-            batch_pos_ids.append(pos_ids)
-            batch_cache_positions.append(torch.arange(seq_len))
-
-        embed.to("cpu")
-        assert batch_hidden_states is not None
-
-        # Rotary embeddings
-        position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | dict | None = None
-        layer_types: list[str] | None = None
-        rotary_name = self._find_rotary_embedding_name(model)
-        if rotary_name is not None:
-            rotary_mod = model
-            for part in rotary_name.split("."):
-                rotary_mod = getattr(rotary_mod, part)
-            rotary_mod.to(device)
-
-            text_cfg = getattr(
-                getattr(model, "config", None), "text_config",
-                getattr(model, "config", None),
-            )
-            layer_types_cfg = getattr(text_cfg, "layer_types", None)
-            # Use a single sample's pos_ids so cos/sin broadcast to any batch size
-            pe_hs = _mmap_read_slice(
-                batch_hidden_states, 0, 1, self.dtype,
-            ).to(device)
-            pe_pos = batch_pos_ids[0][:1].to(device)
-
-            unique_types = set(layer_types_cfg) if layer_types_cfg is not None else set()
-            if layer_types_cfg is not None and len(unique_types) > 1:
-                layer_types = list(layer_types_cfg)
-                position_embeddings = {}
                 with torch.no_grad():
-                    for lt in unique_types:
-                        pe = rotary_mod(pe_hs, pe_pos, layer_type=lt)
-                        position_embeddings[lt] = tuple(t.cpu() for t in pe)
-            else:
-                if layer_types_cfg is not None:
-                    layer_types = list(layer_types_cfg)
-                with torch.no_grad():
-                    pe = rotary_mod(pe_hs, pe_pos)
-                    if isinstance(pe, tuple):
-                        position_embeddings = tuple(t.cpu() for t in pe)
-                    else:
-                        position_embeddings = pe.cpu()
-            rotary_mod.to("cpu")
+                    hs = embed(ids.to(device)).cpu()
 
-        assert hidden_dim is not None
-        decoder_layers = _get_decoder_layers(model)
-
-        # Accumulators
-        # Per-signal basis: {signal_name: [n_layers, dim, k_eff]}
-        # We'll build these after seeing actual dims from hooks
-        signal_bases: dict[str, list[np.ndarray | None]] = {
-            sig: [None] * num_layers for sig in signals
-        }
-        signal_dims: dict[str, int] = {}  # discovered during first chunk
-        # Projections + coords are pre-allocated at full size so each chunk
-        # writes into a fixed slice rather than append-growing a list. This
-        # keeps cross-chunk memory constant: without it, all_proj_chunks
-        # (fp16) and the four coord Python-int lists grew ~1.3 GB per chunk
-        # and dominated working-set pressure on long scans. Skip allocation
-        # under the reducers path (spec 003) — nothing is written.
-        N_total = all_input_ids.shape[0]
-        S_max = all_input_ids.shape[1]
-        n_signals = len(signals)
-        if reducers is None:
-            total_rows = num_layers * n_signals * N_total * S_max
-            all_projections = np.zeros(
-                (total_rows, 1, n_components), dtype=np.float16,
-            )
-            all_coord_sample_id = np.zeros(total_rows, dtype=np.int32)
-            all_coord_layer = np.zeros(total_rows, dtype=np.int16)
-            all_coord_token_pos = np.zeros(total_rows, dtype=np.int16)
-            all_coord_signal = np.zeros(total_rows, dtype=np.int8)
-        else:
-            all_projections = np.zeros((0, 1, n_components), dtype=np.float16)
-            all_coord_sample_id = np.zeros(0, dtype=np.int32)
-            all_coord_layer = np.zeros(0, dtype=np.int16)
-            all_coord_token_pos = np.zeros(0, dtype=np.int16)
-            all_coord_signal = np.zeros(0, dtype=np.int8)
-        proj_cursor: int = 0
-
-        # Spec 002: stream-project through pre-fit basis to avoid accumulating
-        # full [N, S, H] activation tensors on CPU. Basis stays on device for
-        # the whole sweep; only [B, S, k] projections move to CPU.
-        stream_signals: set[str] = (
-            set(external_bases.keys()) if external_bases is not None else set()
-        )
-        basis_gpu: dict[str, torch.Tensor] = {}
-        if external_bases is not None:
-            for sig, arr in external_bases.items():
-                basis_gpu[sig] = torch.from_numpy(
-                    np.ascontiguousarray(arr),
-                ).to(device=device, dtype=torch.float32)
-
-        def _stream_project(
-            delta: torch.Tensor, sig_name: str, layer_idx: int,
-        ) -> np.ndarray:
-            B, S, H = delta.shape
-            basis = basis_gpu[sig_name][layer_idx]
-            flat = delta.reshape(-1, H).to(torch.float32)
-            proj = (flat @ basis).reshape(B, S, -1).to(torch.float16)
-            out = proj.cpu().numpy()
-            del flat, proj
-            return out
-
-        # Spec 003: when reducers are supplied, preload signal_bases from
-        # external_bases so the final_bases assembly loop doesn't rely on
-        # per_layer_projected being populated (it won't be — reducers own
-        # the output and the per-token path is skipped).
-        signal_to_idx = {s: i for i, s in enumerate(signals)}
-        if reducers is not None and external_bases is not None:
-            for sig in stream_signals:
-                for layer_idx_pre in range(num_layers):
-                    signal_bases[sig][layer_idx_pre] = (
-                        external_bases[sig][layer_idx_pre]
+                if hidden_dim is None:
+                    hidden_dim = int(hs.shape[-1])
+                if batch_hidden_states is None:
+                    hs_path = os.path.join(_hs_tmpdir.name, "batch_hidden_states.bin")
+                    batch_hidden_states = np.memmap(
+                        hs_path,
+                        dtype=_mmap_np_dtype(self.dtype),
+                        mode="w+",
+                        shape=(_hs_N_total, _hs_S_max, hidden_dim),
                     )
-                signal_dims.setdefault(sig, external_bases[sig].shape[1])
-
-        def _dispatch_reducers(
-            proj_cpu: np.ndarray,
-            sig_name: str,
-            layer_idx: int,
-            start: int,
-            end: int,
-        ) -> None:
-            """Spec 003: feed one microbatch's projection to every reducer."""
-            assert reducers is not None
-            sample_ids_batch = np.arange(start, end)
-            mask_batch_np = (
-                all_attention_mask[start:end].cpu().numpy().astype(bool)
-            )
-            sig_idx = signal_to_idx[sig_name]
-            for _name, (red, state) in reducers.items():
-                red.update(
-                    state, proj_cpu, sample_ids_batch,
-                    layer_idx, sig_idx, mask_batch_np,
-                )
-
-        # --- Layer chunk loop ---
-        n_chunks = (num_layers + chunk_size - 1) // chunk_size
-        chunk_pbar = tqdm(
-            range(0, num_layers, chunk_size),
-            desc="Scan: layer chunks",
-            total=n_chunks,
-        )
-        for chunk_start in chunk_pbar:
-            chunk_end = min(chunk_start + chunk_size, num_layers)
-            chunk_pbar.set_postfix(layers=f"{chunk_start}-{chunk_end-1}")
-
-            for i in range(chunk_start, chunk_end):
-                decoder_layers[i].to(device)
-
-            # {layer_idx: {signal_name: [tensor_per_batch, ...]}}
-            # Legacy path (PCA fit, or signals not in external_bases).
-            per_layer_captures: dict[int, dict[str, list[torch.Tensor]]] = {
-                L: {sig: [] for sig in signals}
-                for L in range(chunk_start, chunk_end)
-            }
-            # Stream-project path (external_bases signals).
-            per_layer_projected: dict[int, dict[str, list[np.ndarray]]] = {
-                L: {sig: [] for sig in signals}
-                for L in range(chunk_start, chunk_end)
-            }
-
-            for batch_idx, (start, end) in enumerate(batches):
-                # Push per-batch progress onto the chunk bar so the user sees
-                # forward motion inside a chunk — a chunk-level tick can take
-                # hours on large fused sweeps (N_batches × chunk_size forward
-                # passes between ticks).
-                chunk_pbar.set_postfix(
-                    layers=f"{chunk_start}-{chunk_end-1}",
-                    batch=f"{batch_idx+1}/{len(batches)}",
-                )
-                hs = _mmap_read_slice(
-                    batch_hidden_states, start, end, self.dtype,
-                ).to(device)
-                # Build the causal mask on-the-fly and push straight to GPU;
-                # drop the CPU copy at batch-end so [B, 1, S, S] tensors
-                # don't persist across 1000s of batches.
-                mask_2d = all_attention_mask[start:end]
-                mask_dev = _make_causal_mask(mask_2d, self.dtype).to(device)
-                pos_dev = batch_pos_ids[batch_idx].to(device)
-                pe_dev = self._pe_to_device(position_embeddings, device)
-
-                with torch.no_grad():
-                    for layer_idx in range(chunk_start, chunk_end):
-                        layer_module = decoder_layers[layer_idx]
-
-                        hook_list, capture_residual = self._resolve_signal_hooks(
-                            signals, layer_module, layer_idx,
-                            router_module_template, model,
-                            stream_signals=stream_signals,
-                        )
-
-                        layer_kwargs = self._build_layer_kwargs(
-                            mask_dev, pos_dev, batch_cache_positions[batch_idx],
-                            pe_dev, layer_types, layer_idx, device,
-                        )
-
-                        output = layer_module(hs, **layer_kwargs)
-                        hs = output[0] if isinstance(output, tuple) else output
-
-                        # Collect hooked signals. Stream-projected signals
-                        # get `(delta @ basis)` on GPU right here; legacy
-                        # signals go to CPU for between-chunk PCA.
-                        for sig_name, handle, buf in hook_list:
-                            handle.remove()
-                            if not buf:
-                                continue
-                            if sig_name in stream_signals:
-                                delta_gpu = buf[0]
-                                if sig_name not in signal_dims:
-                                    signal_dims[sig_name] = delta_gpu.shape[-1]
-                                proj_cpu = _stream_project(
-                                    delta_gpu, sig_name, layer_idx,
-                                )
-                                if reducers is not None:
-                                    _dispatch_reducers(
-                                        proj_cpu, sig_name, layer_idx,
-                                        start, end,
-                                    )
-                                    del proj_cpu
-                                else:
-                                    per_layer_projected[layer_idx][sig_name].append(
-                                        proj_cpu,
-                                    )
-                                del delta_gpu
-                            else:
-                                per_layer_captures[layer_idx][sig_name].append(buf[0])
-
-                        # Residual = layer output (already in hs).
-                        if capture_residual:
-                            if "residual" in stream_signals:
-                                if "residual" not in signal_dims:
-                                    signal_dims["residual"] = hs.shape[-1]
-                                proj_cpu = _stream_project(
-                                    hs.detach(), "residual", layer_idx,
-                                )
-                                if reducers is not None:
-                                    _dispatch_reducers(
-                                        proj_cpu, "residual", layer_idx,
-                                        start, end,
-                                    )
-                                    del proj_cpu
-                                else:
-                                    per_layer_projected[layer_idx]["residual"].append(
-                                        proj_cpu,
-                                    )
-                            else:
-                                per_layer_captures[layer_idx]["residual"].append(
-                                    hs.detach().cpu()
-                                )
-
                 _mmap_write_slice(batch_hidden_states, start, end, hs)
-                del hs, mask_dev, pos_dev, pe_dev
+                del hs
 
-            # Offload chunk
-            for i in range(chunk_start, chunk_end):
-                decoder_layers[i].to("cpu")
-            gc.collect()
-            if torch.cuda.is_available() and device != "cpu":
-                torch.cuda.empty_cache()
+                seq_len = ids.shape[1]
+                pos_ids = mask.long().cumsum(-1) - 1
+                pos_ids.masked_fill_(mask == 0, 1)
+                batch_pos_ids.append(pos_ids)
+                batch_cache_positions.append(torch.arange(seq_len))
 
-            # --- Between-chunk PCA fit or basis projection ---
-            pca_items = [
-                (layer_idx, sig_idx, sig_name)
-                for layer_idx in range(chunk_start, chunk_end)
-                for sig_idx, sig_name in enumerate(signals)
-            ]
-            _stage_label = (
-                "projecting" if external_bases is not None else "PCA fit"
-            )
-            for layer_idx, sig_idx, sig_name in tqdm(
-                pca_items,
-                desc=f"  {_stage_label} (layers {chunk_start}-{chunk_end-1})",
-                leave=False,
-            ):
-                if sig_name in stream_signals:
-                    # Stream-project branch: concatenate already-projected
-                    # per-batch arrays; skip PCA and float32 upcast entirely.
-                    chunks = per_layer_projected[layer_idx][sig_name]
-                    if not chunks:
-                        continue
-                    assert external_bases is not None
-                    basis = external_bases[sig_name][layer_idx]
-                    signal_bases[sig_name][layer_idx] = basis
-                    k = basis.shape[1]
-                    # np.concatenate allocates a single contiguous buffer;
-                    # `projected` is a view of it and is the only copy kept
-                    # alive via all_proj_chunks. Clearing the per-batch
-                    # chunks list here (rather than waiting for the chunk
-                    # loop's `del per_layer_projected` at the bottom)
-                    # releases the duplicate per-batch storage progressively
-                    # across the assembly loop — up to 18 GB freed on a
-                    # 1000-sample sweep.
-                    B_total = sum(c.shape[0] for c in chunks)
-                    S = chunks[0].shape[1]
-                    projected = np.concatenate(chunks, axis=0).reshape(-1, k)
-                    per_layer_projected[layer_idx][sig_name] = []
-                    del chunks
+            embed.to("cpu")
+            assert batch_hidden_states is not None
+
+            # Rotary embeddings
+            position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | dict | None = None
+            layer_types: list[str] | None = None
+            rotary_name = self._find_rotary_embedding_name(model)
+            if rotary_name is not None:
+                rotary_mod = model
+                for part in rotary_name.split("."):
+                    rotary_mod = getattr(rotary_mod, part)
+                rotary_mod.to(device)
+
+                text_cfg = getattr(
+                    getattr(model, "config", None), "text_config",
+                    getattr(model, "config", None),
+                )
+                layer_types_cfg = getattr(text_cfg, "layer_types", None)
+                # Use a single sample's pos_ids so cos/sin broadcast to any batch size
+                pe_hs = _mmap_read_slice(
+                    batch_hidden_states, 0, 1, self.dtype,
+                ).to(device)
+                pe_pos = batch_pos_ids[0][:1].to(device)
+
+                unique_types = set(layer_types_cfg) if layer_types_cfg is not None else set()
+                if layer_types_cfg is not None and len(unique_types) > 1:
+                    layer_types = list(layer_types_cfg)
+                    position_embeddings = {}
+                    with torch.no_grad():
+                        for lt in unique_types:
+                            pe = rotary_mod(pe_hs, pe_pos, layer_type=lt)
+                            position_embeddings[lt] = tuple(t.cpu() for t in pe)
                 else:
-                    # Fit + project on GPU via cuml when available (falls back
-                    # to sklearn on CPU). The helper pops from the captures
-                    # list as it streams to GPU, so the entry is drained by
-                    # the time the call returns.
-                    captures = per_layer_captures[layer_idx][sig_name]
-                    if not captures:
-                        continue
-                    if sig_name not in signal_dims:
-                        signal_dims[sig_name] = int(captures[0].shape[2])
-                    basis, projected, B_total, S, dim = _fit_project_scan_pca(
-                        captures,
-                        device=device,
-                        n_components=n_components,
-                        generative_masks=generative_masks,
-                    )
-                    k = basis.shape[1]
-                    signal_bases[sig_name][layer_idx] = basis
-                    # `captures` was drained in place by the helper; make sure
-                    # the dict entry is empty too.
-                    per_layer_captures[layer_idx][sig_name] = []
-                    del captures
-                # Write directly into the pre-allocated outputs at the
-                # current cursor. Coords are generated vectorized — no
-                # Python int-list overhead (~1.3 GB/chunk savings on a
-                # 40-layer scan of 1000 samples × 611 tokens).
-                block = B_total * S
-                row_end = proj_cursor + block
-                all_projections[proj_cursor:row_end, 0, :k] = projected
-                if k < n_components:
-                    all_projections[proj_cursor:row_end, 0, k:] = 0
-                all_coord_sample_id[proj_cursor:row_end] = np.repeat(
-                    np.arange(B_total, dtype=np.int32), S,
-                )
-                all_coord_layer[proj_cursor:row_end] = layer_idx
-                all_coord_token_pos[proj_cursor:row_end] = np.tile(
-                    np.arange(S, dtype=np.int16), B_total,
-                )
-                all_coord_signal[proj_cursor:row_end] = sig_idx
-                proj_cursor = row_end
+                    if layer_types_cfg is not None:
+                        layer_types = list(layer_types_cfg)
+                    with torch.no_grad():
+                        pe = rotary_mod(pe_hs, pe_pos)
+                        if isinstance(pe, tuple):
+                            position_embeddings = tuple(t.cpu() for t in pe)
+                        else:
+                            position_embeddings = pe.cpu()
+                rotary_mod.to("cpu")
 
-                del projected
+            assert hidden_dim is not None
+            decoder_layers = _get_decoder_layers(model)
+
+            # Accumulators
+            # Per-signal basis: {signal_name: [n_layers, dim, k_eff]}
+            # We'll build these after seeing actual dims from hooks
+            signal_bases: dict[str, list[np.ndarray | None]] = {
+                sig: [None] * num_layers for sig in signals
+            }
+            signal_dims: dict[str, int] = {}  # discovered during first chunk
+            # Projections + coords are pre-allocated at full size so each chunk
+            # writes into a fixed slice rather than append-growing a list. This
+            # keeps cross-chunk memory constant: without it, all_proj_chunks
+            # (fp16) and the four coord Python-int lists grew ~1.3 GB per chunk
+            # and dominated working-set pressure on long scans. Skip allocation
+            # under the reducers path (spec 003) — nothing is written.
+            N_total = all_input_ids.shape[0]
+            S_max = all_input_ids.shape[1]
+            n_signals = len(signals)
+            if reducers is None:
+                total_rows = num_layers * n_signals * N_total * S_max
+                all_projections = np.zeros(
+                    (total_rows, 1, n_components), dtype=np.float16,
+                )
+                all_coord_sample_id = np.zeros(total_rows, dtype=np.int32)
+                all_coord_layer = np.zeros(total_rows, dtype=np.int16)
+                all_coord_token_pos = np.zeros(total_rows, dtype=np.int16)
+                all_coord_signal = np.zeros(total_rows, dtype=np.int8)
+            else:
+                all_projections = np.zeros((0, 1, n_components), dtype=np.float16)
+                all_coord_sample_id = np.zeros(0, dtype=np.int32)
+                all_coord_layer = np.zeros(0, dtype=np.int16)
+                all_coord_token_pos = np.zeros(0, dtype=np.int16)
+                all_coord_signal = np.zeros(0, dtype=np.int8)
+            proj_cursor: int = 0
+
+            # Spec 002: stream-project through pre-fit basis to avoid accumulating
+            # full [N, S, H] activation tensors on CPU. Basis stays on device for
+            # the whole sweep; only [B, S, k] projections move to CPU.
+            stream_signals: set[str] = (
+                set(external_bases.keys()) if external_bases is not None else set()
+            )
+            basis_gpu: dict[str, torch.Tensor] = {}
+            if external_bases is not None:
+                for sig, arr in external_bases.items():
+                    basis_gpu[sig] = torch.from_numpy(
+                        np.ascontiguousarray(arr),
+                    ).to(device=device, dtype=torch.float32)
+
+            def _stream_project(
+                delta: torch.Tensor, sig_name: str, layer_idx: int,
+            ) -> np.ndarray:
+                B, S, H = delta.shape
+                basis = basis_gpu[sig_name][layer_idx]
+                flat = delta.reshape(-1, H).to(torch.float32)
+                proj = (flat @ basis).reshape(B, S, -1).to(torch.float16)
+                out = proj.cpu().numpy()
+                del flat, proj
+                return out
+
+            # Spec 003: when reducers are supplied, preload signal_bases from
+            # external_bases so the final_bases assembly loop doesn't rely on
+            # per_layer_projected being populated (it won't be — reducers own
+            # the output and the per-token path is skipped).
+            signal_to_idx = {s: i for i, s in enumerate(signals)}
+            if reducers is not None and external_bases is not None:
+                for sig in stream_signals:
+                    for layer_idx_pre in range(num_layers):
+                        signal_bases[sig][layer_idx_pre] = (
+                            external_bases[sig][layer_idx_pre]
+                        )
+                    signal_dims.setdefault(sig, external_bases[sig].shape[1])
+
+            def _dispatch_reducers(
+                proj_cpu: np.ndarray,
+                sig_name: str,
+                layer_idx: int,
+                start: int,
+                end: int,
+            ) -> None:
+                """Spec 003: feed one microbatch's projection to every reducer."""
+                assert reducers is not None
+                sample_ids_batch = np.arange(start, end)
+                mask_batch_np = (
+                    all_attention_mask[start:end].cpu().numpy().astype(bool)
+                )
+                sig_idx = signal_to_idx[sig_name]
+                for _name, (red, state) in reducers.items():
+                    red.update(
+                        state, proj_cpu, sample_ids_batch,
+                        layer_idx, sig_idx, mask_batch_np,
+                    )
+
+            # --- Layer chunk loop ---
+            n_chunks = (num_layers + chunk_size - 1) // chunk_size
+            chunk_pbar = tqdm(
+                range(0, num_layers, chunk_size),
+                desc="Scan: layer chunks",
+                total=n_chunks,
+            )
+            for chunk_start in chunk_pbar:
+                chunk_end = min(chunk_start + chunk_size, num_layers)
+                chunk_pbar.set_postfix(layers=f"{chunk_start}-{chunk_end-1}")
+
+                for i in range(chunk_start, chunk_end):
+                    decoder_layers[i].to(device)
+
+                # {layer_idx: {signal_name: [tensor_per_batch, ...]}}
+                # Legacy path (PCA fit, or signals not in external_bases).
+                per_layer_captures: dict[int, dict[str, list[torch.Tensor]]] = {
+                    L: {sig: [] for sig in signals}
+                    for L in range(chunk_start, chunk_end)
+                }
+                # Stream-project path (external_bases signals).
+                per_layer_projected: dict[int, dict[str, list[np.ndarray]]] = {
+                    L: {sig: [] for sig in signals}
+                    for L in range(chunk_start, chunk_end)
+                }
+
+                for batch_idx, (start, end) in enumerate(batches):
+                    # Push per-batch progress onto the chunk bar so the user sees
+                    # forward motion inside a chunk — a chunk-level tick can take
+                    # hours on large fused sweeps (N_batches × chunk_size forward
+                    # passes between ticks).
+                    chunk_pbar.set_postfix(
+                        layers=f"{chunk_start}-{chunk_end-1}",
+                        batch=f"{batch_idx+1}/{len(batches)}",
+                    )
+                    hs = _mmap_read_slice(
+                        batch_hidden_states, start, end, self.dtype,
+                    ).to(device)
+                    # Build the causal mask on-the-fly and push straight to GPU;
+                    # drop the CPU copy at batch-end so [B, 1, S, S] tensors
+                    # don't persist across 1000s of batches.
+                    mask_2d = all_attention_mask[start:end]
+                    mask_dev = _make_causal_mask(mask_2d, self.dtype).to(device)
+                    pos_dev = batch_pos_ids[batch_idx].to(device)
+                    pe_dev = self._pe_to_device(position_embeddings, device)
+
+                    with torch.no_grad():
+                        for layer_idx in range(chunk_start, chunk_end):
+                            layer_module = decoder_layers[layer_idx]
+
+                            hook_list, capture_residual = self._resolve_signal_hooks(
+                                signals, layer_module, layer_idx,
+                                router_module_template, model,
+                                stream_signals=stream_signals,
+                            )
+
+                            layer_kwargs = self._build_layer_kwargs(
+                                mask_dev, pos_dev, batch_cache_positions[batch_idx],
+                                pe_dev, layer_types, layer_idx, device,
+                            )
+
+                            output = layer_module(hs, **layer_kwargs)
+                            hs = output[0] if isinstance(output, tuple) else output
+
+                            # Collect hooked signals. Stream-projected signals
+                            # get `(delta @ basis)` on GPU right here; legacy
+                            # signals go to CPU for between-chunk PCA.
+                            for sig_name, handle, buf in hook_list:
+                                handle.remove()
+                                if not buf:
+                                    continue
+                                if sig_name in stream_signals:
+                                    delta_gpu = buf[0]
+                                    if sig_name not in signal_dims:
+                                        signal_dims[sig_name] = delta_gpu.shape[-1]
+                                    proj_cpu = _stream_project(
+                                        delta_gpu, sig_name, layer_idx,
+                                    )
+                                    if reducers is not None:
+                                        _dispatch_reducers(
+                                            proj_cpu, sig_name, layer_idx,
+                                            start, end,
+                                        )
+                                        del proj_cpu
+                                    else:
+                                        per_layer_projected[layer_idx][sig_name].append(
+                                            proj_cpu,
+                                        )
+                                    del delta_gpu
+                                else:
+                                    per_layer_captures[layer_idx][sig_name].append(buf[0])
+
+                            # Residual = layer output (already in hs).
+                            if capture_residual:
+                                if "residual" in stream_signals:
+                                    if "residual" not in signal_dims:
+                                        signal_dims["residual"] = hs.shape[-1]
+                                    proj_cpu = _stream_project(
+                                        hs.detach(), "residual", layer_idx,
+                                    )
+                                    if reducers is not None:
+                                        _dispatch_reducers(
+                                            proj_cpu, "residual", layer_idx,
+                                            start, end,
+                                        )
+                                        del proj_cpu
+                                    else:
+                                        per_layer_projected[layer_idx]["residual"].append(
+                                            proj_cpu,
+                                        )
+                                else:
+                                    per_layer_captures[layer_idx]["residual"].append(
+                                        hs.detach().cpu()
+                                    )
+
+                    _mmap_write_slice(batch_hidden_states, start, end, hs)
+                    del hs, mask_dev, pos_dev, pe_dev
+
+                # Offload chunk
+                for i in range(chunk_start, chunk_end):
+                    decoder_layers[i].to("cpu")
+                gc.collect()
+                if torch.cuda.is_available() and device != "cpu":
+                    torch.cuda.empty_cache()
+
+                # --- Between-chunk PCA fit or basis projection ---
+                pca_items = [
+                    (layer_idx, sig_idx, sig_name)
+                    for layer_idx in range(chunk_start, chunk_end)
+                    for sig_idx, sig_name in enumerate(signals)
+                ]
+                _stage_label = (
+                    "projecting" if external_bases is not None else "PCA fit"
+                )
+                for layer_idx, sig_idx, sig_name in tqdm(
+                    pca_items,
+                    desc=f"  {_stage_label} (layers {chunk_start}-{chunk_end-1})",
+                    leave=False,
+                ):
+                    if sig_name in stream_signals:
+                        # Stream-project branch: concatenate already-projected
+                        # per-batch arrays; skip PCA and float32 upcast entirely.
+                        chunks = per_layer_projected[layer_idx][sig_name]
+                        if not chunks:
+                            continue
+                        assert external_bases is not None
+                        basis = external_bases[sig_name][layer_idx]
+                        signal_bases[sig_name][layer_idx] = basis
+                        k = basis.shape[1]
+                        # np.concatenate allocates a single contiguous buffer;
+                        # `projected` is a view of it and is the only copy kept
+                        # alive via all_proj_chunks. Clearing the per-batch
+                        # chunks list here (rather than waiting for the chunk
+                        # loop's `del per_layer_projected` at the bottom)
+                        # releases the duplicate per-batch storage progressively
+                        # across the assembly loop — up to 18 GB freed on a
+                        # 1000-sample sweep.
+                        B_total = sum(c.shape[0] for c in chunks)
+                        S = chunks[0].shape[1]
+                        projected = np.concatenate(chunks, axis=0).reshape(-1, k)
+                        per_layer_projected[layer_idx][sig_name] = []
+                        del chunks
+                    else:
+                        # Fit + project on GPU via cuml when available (falls back
+                        # to sklearn on CPU). The helper pops from the captures
+                        # list as it streams to GPU, so the entry is drained by
+                        # the time the call returns.
+                        captures = per_layer_captures[layer_idx][sig_name]
+                        if not captures:
+                            continue
+                        if sig_name not in signal_dims:
+                            signal_dims[sig_name] = int(captures[0].shape[2])
+                        basis, projected, B_total, S, dim = _fit_project_scan_pca(
+                            captures,
+                            device=device,
+                            n_components=n_components,
+                            generative_masks=generative_masks,
+                        )
+                        k = basis.shape[1]
+                        signal_bases[sig_name][layer_idx] = basis
+                        # `captures` was drained in place by the helper; make sure
+                        # the dict entry is empty too.
+                        per_layer_captures[layer_idx][sig_name] = []
+                        del captures
+                    # Write directly into the pre-allocated outputs at the
+                    # current cursor. Coords are generated vectorized — no
+                    # Python int-list overhead (~1.3 GB/chunk savings on a
+                    # 40-layer scan of 1000 samples × 611 tokens).
+                    block = B_total * S
+                    row_end = proj_cursor + block
+                    all_projections[proj_cursor:row_end, 0, :k] = projected
+                    if k < n_components:
+                        all_projections[proj_cursor:row_end, 0, k:] = 0
+                    all_coord_sample_id[proj_cursor:row_end] = np.repeat(
+                        np.arange(B_total, dtype=np.int32), S,
+                    )
+                    all_coord_layer[proj_cursor:row_end] = layer_idx
+                    all_coord_token_pos[proj_cursor:row_end] = np.tile(
+                        np.arange(S, dtype=np.int16), B_total,
+                    )
+                    all_coord_signal[proj_cursor:row_end] = sig_idx
+                    proj_cursor = row_end
+
+                    del projected
+                    gc.collect()
+
+                del per_layer_captures, per_layer_projected
                 gc.collect()
 
-            del per_layer_captures, per_layer_projected
-            gc.collect()
+            # Assemble per-signal basis arrays: {sig: [n_layers, dim, k_eff]}
+            final_bases: dict[str, np.ndarray] = {}
+            for sig_name in signals:
+                dim = signal_dims.get(sig_name, hidden_dim)
+                k_eff = min(n_components, dim)
+                basis_arr = np.zeros((num_layers, dim, k_eff), dtype=np.float16)
+                for L in range(num_layers):
+                    layer_basis = signal_bases[sig_name][L]
+                    if layer_basis is not None:
+                        actual_k = layer_basis.shape[1]
+                        basis_arr[L, :, :actual_k] = layer_basis
+                final_bases[sig_name] = basis_arr
 
-        # Assemble per-signal basis arrays: {sig: [n_layers, dim, k_eff]}
-        final_bases: dict[str, np.ndarray] = {}
-        for sig_name in signals:
-            dim = signal_dims.get(sig_name, hidden_dim)
-            k_eff = min(n_components, dim)
-            basis_arr = np.zeros((num_layers, dim, k_eff), dtype=np.float16)
-            for L in range(num_layers):
-                layer_basis = signal_bases[sig_name][L]
-                if layer_basis is not None:
-                    actual_k = layer_basis.shape[1]
-                    basis_arr[L, :, :actual_k] = layer_basis
-            final_bases[sig_name] = basis_arr
+            # Truncate the pre-allocated outputs to `proj_cursor` — in the
+            # reducers path (spec 003) nothing is written, so cursor stays 0.
+            all_projections = all_projections[:proj_cursor]
+            all_coord_sample_id = all_coord_sample_id[:proj_cursor]
+            all_coord_layer = all_coord_layer[:proj_cursor]
+            all_coord_token_pos = all_coord_token_pos[:proj_cursor]
+            all_coord_signal = all_coord_signal[:proj_cursor]
 
-        # Truncate the pre-allocated outputs to `proj_cursor` — in the
-        # reducers path (spec 003) nothing is written, so cursor stays 0.
-        all_projections = all_projections[:proj_cursor]
-        all_coord_sample_id = all_coord_sample_id[:proj_cursor]
-        all_coord_layer = all_coord_layer[:proj_cursor]
-        all_coord_token_pos = all_coord_token_pos[:proj_cursor]
-        all_coord_signal = all_coord_signal[:proj_cursor]
+            metadata = {
+                "model_id": self.model_name,
+                "hidden_dim": hidden_dim,
+                "n_layers": num_layers,
+                "n_components": n_components,
+                "n_samples": n_samples,
+                "signals": signals,
+            }
 
-        metadata = {
-            "model_id": self.model_name,
-            "hidden_dim": hidden_dim,
-            "n_layers": num_layers,
-            "n_components": n_components,
-            "n_samples": n_samples,
-            "signals": signals,
-        }
+            coords = {
+                "sample_id": all_coord_sample_id,
+                "layer": all_coord_layer,
+                "token_pos": all_coord_token_pos,
+                "signal": all_coord_signal,
+            }
 
-        coords = {
-            "sample_id": all_coord_sample_id,
-            "layer": all_coord_layer,
-            "token_pos": all_coord_token_pos,
-            "signal": all_coord_signal,
-        }
 
-        # Release the memmap + temp directory. Drop the memmap reference
-        # first so Python releases the mmap before TemporaryDirectory
-        # unlinks the backing file (matters on Windows; harmless on
-        # Linux). On the exception path, the weakref finalizer
-        # registered by TemporaryDirectory handles cleanup on GC.
-        del batch_hidden_states
-        _hs_tmpdir.cleanup()
-
-        return (
-            metadata,
-            final_bases,
-            all_projections,
-            coords,
-            token_ids_per_sample,
-            seq_lengths,
-            all_attention_mask,
-            signal_dims,
-        )
+            return (
+                metadata,
+                final_bases,
+                all_projections,
+                coords,
+                token_ids_per_sample,
+                seq_lengths,
+                all_attention_mask,
+                signal_dims,
+            )
+        finally:
+            # Deterministic memmap + tempdir cleanup. Drop the
+            # memmap reference first so Python releases the mmap
+            # before TemporaryDirectory unlinks the backing file
+            # (matters on Windows; harmless on Linux).
+            try:
+                del batch_hidden_states
+            except NameError:
+                pass
+            _hs_tmpdir.cleanup()
 
     def project_forward(
         self,

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1801,15 +1801,18 @@ class ChunkedLocalBackend(ExtractionBackend):
             if torch.cuda.is_available() and device != "cpu":
                 torch.cuda.empty_cache()
 
-            # --- Between-chunk PCA ---
+            # --- Between-chunk PCA fit or basis projection ---
             pca_items = [
                 (layer_idx, sig_idx, sig_name)
                 for layer_idx in range(chunk_start, chunk_end)
                 for sig_idx, sig_name in enumerate(signals)
             ]
+            _stage_label = (
+                "projecting" if external_bases is not None else "PCA fit"
+            )
             for layer_idx, sig_idx, sig_name in tqdm(
                 pca_items,
-                desc=f"  PCA fit (layers {chunk_start}-{chunk_end-1})",
+                desc=f"  {_stage_label} (layers {chunk_start}-{chunk_end-1})",
                 leave=False,
             ):
                 captures = per_layer_captures[layer_idx][sig_name]

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1805,6 +1805,14 @@ class ChunkedLocalBackend(ExtractionBackend):
             }
 
             for batch_idx, (start, end) in enumerate(batches):
+                # Push per-batch progress onto the chunk bar so the user sees
+                # forward motion inside a chunk — a chunk-level tick can take
+                # hours on large fused sweeps (N_batches × chunk_size forward
+                # passes between ticks).
+                chunk_pbar.set_postfix(
+                    layers=f"{chunk_start}-{chunk_end-1}",
+                    batch=f"{batch_idx+1}/{len(batches)}",
+                )
                 hs = batch_hidden_states[batch_idx].to(device)
                 mask_dev = batch_causal_masks[batch_idx].to(device)
                 pos_dev = batch_pos_ids[batch_idx].to(device)

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -12,6 +12,7 @@ This module defines the ExtractionBackend ABC and provides implementations:
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
@@ -24,6 +25,232 @@ if TYPE_CHECKING:
 
     from .activation_types import ExtractedBatch, ExtractionSpec
     from .reducers import Reducer
+
+
+_logger = logging.getLogger(__name__)
+
+
+# --- spec 004: memmap-backed batch_hidden_states ---------------------------
+#
+# `np.memmap` has no native bfloat16. For bf16 we store bytes as uint16
+# (same width) and reinterpret via `torch.Tensor.view(torch.bfloat16)` on
+# read / `.view(torch.uint16)` on write. fp16/fp32/fp64 map directly.
+
+_TORCH_TO_MMAP_NUMPY: dict[torch.dtype, Any] = {
+    torch.bfloat16: np.uint16,
+    torch.float16: np.float16,
+    torch.float32: np.float32,
+    torch.float64: np.float64,
+}
+
+
+def _mmap_np_dtype(torch_dtype: torch.dtype) -> Any:
+    try:
+        return _TORCH_TO_MMAP_NUMPY[torch_dtype]
+    except KeyError as e:
+        raise ValueError(
+            f"scan_forward: unsupported dtype for memmap residuals: {torch_dtype}"
+        ) from e
+
+
+def _mmap_read_slice(
+    mmap: np.memmap, start: int, end: int, torch_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Read `mmap[start:end]` into a detached torch tensor with the
+    correct float dtype. The copy is intentional — we don't want the
+    returned tensor (which will be moved to GPU) to pin memmap pages."""
+    np_slice = np.array(mmap[start:end], copy=True)
+    t = torch.from_numpy(np_slice)
+    if torch_dtype == torch.bfloat16:
+        t = t.view(torch.bfloat16)
+    return t
+
+
+def _mmap_write_slice(
+    mmap: np.memmap, start: int, end: int, tensor: torch.Tensor,
+) -> None:
+    """Write `tensor` (CPU, any float dtype) into `mmap[start:end]`."""
+    t = tensor.detach().cpu().contiguous()
+    if t.dtype == torch.bfloat16:
+        t = t.view(torch.uint16)
+    mmap[start:end] = t.numpy()
+
+
+_CUML_CHECKED = False
+_CUML_AVAILABLE = False
+
+
+def _cuml_available() -> bool:
+    """Return True if cuml + cupy are importable and a CUDA device is
+    present. Result is cached after first check."""
+    global _CUML_CHECKED, _CUML_AVAILABLE
+    if _CUML_CHECKED:
+        return _CUML_AVAILABLE
+    _CUML_CHECKED = True
+    if not torch.cuda.is_available():
+        _CUML_AVAILABLE = False
+        return False
+    try:
+        import cuml  # noqa: F401
+        import cupy  # noqa: F401
+        _CUML_AVAILABLE = True
+        _logger.info(
+            "lmprobe: cuml + cupy detected — scan-time PCA will run on GPU",
+        )
+    except ImportError:
+        _CUML_AVAILABLE = False
+    return _CUML_AVAILABLE
+
+
+def _fit_project_scan_pca(
+    captures: list[torch.Tensor],
+    *,
+    device: str,
+    n_components: int,
+    generative_masks: list[np.ndarray] | None,
+    sample_id_offset: int = 0,
+) -> tuple[np.ndarray, np.ndarray, int, int, int]:
+    """Fit a PCA basis on the union of capture tensors and project every
+    token through the resulting basis.
+
+    On a CUDA box with cuml/cupy installed, this runs entirely on GPU
+    (zero-copy from torch via dlpack). Captures are moved to GPU one at
+    a time; the caller is responsible for clearing the source list after
+    this function returns. The full `[B_total, S, dim]` tensor is never
+    materialized on CPU.
+
+    Without cuml, falls back to the original sklearn-on-CPU path.
+
+    Parameters
+    ----------
+    captures : list of torch.Tensor
+        Per-batch capture tensors, each ``[B_i, S, dim]``, on CPU (bf16
+        or fp16 typically).
+    device : str
+        CUDA device string (e.g. ``"cuda:0"``). Used when cuml is
+        available.
+    n_components : int
+        Target PCA rank. Effective ``k = min(n_components, n_fit_rows - 1, dim)``.
+    generative_masks : list of np.ndarray or None
+        Per-sample boolean masks (``True`` = fit on this token). When
+        provided, PCA is fit only on the True rows; all rows are still
+        projected through the resulting basis.
+    sample_id_offset : int
+        Offset to apply when indexing into ``generative_masks``
+        (used when captures correspond to a sub-range of the corpus).
+
+    Returns
+    -------
+    basis_fp16 : np.ndarray, shape [dim, k]
+        PCA basis as a column-of-components matrix (so that
+        ``data @ basis`` yields projections).
+    projected_fp16 : np.ndarray, shape [B_total * S, k]
+        Projections of every token through the basis.
+    B_total, S, dim : int
+        Shape components of the concatenated capture tensor.
+    """
+    use_cuml = _cuml_available()
+
+    # Shape discovery (cheap — no data movement).
+    B_total = sum(int(c.shape[0]) for c in captures)
+    S = int(captures[0].shape[1])
+    dim = int(captures[0].shape[2])
+
+    # Build the PCA-fit mask in CPU numpy regardless of backend — it's
+    # tiny (B_total * S bools) and shared across paths.
+    if generative_masks is not None:
+        mask_parts: list[np.ndarray] = []
+        for sid in range(B_total):
+            gid = sid + sample_id_offset
+            if gid < len(generative_masks) and generative_masks[gid] is not None:
+                gmask = generative_masks[gid]
+                padded = np.zeros(S, dtype=bool)
+                padded[:min(len(gmask), S)] = gmask[:S]
+                mask_parts.append(padded)
+            else:
+                mask_parts.append(np.ones(S, dtype=bool))
+        fit_mask_np = np.concatenate(mask_parts)
+    else:
+        fit_mask_np = None
+
+    if use_cuml:
+        import cupy as cp
+        from cuml.decomposition import PCA as CuPCA
+        from torch.utils.dlpack import to_dlpack
+
+        # Move each capture to GPU (fp32 for numerical stability in PCA)
+        # and concat on-device. Source CPU tensors are released as soon
+        # as their GPU copy exists.
+        gpu_parts: list[torch.Tensor] = []
+        while captures:
+            c = captures.pop(0)
+            gpu_parts.append(c.to(device, dtype=torch.float32, non_blocking=True))
+            del c
+        stacked_gpu = torch.cat(gpu_parts, dim=0).contiguous()
+        del gpu_parts
+        flat_gpu = stacked_gpu.reshape(B_total * S, dim)
+        # Keep stacked_gpu alive — flat_gpu is a view.
+
+        if fit_mask_np is not None:
+            fit_mask_gpu = torch.from_numpy(fit_mask_np).to(device)
+            flat_fit_gpu = flat_gpu[fit_mask_gpu].contiguous()
+        else:
+            fit_mask_gpu = None
+            flat_fit_gpu = flat_gpu
+
+        k = min(n_components, int(flat_fit_gpu.shape[0]) - 1, dim)
+        torch.cuda.empty_cache()
+
+        # Phase 1: fit on the assistant-token subset. Zero-copy view.
+        # `svd_solver="jacobi"` runs a truncated SVD for small k — GPU
+        # working set is O(n × k) instead of O(n × d).
+        fit_cp = cp.from_dlpack(to_dlpack(flat_fit_gpu))
+        pca = CuPCA(n_components=k, output_type="cupy", svd_solver="jacobi")
+        pca.fit(fit_cp)
+        basis_np = cp.asnumpy(pca.components_).T.astype(np.float16)
+        basis_gpu = torch.from_numpy(basis_np).to(device, dtype=torch.float32)
+
+        # Release fit data + fit mask before projecting — keeping the
+        # filtered subset live through transform doubles the GPU
+        # footprint for no reason (we already have the basis).
+        del fit_cp, pca, flat_fit_gpu
+        if fit_mask_gpu is not None:
+            del fit_mask_gpu
+        torch.cuda.empty_cache()
+
+        # Phase 2: project via matmul. torch @ is fp32 on GPU, output
+        # fp16. Avoids cuml's transform allocating another large buffer.
+        projected_gpu = (flat_gpu @ basis_gpu).half()
+        projected_np = projected_gpu.cpu().numpy()
+
+        del projected_gpu, basis_gpu, flat_gpu, stacked_gpu
+        torch.cuda.empty_cache()
+        return basis_np, projected_np, B_total, S, dim
+
+    # --- sklearn fallback (CPU) ---
+    from sklearn.decomposition import PCA
+
+    stacked = torch.cat(captures, dim=0)
+    while captures:
+        captures.pop(0)
+    flat = stacked.reshape(B_total * S, dim).float().numpy()
+    del stacked
+
+    if fit_mask_np is not None:
+        flat_fit = flat[fit_mask_np]
+    else:
+        flat_fit = flat
+
+    k = min(n_components, int(flat_fit.shape[0]) - 1, dim)
+    pca = PCA(n_components=k)
+    pca.fit(flat_fit)
+    basis_np = pca.components_.T.astype(np.float16)
+    projected_np = pca.transform(flat).astype(np.float16)
+    flat_is_fit = flat_fit is flat
+    del pca, flat
+    if not flat_is_fit:
+        del flat_fit
+    return basis_np, projected_np, B_total, S, dim
 
 
 class ExtractionBackend(ABC):
@@ -1629,9 +1856,10 @@ class ChunkedLocalBackend(ExtractionBackend):
         Returns all data needed to write a SampleScan to disk.
         """
         import gc
+        import os
+        import tempfile
 
         import numpy as np
-        from sklearn.decomposition import PCA
         from tqdm import tqdm
 
         from .activation_types import detect_moe_info
@@ -1695,17 +1923,27 @@ class ChunkedLocalBackend(ExtractionBackend):
             end = min(start + batch_size, n_samples)
             batches.append((start, end))
 
-        # Run embedding for each batch. We keep residuals (`hidden_states`)
-        # on CPU — they're reused across every chunk's layer loop — but
-        # *not* the per-batch causal masks: a [B, 1, S, S] bf16 mask is
-        # ~S²·B·2 bytes, which for long sequences dominates the CPU
-        # residuals. Recomputing inside the batch loop is trivially cheap
-        # (one triu + masked_fill) compared to the forward pass.
+        # Spec 004: residuals (`batch_hidden_states`) live in an
+        # np.memmap-backed buffer of shape [N_total, S_max, hidden_dim]
+        # rather than a list of CPU tensors. Linux's page cache handles
+        # residency — we only pay for what's touched in the current
+        # chunk, not the whole corpus. For a 9k-sample × 574-token ×
+        # 5120-hidden run that's the difference between 54 GB of
+        # always-resident CPU RAM and roughly `batch_size × S × H` of
+        # active pages at any moment.
+        #
+        # Per-batch causal masks are *not* persisted: a [B, 1, S, S]
+        # bf16 mask is S²-heavy and recomputing inside the batch loop
+        # is trivially cheap (one triu + masked_fill).
         embed = _get_embedding_module(model)
         embed.to(device)
-        batch_hidden_states: list[torch.Tensor] = []
         batch_pos_ids: list[torch.Tensor] = []
         batch_cache_positions: list[torch.Tensor] = []
+
+        _hs_tmpdir = tempfile.TemporaryDirectory(prefix="lmprobe_scan_")
+        batch_hidden_states: np.memmap | None = None
+        _hs_N_total = int(all_input_ids.shape[0])
+        _hs_S_max = int(all_input_ids.shape[1])
 
         for start, end in batches:
             ids = all_input_ids[start:end]
@@ -1713,7 +1951,19 @@ class ChunkedLocalBackend(ExtractionBackend):
 
             with torch.no_grad():
                 hs = embed(ids.to(device)).cpu()
-            batch_hidden_states.append(hs)
+
+            if hidden_dim is None:
+                hidden_dim = int(hs.shape[-1])
+            if batch_hidden_states is None:
+                hs_path = os.path.join(_hs_tmpdir.name, "batch_hidden_states.bin")
+                batch_hidden_states = np.memmap(
+                    hs_path,
+                    dtype=_mmap_np_dtype(self.dtype),
+                    mode="w+",
+                    shape=(_hs_N_total, _hs_S_max, hidden_dim),
+                )
+            _mmap_write_slice(batch_hidden_states, start, end, hs)
+            del hs
 
             seq_len = ids.shape[1]
             pos_ids = mask.long().cumsum(-1) - 1
@@ -1721,10 +1971,8 @@ class ChunkedLocalBackend(ExtractionBackend):
             batch_pos_ids.append(pos_ids)
             batch_cache_positions.append(torch.arange(seq_len))
 
-            if hidden_dim is None:
-                hidden_dim = hs.shape[-1]
-
         embed.to("cpu")
+        assert batch_hidden_states is not None
 
         # Rotary embeddings
         position_embeddings: tuple[torch.Tensor, ...] | torch.Tensor | dict | None = None
@@ -1742,7 +1990,9 @@ class ChunkedLocalBackend(ExtractionBackend):
             )
             layer_types_cfg = getattr(text_cfg, "layer_types", None)
             # Use a single sample's pos_ids so cos/sin broadcast to any batch size
-            pe_hs = batch_hidden_states[0][:1].to(device)
+            pe_hs = _mmap_read_slice(
+                batch_hidden_states, 0, 1, self.dtype,
+            ).to(device)
             pe_pos = batch_pos_ids[0][:1].to(device)
 
             unique_types = set(layer_types_cfg) if layer_types_cfg is not None else set()
@@ -1774,11 +2024,31 @@ class ChunkedLocalBackend(ExtractionBackend):
             sig: [None] * num_layers for sig in signals
         }
         signal_dims: dict[str, int] = {}  # discovered during first chunk
-        all_proj_chunks: list[np.ndarray] = []
-        all_coord_sample_id: list[int] = []
-        all_coord_layer: list[int] = []
-        all_coord_token_pos: list[int] = []
-        all_coord_signal: list[int] = []
+        # Projections + coords are pre-allocated at full size so each chunk
+        # writes into a fixed slice rather than append-growing a list. This
+        # keeps cross-chunk memory constant: without it, all_proj_chunks
+        # (fp16) and the four coord Python-int lists grew ~1.3 GB per chunk
+        # and dominated working-set pressure on long scans. Skip allocation
+        # under the reducers path (spec 003) — nothing is written.
+        N_total = all_input_ids.shape[0]
+        S_max = all_input_ids.shape[1]
+        n_signals = len(signals)
+        if reducers is None:
+            total_rows = num_layers * n_signals * N_total * S_max
+            all_projections = np.zeros(
+                (total_rows, 1, n_components), dtype=np.float16,
+            )
+            all_coord_sample_id = np.zeros(total_rows, dtype=np.int32)
+            all_coord_layer = np.zeros(total_rows, dtype=np.int16)
+            all_coord_token_pos = np.zeros(total_rows, dtype=np.int16)
+            all_coord_signal = np.zeros(total_rows, dtype=np.int8)
+        else:
+            all_projections = np.zeros((0, 1, n_components), dtype=np.float16)
+            all_coord_sample_id = np.zeros(0, dtype=np.int32)
+            all_coord_layer = np.zeros(0, dtype=np.int16)
+            all_coord_token_pos = np.zeros(0, dtype=np.int16)
+            all_coord_signal = np.zeros(0, dtype=np.int8)
+        proj_cursor: int = 0
 
         # Spec 002: stream-project through pre-fit basis to avoid accumulating
         # full [N, S, H] activation tensors on CPU. Basis stays on device for
@@ -1872,7 +2142,9 @@ class ChunkedLocalBackend(ExtractionBackend):
                     layers=f"{chunk_start}-{chunk_end-1}",
                     batch=f"{batch_idx+1}/{len(batches)}",
                 )
-                hs = batch_hidden_states[batch_idx].to(device)
+                hs = _mmap_read_slice(
+                    batch_hidden_states, start, end, self.dtype,
+                ).to(device)
                 # Build the causal mask on-the-fly and push straight to GPU;
                 # drop the CPU copy at batch-end so [B, 1, S, S] tensors
                 # don't persist across 1000s of batches.
@@ -1950,7 +2222,7 @@ class ChunkedLocalBackend(ExtractionBackend):
                                     hs.detach().cpu()
                                 )
 
-                batch_hidden_states[batch_idx] = hs.cpu()
+                _mmap_write_slice(batch_hidden_states, start, end, hs)
                 del hs, mask_dev, pos_dev, pe_dev
 
             # Offload chunk
@@ -1998,61 +2270,48 @@ class ChunkedLocalBackend(ExtractionBackend):
                     per_layer_projected[layer_idx][sig_name] = []
                     del chunks
                 else:
-                    # Legacy path: stack → flat → PCA (or external project).
+                    # Fit + project on GPU via cuml when available (falls back
+                    # to sklearn on CPU). The helper pops from the captures
+                    # list as it streams to GPU, so the entry is drained by
+                    # the time the call returns.
                     captures = per_layer_captures[layer_idx][sig_name]
                     if not captures:
                         continue
-
-                    stacked = torch.cat(captures, dim=0)  # [B_total, S, dim]
-                    B_total, S, dim = stacked.shape
-                    flat = stacked.reshape(-1, dim).float().numpy()
-
                     if sig_name not in signal_dims:
-                        signal_dims[sig_name] = dim
-
-                    # Build PCA fit data — filter to generative tokens if mask provided
-                    if generative_masks is not None:
-                        fit_mask_parts = []
-                        for sid in range(B_total):
-                            if sid < len(generative_masks) and generative_masks[sid] is not None:
-                                gmask = generative_masks[sid]
-                                padded_mask = np.zeros(S, dtype=bool)
-                                padded_mask[:min(len(gmask), S)] = gmask[:S]
-                                fit_mask_parts.append(padded_mask)
-                            else:
-                                fit_mask_parts.append(np.ones(S, dtype=bool))
-                        fit_mask = np.concatenate(fit_mask_parts)
-                        flat_fit = flat[fit_mask]
-                    else:
-                        flat_fit = flat
-
-                    k = min(n_components, flat_fit.shape[0] - 1, dim)
-                    pca = PCA(n_components=k)
-                    pca.fit(flat_fit)
-
-                    basis = pca.components_.T.astype(np.float16)
-                    signal_bases[sig_name][layer_idx] = basis
-
-                    # Project ALL tokens through the basis
-                    projected = pca.transform(flat).astype(np.float16)
-                    del stacked, flat
-                if k < n_components:
-                    padded = np.zeros(
-                        (projected.shape[0], n_components), dtype=np.float16,
+                        signal_dims[sig_name] = int(captures[0].shape[2])
+                    basis, projected, B_total, S, dim = _fit_project_scan_pca(
+                        captures,
+                        device=device,
+                        n_components=n_components,
+                        generative_masks=generative_masks,
                     )
-                    padded[:, :k] = projected
-                    projected = padded
-
-                all_proj_chunks.append(projected)
-
-                for sample_idx in range(B_total):
-                    for tok in range(S):
-                        all_coord_sample_id.append(sample_idx)
-                        all_coord_layer.append(layer_idx)
-                        all_coord_token_pos.append(tok)
-                        all_coord_signal.append(sig_idx)
+                    k = basis.shape[1]
+                    signal_bases[sig_name][layer_idx] = basis
+                    # `captures` was drained in place by the helper; make sure
+                    # the dict entry is empty too.
+                    per_layer_captures[layer_idx][sig_name] = []
+                    del captures
+                # Write directly into the pre-allocated outputs at the
+                # current cursor. Coords are generated vectorized — no
+                # Python int-list overhead (~1.3 GB/chunk savings on a
+                # 40-layer scan of 1000 samples × 611 tokens).
+                block = B_total * S
+                row_end = proj_cursor + block
+                all_projections[proj_cursor:row_end, 0, :k] = projected
+                if k < n_components:
+                    all_projections[proj_cursor:row_end, 0, k:] = 0
+                all_coord_sample_id[proj_cursor:row_end] = np.repeat(
+                    np.arange(B_total, dtype=np.int32), S,
+                )
+                all_coord_layer[proj_cursor:row_end] = layer_idx
+                all_coord_token_pos[proj_cursor:row_end] = np.tile(
+                    np.arange(S, dtype=np.int16), B_total,
+                )
+                all_coord_signal[proj_cursor:row_end] = sig_idx
+                proj_cursor = row_end
 
                 del projected
+                gc.collect()
 
             del per_layer_captures, per_layer_projected
             gc.collect()
@@ -2070,16 +2329,13 @@ class ChunkedLocalBackend(ExtractionBackend):
                     basis_arr[L, :, :actual_k] = layer_basis
             final_bases[sig_name] = basis_arr
 
-        # Stack projections. Empty under the reducers path (spec 003) —
-        # reducers own the output; the returned projection array is
-        # intentionally shape (0, 1, n_components).
-        if all_proj_chunks:
-            all_projections = np.concatenate(all_proj_chunks, axis=0)
-            all_projections = all_projections[:, np.newaxis, :]  # [N_total, 1, k]
-        else:
-            all_projections = np.zeros(
-                (0, 1, n_components), dtype=np.float16,
-            )
+        # Truncate the pre-allocated outputs to `proj_cursor` — in the
+        # reducers path (spec 003) nothing is written, so cursor stays 0.
+        all_projections = all_projections[:proj_cursor]
+        all_coord_sample_id = all_coord_sample_id[:proj_cursor]
+        all_coord_layer = all_coord_layer[:proj_cursor]
+        all_coord_token_pos = all_coord_token_pos[:proj_cursor]
+        all_coord_signal = all_coord_signal[:proj_cursor]
 
         metadata = {
             "model_id": self.model_name,
@@ -2096,6 +2352,14 @@ class ChunkedLocalBackend(ExtractionBackend):
             "token_pos": all_coord_token_pos,
             "signal": all_coord_signal,
         }
+
+        # Release the memmap + temp directory. Drop the memmap reference
+        # first so Python releases the mmap before TemporaryDirectory
+        # unlinks the backing file (matters on Windows; harmless on
+        # Linux). On the exception path, the weakref finalizer
+        # registered by TemporaryDirectory handles cleanup on GC.
+        del batch_hidden_states
+        _hs_tmpdir.cleanup()
 
         return (
             metadata,
@@ -2960,7 +3224,6 @@ class DiskOffloadBackend(ExtractionBackend):
         import gc
 
         import numpy as np
-        from sklearn.decomposition import PCA
         from tqdm import tqdm
 
         if signals is None:
@@ -3100,11 +3363,29 @@ class DiskOffloadBackend(ExtractionBackend):
             sig: [None] * num_layers for sig in signals
         }
         signal_dims: dict[str, int] = {}
-        all_proj_chunks: list[np.ndarray] = []
-        all_coord_sample_id: list[int] = []
-        all_coord_layer: list[int] = []
-        all_coord_token_pos: list[int] = []
-        all_coord_signal: list[int] = []
+        # Pre-allocated per-scan outputs — same rationale as the chunked
+        # backend (see the equivalent comment there). Keeps cross-layer
+        # memory constant on multi-layer scans of long-sequence corpora.
+        # Skip under the reducers path — nothing is written there.
+        N_total = all_input_ids.shape[0]
+        S_max = all_input_ids.shape[1]
+        n_signals = len(signals)
+        if reducers is None:
+            total_rows = num_layers * n_signals * N_total * S_max
+            all_projections = np.zeros(
+                (total_rows, 1, n_components), dtype=np.float16,
+            )
+            all_coord_sample_id = np.zeros(total_rows, dtype=np.int32)
+            all_coord_layer = np.zeros(total_rows, dtype=np.int16)
+            all_coord_token_pos = np.zeros(total_rows, dtype=np.int16)
+            all_coord_signal = np.zeros(total_rows, dtype=np.int8)
+        else:
+            all_projections = np.zeros((0, 1, n_components), dtype=np.float16)
+            all_coord_sample_id = np.zeros(0, dtype=np.int32)
+            all_coord_layer = np.zeros(0, dtype=np.int16)
+            all_coord_token_pos = np.zeros(0, dtype=np.int16)
+            all_coord_signal = np.zeros(0, dtype=np.int8)
+        proj_cursor: int = 0
 
         # Spec 002: when projecting through a pre-fit basis, keep the basis
         # on device and project each microbatch's delta on GPU rather than
@@ -3313,52 +3594,33 @@ class DiskOffloadBackend(ExtractionBackend):
                     captures = per_signal_captures[sig_name]
                     if not captures:
                         continue
-                    stacked = torch.cat(captures, dim=0)  # [B_total, S, dim]
-                    B_total, S, dim = stacked.shape
-                    flat = stacked.reshape(-1, dim).float().numpy()
-
                     if sig_name not in signal_dims:
-                        signal_dims[sig_name] = dim
-
-                    if generative_masks is not None:
-                        fit_mask_parts = []
-                        for sid in range(B_total):
-                            if sid < len(generative_masks) and generative_masks[sid] is not None:
-                                gmask = generative_masks[sid]
-                                padded_mask = np.zeros(S, dtype=bool)
-                                padded_mask[:min(len(gmask), S)] = gmask[:S]
-                                fit_mask_parts.append(padded_mask)
-                            else:
-                                fit_mask_parts.append(np.ones(S, dtype=bool))
-                        fit_mask = np.concatenate(fit_mask_parts)
-                        flat_fit = flat[fit_mask]
-                    else:
-                        flat_fit = flat
-
-                    k = min(n_components, flat_fit.shape[0] - 1, dim)
-                    pca = PCA(n_components=k)
-                    pca.fit(flat_fit)
-
-                    basis = pca.components_.T.astype(np.float16)
-                    signal_bases[sig_name][layer_idx] = basis
-                    projected = pca.transform(flat).astype(np.float16)
-                    del stacked, flat
-
-                if k < n_components:
-                    padded = np.zeros(
-                        (projected.shape[0], n_components), dtype=np.float16,
+                        signal_dims[sig_name] = int(captures[0].shape[2])
+                    basis, projected, B_total, S, dim = _fit_project_scan_pca(
+                        captures,
+                        device=device,
+                        n_components=n_components,
+                        generative_masks=generative_masks,
                     )
-                    padded[:, :k] = projected
-                    projected = padded
+                    k = basis.shape[1]
+                    signal_bases[sig_name][layer_idx] = basis
+                    per_signal_captures[sig_name] = []
+                    del captures
 
-                all_proj_chunks.append(projected)
-
-                for sample_idx in range(B_total):
-                    for tok in range(S):
-                        all_coord_sample_id.append(sample_idx)
-                        all_coord_layer.append(layer_idx)
-                        all_coord_token_pos.append(tok)
-                        all_coord_signal.append(sig_idx)
+                block = B_total * S
+                row_end = proj_cursor + block
+                all_projections[proj_cursor:row_end, 0, :k] = projected
+                if k < n_components:
+                    all_projections[proj_cursor:row_end, 0, k:] = 0
+                all_coord_sample_id[proj_cursor:row_end] = np.repeat(
+                    np.arange(B_total, dtype=np.int32), S,
+                )
+                all_coord_layer[proj_cursor:row_end] = layer_idx
+                all_coord_token_pos[proj_cursor:row_end] = np.tile(
+                    np.arange(S, dtype=np.int16), B_total,
+                )
+                all_coord_signal[proj_cursor:row_end] = sig_idx
+                proj_cursor = row_end
 
                 del projected
 
@@ -3378,14 +3640,13 @@ class DiskOffloadBackend(ExtractionBackend):
                     basis_arr[L, :, :actual_k] = layer_basis
             final_bases[sig_name] = basis_arr
 
-        # Empty under the reducers path (spec 003) — reducers own the output.
-        if all_proj_chunks:
-            all_projections = np.concatenate(all_proj_chunks, axis=0)
-            all_projections = all_projections[:, np.newaxis, :]
-        else:
-            all_projections = np.zeros(
-                (0, 1, n_components), dtype=np.float16,
-            )
+        # Truncate pre-allocated outputs to cursor. In the reducers path
+        # (spec 003) cursor stays 0 and these become empty views.
+        all_projections = all_projections[:proj_cursor]
+        all_coord_sample_id = all_coord_sample_id[:proj_cursor]
+        all_coord_layer = all_coord_layer[:proj_cursor]
+        all_coord_token_pos = all_coord_token_pos[:proj_cursor]
+        all_coord_signal = all_coord_signal[:proj_cursor]
 
         metadata = {
             "model_id": self.model_name,

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1887,6 +1887,7 @@ class ChunkedLocalBackend(ExtractionBackend):
                     chunks = per_layer_projected[layer_idx][sig_name]
                     if not chunks:
                         continue
+                    assert external_bases is not None
                     basis = external_bases[sig_name][layer_idx]
                     signal_bases[sig_name][layer_idx] = basis
                     k = basis.shape[1]
@@ -3122,6 +3123,7 @@ class DiskOffloadBackend(ExtractionBackend):
                     chunks = per_signal_projected[sig_name]
                     if not chunks:
                         continue
+                    assert external_bases is not None
                     basis = external_bases[sig_name][layer_idx]
                     signal_bases[sig_name][layer_idx] = basis
                     k = basis.shape[1]

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -420,9 +420,11 @@ def _get_local_model(
 
         check_cuda_compatibility(device)
 
-        from transformers import AutoModelForCausalLM, AutoTokenizer
+        from transformers import AutoModelForCausalLM
 
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        from ._tokenizer_utils import load_tokenizer
+
+        tokenizer = load_tokenizer(model_name)
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 
@@ -1017,9 +1019,9 @@ class ChunkedLocalBackend(ExtractionBackend):
     @property
     def tokenizer(self) -> PreTrainedTokenizerBase:
         if self._tokenizer is None:
-            from transformers import AutoTokenizer
+            from ._tokenizer_utils import load_tokenizer
 
-            self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            self._tokenizer = load_tokenizer(self.model_name)
             if self._tokenizer.pad_token is None:
                 self._tokenizer.pad_token = self._tokenizer.eos_token
         return self._tokenizer
@@ -2480,8 +2482,8 @@ class DiskOffloadBackend(ExtractionBackend):
     @property
     def tokenizer(self) -> PreTrainedTokenizerBase:
         if self._tokenizer_obj is None:
-            from transformers import AutoTokenizer
-            self._tokenizer_obj = AutoTokenizer.from_pretrained(self.model_name)
+            from ._tokenizer_utils import load_tokenizer
+            self._tokenizer_obj = load_tokenizer(self.model_name)
             if self._tokenizer_obj.pad_token is None:
                 self._tokenizer_obj.pad_token = self._tokenizer_obj.eos_token
         return self._tokenizer_obj

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1816,7 +1816,7 @@ class ChunkedLocalBackend(ExtractionBackend):
         dict[str, Any],                # metadata
         dict[str, np.ndarray],          # bases: {signal_name: [n_layers, dim, k_eff]}
         np.ndarray,                     # projections [N_total, 1, k]
-        dict[str, list],                # coords {sample_id, layer, token_pos, signal}
+        dict[str, np.ndarray],          # coords {sample_id, layer, token_pos, signal}
         list[list[int]],                # token_ids per sample
         list[int],                      # seq_lengths per sample
         torch.Tensor,                   # attention_mask [n_samples, max_seq_len]
@@ -3207,7 +3207,7 @@ class DiskOffloadBackend(ExtractionBackend):
         dict[str, Any],                # metadata
         dict[str, np.ndarray],          # bases
         np.ndarray,                     # projections [N_total, 1, k]
-        dict[str, list],                # coords
+        dict[str, np.ndarray],          # coords
         list[list[int]],                # token_ids per sample
         list[int],                      # seq_lengths per sample
         torch.Tensor,                   # attention_mask

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -1502,6 +1502,8 @@ class ChunkedLocalBackend(ExtractionBackend):
         layer_idx: int,
         router_module_template: str | None,
         model: Any,
+        *,
+        stream_signals: set[str] | None = None,
     ) -> tuple[
         list[tuple[str, Any, list[torch.Tensor]]],  # [(signal_name, hook_handle, buffer)]
         bool,  # capture_residual — no hook, just layer output
@@ -1510,7 +1512,16 @@ class ChunkedLocalBackend(ExtractionBackend):
 
         Returns list of (signal_name, hook_handle, buffer) for hookable signals,
         plus a flag indicating whether to capture the residual (layer output).
+
+        Parameters
+        ----------
+        stream_signals : set[str] or None
+            Signals whose captures should stay on device (for downstream
+            stream-projection via an external basis — spec 002). Signals
+            *not* in this set — or always, when this is None — are
+            ``.cpu()``-ed inside the hook as before.
         """
+        stream_signals = stream_signals or set()
         hooks: list[tuple[str, Any, list[torch.Tensor]]] = []
         capture_residual = False
 
@@ -1520,13 +1531,18 @@ class ChunkedLocalBackend(ExtractionBackend):
                 continue
 
             buf: list[torch.Tensor] = []
+            stream = sig in stream_signals
 
             def _hook(
                 _mod: Any, _inp: Any, out: Any,
                 _buf: list = buf,
+                _stream: bool = stream,
             ) -> None:
                 delta = out[0] if isinstance(out, tuple) else out
-                _buf.append(delta.detach().cpu())
+                if _stream:
+                    _buf.append(delta.detach())
+                else:
+                    _buf.append(delta.detach().cpu())
 
             if sig == "attn_delta":
                 mod = _get_attn_submodule(layer_module)
@@ -1736,6 +1752,30 @@ class ChunkedLocalBackend(ExtractionBackend):
         all_coord_token_pos: list[int] = []
         all_coord_signal: list[int] = []
 
+        # Spec 002: stream-project through pre-fit basis to avoid accumulating
+        # full [N, S, H] activation tensors on CPU. Basis stays on device for
+        # the whole sweep; only [B, S, k] projections move to CPU.
+        stream_signals: set[str] = (
+            set(external_bases.keys()) if external_bases is not None else set()
+        )
+        basis_gpu: dict[str, torch.Tensor] = {}
+        if external_bases is not None:
+            for sig, arr in external_bases.items():
+                basis_gpu[sig] = torch.from_numpy(
+                    np.ascontiguousarray(arr),
+                ).to(device=device, dtype=torch.float32)
+
+        def _stream_project(
+            delta: torch.Tensor, sig_name: str, layer_idx: int,
+        ) -> np.ndarray:
+            B, S, H = delta.shape
+            basis = basis_gpu[sig_name][layer_idx]
+            flat = delta.reshape(-1, H).to(torch.float32)
+            proj = (flat @ basis).reshape(B, S, -1).to(torch.float16)
+            out = proj.cpu().numpy()
+            del flat, proj
+            return out
+
         # --- Layer chunk loop ---
         n_chunks = (num_layers + chunk_size - 1) // chunk_size
         chunk_pbar = tqdm(
@@ -1751,7 +1791,13 @@ class ChunkedLocalBackend(ExtractionBackend):
                 decoder_layers[i].to(device)
 
             # {layer_idx: {signal_name: [tensor_per_batch, ...]}}
+            # Legacy path (PCA fit, or signals not in external_bases).
             per_layer_captures: dict[int, dict[str, list[torch.Tensor]]] = {
+                L: {sig: [] for sig in signals}
+                for L in range(chunk_start, chunk_end)
+            }
+            # Stream-project path (external_bases signals).
+            per_layer_projected: dict[int, dict[str, list[np.ndarray]]] = {
                 L: {sig: [] for sig in signals}
                 for L in range(chunk_start, chunk_end)
             }
@@ -1769,6 +1815,7 @@ class ChunkedLocalBackend(ExtractionBackend):
                         hook_list, capture_residual = self._resolve_signal_hooks(
                             signals, layer_module, layer_idx,
                             router_module_template, model,
+                            stream_signals=stream_signals,
                         )
 
                         layer_kwargs = self._build_layer_kwargs(
@@ -1779,17 +1826,36 @@ class ChunkedLocalBackend(ExtractionBackend):
                         output = layer_module(hs, **layer_kwargs)
                         hs = output[0] if isinstance(output, tuple) else output
 
-                        # Collect hooked signals
+                        # Collect hooked signals. Stream-projected signals
+                        # get `(delta @ basis)` on GPU right here; legacy
+                        # signals go to CPU for between-chunk PCA.
                         for sig_name, handle, buf in hook_list:
                             handle.remove()
-                            if buf:
+                            if not buf:
+                                continue
+                            if sig_name in stream_signals:
+                                delta_gpu = buf[0]
+                                if sig_name not in signal_dims:
+                                    signal_dims[sig_name] = delta_gpu.shape[-1]
+                                per_layer_projected[layer_idx][sig_name].append(
+                                    _stream_project(delta_gpu, sig_name, layer_idx),
+                                )
+                                del delta_gpu
+                            else:
                                 per_layer_captures[layer_idx][sig_name].append(buf[0])
 
-                        # Residual = layer output (already in hs)
+                        # Residual = layer output (already in hs).
                         if capture_residual:
-                            per_layer_captures[layer_idx]["residual"].append(
-                                hs.detach().cpu()
-                            )
+                            if "residual" in stream_signals:
+                                if "residual" not in signal_dims:
+                                    signal_dims["residual"] = hs.shape[-1]
+                                per_layer_projected[layer_idx]["residual"].append(
+                                    _stream_project(hs.detach(), "residual", layer_idx),
+                                )
+                            else:
+                                per_layer_captures[layer_idx]["residual"].append(
+                                    hs.detach().cpu()
+                                )
 
                 batch_hidden_states[batch_idx] = hs.cpu()
                 del hs, mask_dev, pos_dev, pe_dev
@@ -1815,25 +1881,32 @@ class ChunkedLocalBackend(ExtractionBackend):
                 desc=f"  {_stage_label} (layers {chunk_start}-{chunk_end-1})",
                 leave=False,
             ):
-                captures = per_layer_captures[layer_idx][sig_name]
-                if not captures:
-                    continue
-
-                stacked = torch.cat(captures, dim=0)  # [B_total, S, dim]
-                B_total, S, dim = stacked.shape
-                flat = stacked.reshape(-1, dim).float().numpy()
-
-                # Record signal dimension
-                if sig_name not in signal_dims:
-                    signal_dims[sig_name] = dim
-
-                if external_bases is not None and sig_name in external_bases:
-                    # Use pre-trained basis — skip PCA fitting
-                    basis = external_bases[sig_name][layer_idx]  # [dim, k]
+                if sig_name in stream_signals:
+                    # Stream-project branch: concatenate already-projected
+                    # per-batch arrays; skip PCA and float32 upcast entirely.
+                    chunks = per_layer_projected[layer_idx][sig_name]
+                    if not chunks:
+                        continue
+                    basis = external_bases[sig_name][layer_idx]
                     signal_bases[sig_name][layer_idx] = basis
                     k = basis.shape[1]
-                    projected = (flat @ basis.astype(np.float32)).astype(np.float16)
+                    stacked_proj = np.concatenate(chunks, axis=0)  # [B_total, S, k]
+                    B_total, S, _ = stacked_proj.shape
+                    projected = stacked_proj.reshape(-1, k)
+                    del stacked_proj
                 else:
+                    # Legacy path: stack → flat → PCA (or external project).
+                    captures = per_layer_captures[layer_idx][sig_name]
+                    if not captures:
+                        continue
+
+                    stacked = torch.cat(captures, dim=0)  # [B_total, S, dim]
+                    B_total, S, dim = stacked.shape
+                    flat = stacked.reshape(-1, dim).float().numpy()
+
+                    if sig_name not in signal_dims:
+                        signal_dims[sig_name] = dim
+
                     # Build PCA fit data — filter to generative tokens if mask provided
                     if generative_masks is not None:
                         fit_mask_parts = []
@@ -1859,6 +1932,7 @@ class ChunkedLocalBackend(ExtractionBackend):
 
                     # Project ALL tokens through the basis
                     projected = pca.transform(flat).astype(np.float16)
+                    del stacked, flat
                 if k < n_components:
                     padded = np.zeros(
                         (projected.shape[0], n_components), dtype=np.float16,
@@ -1875,9 +1949,9 @@ class ChunkedLocalBackend(ExtractionBackend):
                         all_coord_token_pos.append(tok)
                         all_coord_signal.append(sig_idx)
 
-                del stacked, flat, projected
+                del projected
 
-            del per_layer_captures
+            del per_layer_captures, per_layer_projected
             gc.collect()
 
         # Assemble per-signal basis arrays: {sig: [n_layers, dim, k_eff]}
@@ -2902,6 +2976,29 @@ class DiskOffloadBackend(ExtractionBackend):
         all_coord_token_pos: list[int] = []
         all_coord_signal: list[int] = []
 
+        # Spec 002: when projecting through a pre-fit basis, keep the basis
+        # on device and project each microbatch's delta on GPU rather than
+        # accumulating full [N, S, H] activations on CPU.
+        basis_gpu: dict[str, torch.Tensor] = {}
+        if external_bases is not None:
+            for sig, arr in external_bases.items():
+                basis_gpu[sig] = torch.from_numpy(
+                    np.ascontiguousarray(arr),
+                ).to(device=device, dtype=torch.float32)
+
+        def _stream_project(
+            delta: torch.Tensor, sig_name: str, layer_idx: int,
+        ) -> np.ndarray:
+            """Project [B, S, H] on GPU through basis_gpu[sig][layer], return
+            [B, S, k] fp16 numpy on CPU. Caller is responsible for coords."""
+            B, S, H = delta.shape
+            basis = basis_gpu[sig_name][layer_idx]  # [H, k] fp32
+            flat = delta.reshape(-1, H).to(torch.float32)
+            proj = (flat @ basis).reshape(B, S, -1).to(torch.float16)
+            out = proj.cpu().numpy()
+            del flat, proj
+            return out
+
         # --- Phase 2: Layer-by-layer ---
         layer_pbar = tqdm(range(num_layers), desc="Scan: layers")
         for layer_idx in layer_pbar:
@@ -2914,7 +3011,12 @@ class DiskOffloadBackend(ExtractionBackend):
             _materialize_module(layer_module, layer_weights, prefix, device)
             del layer_weights
 
+            # Legacy path accumulates CPU tensors for PCA fit.
             per_signal_captures: dict[str, list[torch.Tensor]] = {
+                sig: [] for sig in signals
+            }
+            # Stream-project path accumulates already-projected np arrays.
+            per_signal_projected: dict[str, list[np.ndarray]] = {
                 sig: [] for sig in signals
             }
 
@@ -2925,7 +3027,8 @@ class DiskOffloadBackend(ExtractionBackend):
                 pe_dev = ChunkedLocalBackend._pe_to_device(position_embeddings, device)
 
                 with torch.no_grad():
-                    # Set up signal hooks
+                    # Set up signal hooks — keep captures on GPU when we're
+                    # going to stream-project them; else move to CPU as before.
                     hooks: list[tuple[str, Any, list[torch.Tensor]]] = []
                     capture_residual = False
                     for sig in signals:
@@ -2933,12 +3036,21 @@ class DiskOffloadBackend(ExtractionBackend):
                             capture_residual = True
                             continue
                         buf: list[torch.Tensor] = []
+                        stream = (
+                            external_bases is not None
+                            and sig in external_bases
+                        )
+
                         def _hook(
                             _mod: Any, _inp: Any, out: Any,
                             _buf: list = buf,
+                            _stream: bool = stream,
                         ) -> None:
                             delta = out[0] if isinstance(out, tuple) else out
-                            _buf.append(delta.detach().cpu())
+                            if _stream:
+                                _buf.append(delta.detach())
+                            else:
+                                _buf.append(delta.detach().cpu())
                         if sig == "attn_delta":
                             mod = _get_attn_submodule(layer_module)
                             h = mod.register_forward_hook(_hook)
@@ -2958,11 +3070,38 @@ class DiskOffloadBackend(ExtractionBackend):
 
                     for sig_name, handle, hook_buf in hooks:
                         handle.remove()
-                        if hook_buf:
+                        if not hook_buf:
+                            continue
+                        if (
+                            external_bases is not None
+                            and sig_name in external_bases
+                        ):
+                            delta_gpu = hook_buf[0]
+                            if sig_name not in signal_dims:
+                                signal_dims[sig_name] = delta_gpu.shape[-1]
+                            per_signal_projected[sig_name].append(
+                                _stream_project(delta_gpu, sig_name, layer_idx),
+                            )
+                            del delta_gpu
+                        else:
                             per_signal_captures[sig_name].append(hook_buf[0])
 
                     if capture_residual:
-                        per_signal_captures["residual"].append(hs.detach().cpu())
+                        if (
+                            external_bases is not None
+                            and "residual" in external_bases
+                        ):
+                            if "residual" not in signal_dims:
+                                signal_dims["residual"] = hs.shape[-1]
+                            per_signal_projected["residual"].append(
+                                _stream_project(
+                                    hs.detach(), "residual", layer_idx,
+                                ),
+                            )
+                        else:
+                            per_signal_captures["residual"].append(
+                                hs.detach().cpu(),
+                            )
 
                 batch_hidden_states[batch_idx] = hs.cpu()
                 del hs, mask_dev, pos_dev, pe_dev
@@ -2972,25 +3111,35 @@ class DiskOffloadBackend(ExtractionBackend):
             gc.collect()
             torch.cuda.empty_cache()
 
-            # --- PCA for this layer ---
+            # --- Per-layer assembly ---
             for sig_idx, sig_name in enumerate(signals):
-                captures = per_signal_captures[sig_name]
-                if not captures:
-                    continue
+                stream = (
+                    external_bases is not None
+                    and sig_name in external_bases
+                )
 
-                stacked = torch.cat(captures, dim=0)  # [B_total, S, dim]
-                B_total, S, dim = stacked.shape
-                flat = stacked.reshape(-1, dim).float().numpy()
-
-                if sig_name not in signal_dims:
-                    signal_dims[sig_name] = dim
-
-                if external_bases is not None and sig_name in external_bases:
+                if stream:
+                    chunks = per_signal_projected[sig_name]
+                    if not chunks:
+                        continue
                     basis = external_bases[sig_name][layer_idx]
                     signal_bases[sig_name][layer_idx] = basis
                     k = basis.shape[1]
-                    projected = (flat @ basis.astype(np.float32)).astype(np.float16)
+                    stacked_proj = np.concatenate(chunks, axis=0)  # [B_total, S, k]
+                    B_total, S, _ = stacked_proj.shape
+                    projected = stacked_proj.reshape(-1, k)
+                    del stacked_proj
                 else:
+                    captures = per_signal_captures[sig_name]
+                    if not captures:
+                        continue
+                    stacked = torch.cat(captures, dim=0)  # [B_total, S, dim]
+                    B_total, S, dim = stacked.shape
+                    flat = stacked.reshape(-1, dim).float().numpy()
+
+                    if sig_name not in signal_dims:
+                        signal_dims[sig_name] = dim
+
                     if generative_masks is not None:
                         fit_mask_parts = []
                         for sid in range(B_total):
@@ -3013,6 +3162,7 @@ class DiskOffloadBackend(ExtractionBackend):
                     basis = pca.components_.T.astype(np.float16)
                     signal_bases[sig_name][layer_idx] = basis
                     projected = pca.transform(flat).astype(np.float16)
+                    del stacked, flat
 
                 if k < n_components:
                     padded = np.zeros(
@@ -3030,9 +3180,9 @@ class DiskOffloadBackend(ExtractionBackend):
                         all_coord_token_pos.append(tok)
                         all_coord_signal.append(sig_idx)
 
-                del stacked, flat, projected
+                del projected
 
-            del per_signal_captures
+            del per_signal_captures, per_signal_projected
             gc.collect()
 
         # Assemble bases

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -175,7 +175,7 @@ def _fit_project_scan_pca(
 
     if use_cuml:
         import cupy as cp
-        from cuml.decomposition import PCA as CuPCA
+        from cuml.decomposition import PCA as CuPCA  # noqa: N811
         from torch.utils.dlpack import to_dlpack
 
         # Move each capture to GPU (fp32 for numerical stability in PCA)

--- a/src/lmprobe/logit_utils.py
+++ b/src/lmprobe/logit_utils.py
@@ -269,9 +269,9 @@ def compute_perplexity_from_activations(
 
     # Load tokenizer if not provided
     if tokenizer is None:
-        from transformers import AutoTokenizer
+        from ._tokenizer_utils import load_tokenizer
 
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenizer = load_tokenizer(model_name)
 
     results = []
     per_token_ppl_list: list[torch.Tensor] = []

--- a/src/lmprobe/reducers.py
+++ b/src/lmprobe/reducers.py
@@ -1,0 +1,253 @@
+"""Per-sample reducers for in-chunk projection aggregation.
+
+A :class:`Reducer` consumes per-microbatch :math:`[B, S_{pad}, k]`
+projections produced inside a :class:`SampleScan` forward sweep and folds
+them into a per-sample :math:`[N, L, n_{sig}, k]` summary. Reducers run
+immediately after each microbatch's stream-project step, so per-token
+projections never accumulate across chunks — the final cached data
+product is independent of sequence length and chunk count.
+
+See ``specs/003-per-sample-reduced-projection.md`` for the design
+motivation.
+
+Built-in reducers:
+
+- :class:`LastTokenReducer` — projection at the last ``True`` mask
+  position per sample.
+- :class:`MeanReducer` — mean over ``True`` mask positions per sample.
+- :class:`MeanExclLastNReducer` — mean over ``True`` mask positions
+  excluding the last ``n`` of them per sample. Falls back to
+  :class:`MeanReducer` semantics for samples with ``<= n`` ``True``
+  positions.
+
+Masks are carried per-reducer: ``list[np.ndarray]`` of bool, one per
+sample, where ``mask[i]`` has length ``seq_len_i`` and marks positions
+of interest (e.g. assistant tokens). The reducer aligns ``mask[i]``
+against the microbatch's ``attention_mask`` at update time, which makes
+it robust to left- vs right-padding. Masks must be derived from the
+same tokenizer run lmprobe uses — if ``len(mask[i])`` disagrees with
+the number of real tokens in the microbatch, update raises.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class Reducer(Protocol):
+    """Protocol for per-sample projection reducers.
+
+    A reducer is constructed with per-sample masks, gets
+    :meth:`init_state` called once at the start of a sweep, receives
+    microbatch projections via :meth:`update`, and produces the final
+    per-sample output in :meth:`finalize`.
+    """
+
+    def init_state(
+        self,
+        n_samples: int,
+        n_layers: int,
+        n_signals: int,
+        k: int,
+    ) -> Any:
+        """Allocate accumulators + bookkeeping for a sweep.
+
+        Returned object is threaded back into :meth:`update` and
+        :meth:`finalize`.
+        """
+        ...
+
+    def update(
+        self,
+        state: Any,
+        proj: np.ndarray,
+        sample_ids: np.ndarray,
+        layer_idx: int,
+        sig_idx: int,
+        attention_mask: np.ndarray,
+    ) -> None:
+        """Fold one microbatch's ``[B, S_pad, k]`` projection into the state.
+
+        Called once per (layer, signal) per microbatch.
+        """
+        ...
+
+    def finalize(self, state: Any) -> np.ndarray:
+        """Return the final ``[N, L, n_sig, k]`` reducer output."""
+        ...
+
+
+def _check_n_samples(n_samples: int, n_masks: int) -> None:
+    if n_samples != n_masks:
+        raise ValueError(
+            f"Reducer received n_samples={n_samples} from scan_forward, "
+            f"but was constructed with {n_masks} masks. Mask list length "
+            f"must equal the total number of prompts in the sweep."
+        )
+
+
+def _real_positions(attention_mask_row: np.ndarray) -> np.ndarray:
+    """Indices of real (non-pad) tokens within a padded microbatch row."""
+    return np.where(attention_mask_row.astype(bool))[0]
+
+
+class LastTokenReducer:
+    """Keep the projection at the last ``True`` mask position per sample.
+
+    For a sample whose mask has no ``True`` entries, the output slice is
+    left at zero.
+    """
+
+    def __init__(self, masks: Sequence[np.ndarray]) -> None:
+        self.masks: list[np.ndarray] = [
+            np.asarray(m, dtype=bool) for m in masks
+        ]
+
+    def init_state(
+        self,
+        n_samples: int,
+        n_layers: int,
+        n_signals: int,
+        k: int,
+    ) -> dict[str, Any]:
+        _check_n_samples(n_samples, len(self.masks))
+        last_true: list[int] = []
+        has_true: list[bool] = []
+        for m in self.masks:
+            idx = np.where(m)[0]
+            if len(idx) == 0:
+                last_true.append(-1)
+                has_true.append(False)
+            else:
+                last_true.append(int(idx[-1]))
+                has_true.append(True)
+        return {
+            "out": np.zeros(
+                (n_samples, n_layers, n_signals, k), dtype=np.float16,
+            ),
+            "last_true": last_true,
+            "has_true": has_true,
+        }
+
+    def update(
+        self,
+        state: dict[str, Any],
+        proj: np.ndarray,
+        sample_ids: np.ndarray,
+        layer_idx: int,
+        sig_idx: int,
+        attention_mask: np.ndarray,
+    ) -> None:
+        out = state["out"]
+        last_true = state["last_true"]
+        has_true = state["has_true"]
+        for b in range(proj.shape[0]):
+            sid = int(sample_ids[b])
+            if not has_true[sid]:
+                continue
+            lti = last_true[sid]
+            real_positions = _real_positions(attention_mask[b])
+            if lti >= len(real_positions):
+                raise ValueError(
+                    f"LastTokenReducer: sample {sid} mask last-true index "
+                    f"{lti} >= attention_mask real length "
+                    f"{len(real_positions)}. Masks must be derived from the "
+                    f"same tokenizer run lmprobe uses."
+                )
+            out[sid, layer_idx, sig_idx, :] = proj[b, real_positions[lti], :]
+
+    def finalize(self, state: dict[str, Any]) -> np.ndarray:
+        out: np.ndarray = state["out"]
+        return out
+
+
+class MeanReducer:
+    """Mean of the projection over ``True`` mask positions per sample.
+
+    Accumulates in fp32, divides by per-sample ``True`` count at
+    :meth:`finalize`, and returns fp16. Samples with zero ``True``
+    positions produce zeros.
+    """
+
+    def __init__(self, masks: Sequence[np.ndarray]) -> None:
+        self.masks: list[np.ndarray] = [
+            np.asarray(m, dtype=bool) for m in masks
+        ]
+
+    def init_state(
+        self,
+        n_samples: int,
+        n_layers: int,
+        n_signals: int,
+        k: int,
+    ) -> dict[str, Any]:
+        _check_n_samples(n_samples, len(self.masks))
+        count = np.array([int(m.sum()) for m in self.masks], dtype=np.int64)
+        return {
+            "sum": np.zeros(
+                (n_samples, n_layers, n_signals, k), dtype=np.float32,
+            ),
+            "count": count,
+        }
+
+    def update(
+        self,
+        state: dict[str, Any],
+        proj: np.ndarray,
+        sample_ids: np.ndarray,
+        layer_idx: int,
+        sig_idx: int,
+        attention_mask: np.ndarray,
+    ) -> None:
+        sum_arr = state["sum"]
+        for b in range(proj.shape[0]):
+            sid = int(sample_ids[b])
+            mask = self.masks[sid]
+            real_positions = _real_positions(attention_mask[b])
+            seq_len = len(real_positions)
+            if len(mask) != seq_len:
+                raise ValueError(
+                    f"MeanReducer: sample {sid} mask length {len(mask)} != "
+                    f"attention_mask real length {seq_len}. Masks must be "
+                    f"derived from the same tokenizer run lmprobe uses."
+                )
+            if not mask.any():
+                continue
+            selected = proj[b, real_positions[mask], :].astype(np.float32)
+            sum_arr[sid, layer_idx, sig_idx, :] += selected.sum(axis=0)
+
+    def finalize(self, state: dict[str, Any]) -> np.ndarray:
+        sum_arr: np.ndarray = state["sum"]
+        count: np.ndarray = state["count"]
+        out = np.zeros(sum_arr.shape, dtype=np.float16)
+        nonzero = count > 0
+        if nonzero.any():
+            divisor = count[nonzero].astype(np.float32)[:, None, None, None]
+            out[nonzero] = (sum_arr[nonzero] / divisor).astype(np.float16)
+        return out
+
+
+class MeanExclLastNReducer(MeanReducer):
+    """Mean of the projection over ``True`` mask positions excluding the
+    last ``n`` of them per sample.
+
+    When a sample has ``<= n`` ``True`` positions, behaves identically to
+    :class:`MeanReducer` over the full mask.
+    """
+
+    def __init__(self, masks: Sequence[np.ndarray], n: int = 5) -> None:
+        if n < 0:
+            raise ValueError(f"n must be >= 0, got {n}")
+        self.n = int(n)
+        derived: list[np.ndarray] = []
+        for m in masks:
+            arr = np.asarray(m, dtype=bool).copy()
+            true_idx = np.where(arr)[0]
+            if self.n > 0 and len(true_idx) > self.n:
+                arr[true_idx[-self.n:]] = False
+            derived.append(arr)
+        super().__init__(derived)

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -50,7 +50,34 @@ class SampleScan:
         Path to an existing scan directory on disk.
     """
 
-    def __init__(self, scan_dir: str | Path) -> None:
+    def __init__(
+        self,
+        scan_dir: str | Path,
+        *,
+        backend: str = "auto",
+    ) -> None:
+        """Load an existing scan from disk.
+
+        Parameters
+        ----------
+        scan_dir : str or Path
+            Path to an existing scan directory.
+        backend : str
+            Which backend to use for projection forward passes. One of:
+              - ``"auto"`` (default): heuristic based on model size vs.
+                available CPU RAM. ``disk_offload`` kicks in when the
+                estimated model weight footprint exceeds 80% of system RAM.
+              - ``"chunked"``: force ``ChunkedLocalBackend`` (full model on
+                CPU, layers streamed to GPU in chunks). Fast when the full
+                dataset's intermediate residuals + signal captures fit in
+                CPU RAM alongside the model weights.
+              - ``"disk_offload"``: force ``DiskOffloadBackend`` (layer
+                weights streamed directly from safetensors to GPU, never
+                resident on CPU). Preferred when the full model wouldn't
+                leave room for intermediate activations at the sample
+                counts being projected — e.g. fusing many long-sequence
+                prompts into one call.
+        """
         from . import scan_storage
 
         self._scan_dir = Path(scan_dir)
@@ -64,6 +91,13 @@ class SampleScan:
         self._samples_table = scan_storage.read_samples(self._scan_dir)
         self._projections: np.memmap | None = None
         self._coords_table: Any = None
+
+        if backend not in ("auto", "chunked", "disk_offload"):
+            raise ValueError(
+                f"backend must be one of 'auto', 'chunked', 'disk_offload'; "
+                f"got {backend!r}"
+            )
+        self._backend_mode = backend
 
         # Backend for projection forward passes (lazy-loaded)
         self._backend: Any = None
@@ -609,25 +643,37 @@ class SampleScan:
     def _get_backend(self) -> Any:
         """Lazy-load a backend for projection.
 
-        Uses DiskOffloadBackend for models whose weights exceed ~80% of
-        available CPU RAM; otherwise uses ChunkedLocalBackend.
+        Resolution order:
+          1. If ``self._backend_mode`` was set explicitly at construction
+             (``"chunked"`` or ``"disk_offload"``), honor that.
+          2. Otherwise (``"auto"``), use DiskOffloadBackend when the
+             estimated model weight footprint exceeds 80% of available
+             CPU RAM; else ChunkedLocalBackend.
         """
         if self._backend is None:
             import torch
 
             device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
-            # Estimate model weight size from hidden_dim and n_layers
-            # Rough heuristic: 2 bytes/param (bf16), ~12*hidden^2 params/layer
-            est_bytes = self._metadata.n_layers * 12 * (self._metadata.hidden_dim ** 2) * 2
-            mem_avail: float
-            try:
-                import os
-                mem_avail = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
-            except (ValueError, OSError):
-                mem_avail = float("inf")
+            mode = self._backend_mode
+            if mode == "auto":
+                # Estimate model weight size from hidden_dim and n_layers.
+                # Rough heuristic: 2 bytes/param (bf16), ~12*hidden^2 params/layer.
+                est_bytes = (
+                    self._metadata.n_layers
+                    * 12
+                    * (self._metadata.hidden_dim ** 2)
+                    * 2
+                )
+                mem_avail: float
+                try:
+                    import os
+                    mem_avail = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+                except (ValueError, OSError):
+                    mem_avail = float("inf")
+                mode = "disk_offload" if est_bytes > 0.8 * mem_avail else "chunked"
 
-            if est_bytes > 0.8 * mem_avail:
+            if mode == "disk_offload":
                 from .backends import DiskOffloadBackend
                 self._backend = DiskOffloadBackend(
                     model_name=self._metadata.model_id,

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -26,6 +26,7 @@ Example
 from __future__ import annotations
 
 import datetime
+from collections.abc import Hashable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -66,6 +67,11 @@ class SampleScan:
 
         # Backend for projection forward passes (lazy-loaded)
         self._backend: Any = None
+
+        # Counter for batch_project calls to warn about the N-sweep trap.
+        # See `batch_project_grouped` for the fused alternative.
+        self._batch_project_call_count = 0
+        self._batch_project_warned = False
 
     @classmethod
     def run(
@@ -441,6 +447,12 @@ class SampleScan:
         """Project multiple prompts through the scan basis in a single
         batched forward pass. Much faster than looping project_prompt().
 
+        Each call performs a full layer-streaming sweep (chunked backend)
+        or full-dataset layer load (disk_offload backend). For multiple
+        logical groups (dataset splits, train/eval/control corpora),
+        prefer :meth:`batch_project_grouped` — one sweep for the whole
+        union instead of one sweep per group.
+
         Parameters
         ----------
         prompts : list[str]
@@ -458,7 +470,37 @@ class SampleScan:
             - coords: dict with keys sample_id, layer, token_pos, signal
             - token_ids_per_sample: list of token ID lists
             - seq_lengths: list of int
+
+        See Also
+        --------
+        batch_project_grouped : Fused variant for multiple labeled groups.
         """
+        self._batch_project_call_count += 1
+        if (
+            self._batch_project_call_count >= 3
+            and not self._batch_project_warned
+        ):
+            import warnings
+            warnings.warn(
+                "SampleScan.batch_project called 3+ times on the same "
+                "scan. Each call re-streams every model layer CPU→GPU. "
+                "For multiple prompt groups (e.g. dataset splits), use "
+                "scan.batch_project_grouped({...}) — same semantics, one "
+                "layer sweep for the whole union.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self._batch_project_warned = True
+        return self._batch_project_impl(
+            prompts, signal=signal, batch_size=batch_size,
+        )
+
+    def _batch_project_impl(
+        self,
+        prompts: list[str],
+        signal: str | None = None,
+        batch_size: int = 4,
+    ) -> tuple[np.ndarray, dict[str, list[Any]], list[list[int]], list[int]]:
         backend = self._get_backend()
         proj_signals = [signal] if signal else self.signals
 
@@ -480,6 +522,87 @@ class SampleScan:
         )
 
         return projections, coords, token_ids_per_sample, seq_lengths
+
+    def batch_project_grouped(
+        self,
+        prompt_groups: Mapping[Hashable, list[str]],
+        *,
+        signal: str | None = None,
+        batch_size: int = 4,
+    ) -> dict[
+        Hashable,
+        tuple[np.ndarray, dict[str, list[Any]], list[list[int]], list[int]],
+    ]:
+        """Project multiple labeled groups of prompts in a single
+        layer-streaming sweep.
+
+        Preferred over repeated :meth:`batch_project` calls when multiple
+        groups (e.g. dataset splits) need projecting: layer weights are
+        streamed CPU→GPU once for the whole union of prompts, rather than
+        once per call. Each per-group output is indistinguishable from
+        what :meth:`batch_project` would return if called on that group's
+        prompts alone.
+
+        Parameters
+        ----------
+        prompt_groups : mapping of hashable key → list[str]
+            Named groups of prompts. Iteration order is preserved in the
+            returned dict.
+        signal : str or None
+            If given, only project this signal.
+        batch_size : int
+            Microbatch size for the forward pass.
+
+        Returns
+        -------
+        dict
+            ``{key: (projections, coords, token_ids_per_sample, seq_lengths)}``.
+            Per-group ``coords["sample_id"]`` is rebased to 0..len(group)-1.
+        """
+        keys = list(prompt_groups.keys())
+        all_prompts: list[str] = []
+        bounds: list[tuple[Hashable, int, int]] = []
+        cursor = 0
+        for k in keys:
+            group_prompts = list(prompt_groups[k])
+            start = cursor
+            all_prompts.extend(group_prompts)
+            cursor += len(group_prompts)
+            bounds.append((k, start, cursor))
+
+        projections, coords, token_ids_per_sample, seq_lengths = (
+            self._batch_project_impl(
+                all_prompts, signal=signal, batch_size=batch_size,
+            )
+        )
+
+        sample_id_arr = np.asarray(coords["sample_id"])
+        token_pos_arr = np.asarray(coords["token_pos"])
+        coord_arrays = {c: np.asarray(v) for c, v in coords.items()}
+
+        out: dict[
+            Hashable,
+            tuple[np.ndarray, dict[str, list[Any]], list[list[int]], list[int]],
+        ] = {}
+        for key, start, end in bounds:
+            group_seq_lens = seq_lengths[start:end]
+            # Padding in standalone batch_project is max(seq_len in group);
+            # trim token positions beyond that so per-group output matches.
+            pad_len = max(group_seq_lens) if group_seq_lens else 0
+            mask = (
+                (sample_id_arr >= start)
+                & (sample_id_arr < end)
+                & (token_pos_arr < pad_len)
+            )
+            group_coords = {c: arr[mask] for c, arr in coord_arrays.items()}
+            group_coords["sample_id"] = group_coords["sample_id"] - start
+            out[key] = (
+                projections[mask],
+                {c: v.tolist() for c, v in group_coords.items()},
+                token_ids_per_sample[start:end],
+                group_seq_lens,
+            )
+        return out
 
     # --- Single Projection ---
 

--- a/src/lmprobe/sample_scan.py
+++ b/src/lmprobe/sample_scan.py
@@ -35,6 +35,8 @@ import numpy as np
 if TYPE_CHECKING:
     import matplotlib.figure
 
+    from .reducers import Reducer
+
 
 class SampleScan:
     """A compressed activation scan — a reusable PCA basis fit on a corpus.
@@ -636,6 +638,104 @@ class SampleScan:
                 token_ids_per_sample[start:end],
                 group_seq_lens,
             )
+        return out
+
+    def batch_project_reduced(
+        self,
+        prompt_groups: Mapping[Hashable, list[str]],
+        *,
+        reducers: Mapping[str, Reducer],
+        signal: str | None = None,
+        batch_size: int = 4,
+    ) -> dict[Hashable, dict[str, np.ndarray]]:
+        """Project groups through the scan basis and reduce per-sample in-chunk.
+
+        Spec 003. Fused single-sweep projection over the union of all
+        prompts (same pattern as :meth:`batch_project_grouped`) that applies
+        each supplied reducer to every microbatch's projection as soon as it
+        is produced, then frees it. Per-token projections never accumulate
+        across chunks — cross-chunk memory is bounded by residuals plus the
+        tiny per-sample reducer outputs, independent of sequence length and
+        chunk count.
+
+        The caller-supplied :class:`~lmprobe.reducers.Reducer` instances own
+        their masks. Mask list length must equal the total number of prompts
+        in the union (``sum(len(v) for v in prompt_groups.values())``), with
+        per-sample ordering matching the flattened union order (groups
+        concatenated in ``prompt_groups`` iteration order). Built-in
+        reducers live in :mod:`lmprobe.reducers`.
+
+        Parameters
+        ----------
+        prompt_groups : mapping of hashable key → list[str]
+            Named groups of prompts. Iteration order defines the flat
+            union ordering that reducer masks must match.
+        reducers : mapping of {name: Reducer}
+            Reducers keyed by name. Each is initialized internally via
+            ``init_state(N_total, n_layers, n_signals, k)``.
+        signal : str or None
+            If given, restrict to this signal only; ``n_signals == 1`` and
+            ``sig_idx == 0`` inside reducer state.
+        batch_size : int
+            Microbatch size for the forward pass.
+
+        Returns
+        -------
+        dict
+            ``{group_key: {reducer_name: [N_group, n_layers, n_signals, k]}}``.
+        """
+        keys = list(prompt_groups.keys())
+        all_prompts: list[str] = []
+        bounds: list[tuple[Hashable, int, int]] = []
+        cursor = 0
+        for k in keys:
+            group_prompts = list(prompt_groups[k])
+            start = cursor
+            all_prompts.extend(group_prompts)
+            cursor += len(group_prompts)
+            bounds.append((k, start, cursor))
+
+        n_total = cursor
+        proj_signals = [signal] if signal else self.signals
+        n_layers = self._metadata.n_layers
+        n_signals = len(proj_signals)
+        k_dim = self._metadata.n_components
+
+        bases_subset = {
+            s: self._bases[s] for s in proj_signals if s in self._bases
+        }
+        if not bases_subset:
+            raise ValueError(
+                f"batch_project_reduced: no bases available for requested "
+                f"signals {proj_signals}; scan bases: {list(self._bases)}."
+            )
+        if len(bases_subset) != len(proj_signals):
+            missing = [s for s in proj_signals if s not in bases_subset]
+            raise ValueError(
+                f"batch_project_reduced: scan missing bases for signals "
+                f"{missing}; available: {list(self._bases)}."
+            )
+
+        bound: dict[str, tuple[Reducer, Any]] = {}
+        for name, red in reducers.items():
+            state = red.init_state(n_total, n_layers, n_signals, k_dim)
+            bound[name] = (red, state)
+
+        backend = self._get_backend()
+        backend.scan_forward(
+            all_prompts,
+            signals=proj_signals,
+            n_components=k_dim,
+            batch_size=batch_size,
+            external_bases=bases_subset,
+            reducers=bound,
+        )
+
+        out: dict[Hashable, dict[str, np.ndarray]] = {k: {} for k in keys}
+        for name, (red, state) in bound.items():
+            full = red.finalize(state)
+            for key, start, end in bounds:
+                out[key][name] = full[start:end]
         return out
 
     # --- Single Projection ---

--- a/src/lmprobe/sharing.py
+++ b/src/lmprobe/sharing.py
@@ -898,8 +898,8 @@ def _compute_shard_plan(
 
     # Pre-load tokenizer once before threads if token_perplexity is needed
     if has_token_perplexity and _tokenizer_cache.get("instance") is None:
-        from transformers import AutoTokenizer
-        _tokenizer_cache["instance"] = AutoTokenizer.from_pretrained(model_name)
+        from ._tokenizer_utils import load_tokenizer
+        _tokenizer_cache["instance"] = load_tokenizer(model_name)
 
     def _scan_one(idx: int) -> tuple[int, dict | None]:
         """Scan metadata for a single prompt.  Returns (idx, meta_entry | None)."""

--- a/src/lmprobe/unified_cache.py
+++ b/src/lmprobe/unified_cache.py
@@ -1035,8 +1035,7 @@ class UnifiedCache:
             len(uncached), len(prompts) - len(uncached),
         )
 
-        from transformers import AutoTokenizer
-
+        from ._tokenizer_utils import load_tokenizer
         from .logit_utils import (
             compute_perplexity_from_activations,
             download_lm_head_weights,
@@ -1046,7 +1045,7 @@ class UnifiedCache:
         norm_weight, lm_head_weight, norm_config = download_lm_head_weights(
             self.model_name, device=device,
         )
-        tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        tokenizer = load_tokenizer(self.model_name)
 
         computed = 0
         for batch_start in range(0, len(uncached), batch_size):

--- a/tests/test_chunked_backend.py
+++ b/tests/test_chunked_backend.py
@@ -223,3 +223,96 @@ class TestChunkedExtraction:
 
         num_layers = get_num_layers_from_config(tiny_model)
         assert cs == num_layers
+
+
+# ── scan_forward: memmap-backed batch_hidden_states (spec 004) ──────────────
+
+
+class TestScanForwardMemmap:
+    """Spec 004: cross-chunk residuals live in an np.memmap, not a list of
+    CPU tensors. These tests verify the memmap path is correct under
+    actual chunking (chunk_size < num_layers) and produces results
+    indistinguishable from a single-chunk run."""
+
+    def _scan(self, tiny_model, chunk_size: int, prompts: list[str]):
+        backend = ChunkedLocalBackend(
+            tiny_model, "cpu", dtype=torch.float32, chunk_size=chunk_size,
+        )
+        return backend.scan_forward(
+            prompts=prompts,
+            signals=["attn_delta", "mlp_delta"],
+            n_components=4,
+            batch_size=2,
+        )
+
+    def test_chunked_scan_matches_single_chunk(self, tiny_model):
+        """Running with chunk_size=1 (forces memmap round-trip between
+        every layer) produces identical projections and bases to
+        chunk_size=num_layers (single chunk, no cross-chunk write-back)."""
+        from lmprobe.extraction import get_num_layers_from_config
+
+        num_layers = get_num_layers_from_config(tiny_model)
+        prompts = ["The dog ran fast", "A cat sat quietly", "Fetch the ball"]
+
+        _, bases_full, proj_full, coords_full, _, _, _, _ = self._scan(
+            tiny_model, chunk_size=num_layers, prompts=prompts,
+        )
+        _, bases_chunk, proj_chunk, coords_chunk, _, _, _, _ = self._scan(
+            tiny_model, chunk_size=1, prompts=prompts,
+        )
+
+        import numpy as np
+
+        # With dtype=fp32 the memmap round-trip is byte-identical, so
+        # PCA sees the same input and produces the same output.
+        np.testing.assert_array_equal(proj_full, proj_chunk)
+
+        for sig in bases_full:
+            np.testing.assert_array_equal(bases_full[sig], bases_chunk[sig])
+
+        for key in coords_full:
+            np.testing.assert_array_equal(coords_full[key], coords_chunk[key])
+
+    def test_memmap_file_is_cleaned_up(self, tiny_model, monkeypatch):
+        """The memmap's backing file lives under a TemporaryDirectory
+        scoped to scan_forward — no temp files should persist after
+        the call returns."""
+        import tempfile
+
+        created_dirs: list[str] = []
+        real_tempdir = tempfile.TemporaryDirectory
+
+        class _TrackingTempDir(real_tempdir):  # type: ignore[misc, valid-type]
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_dirs.append(self.name)
+
+        monkeypatch.setattr(tempfile, "TemporaryDirectory", _TrackingTempDir)
+
+        self._scan(tiny_model, chunk_size=1, prompts=["One", "Two"])
+
+        import os
+        # At least one TemporaryDirectory was used, and all are gone.
+        assert created_dirs, "scan_forward did not open a TemporaryDirectory"
+        for d in created_dirs:
+            assert not os.path.exists(d), f"temp dir leaked: {d}"
+
+    def test_bf16_path_roundtrips(self, tiny_model):
+        """Spec 004 stores bf16 residuals in a uint16 memmap container.
+        Verify the reinterpret-view round-trip is stable end-to-end at
+        the default bf16 dtype."""
+        backend = ChunkedLocalBackend(
+            tiny_model, "cpu", dtype=torch.bfloat16, chunk_size=1,
+        )
+        _, bases, proj, _, _, _, _, _ = backend.scan_forward(
+            prompts=["One short", "Two short", "Three short"],
+            signals=["attn_delta"],
+            n_components=2,
+            batch_size=2,
+        )
+        # Shape + finiteness checks. A broken bf16 reinterpret would
+        # typically produce NaN or catastrophically large values.
+        import numpy as np
+        assert proj.shape[-1] == 2
+        assert np.isfinite(proj).all()
+        assert np.isfinite(bases["attn_delta"]).all()

--- a/tests/test_chunked_backend.py
+++ b/tests/test_chunked_backend.py
@@ -299,20 +299,86 @@ class TestScanForwardMemmap:
 
     def test_bf16_path_roundtrips(self, tiny_model):
         """Spec 004 stores bf16 residuals in a uint16 memmap container.
-        Verify the reinterpret-view round-trip is stable end-to-end at
-        the default bf16 dtype."""
-        backend = ChunkedLocalBackend(
-            tiny_model, "cpu", dtype=torch.bfloat16, chunk_size=1,
-        )
-        _, bases, proj, _, _, _, _, _ = backend.scan_forward(
-            prompts=["One short", "Two short", "Three short"],
-            signals=["attn_delta"],
-            n_components=2,
-            batch_size=2,
-        )
-        # Shape + finiteness checks. A broken bf16 reinterpret would
-        # typically produce NaN or catastrophically large values.
+        Compare chunked (cross-chunk memmap roundtrip) to single-chunk
+        (no roundtrip) at bf16. Bit-identical isn't achievable at bf16
+        because sklearn's PCA rounds fp32 intermediates differently
+        across call orderings, but the two paths should agree within
+        bf16-ish tolerance. A broken `.view(torch.bfloat16)` typically
+        blows up well past this."""
         import numpy as np
-        assert proj.shape[-1] == 2
-        assert np.isfinite(proj).all()
-        assert np.isfinite(bases["attn_delta"]).all()
+
+        from lmprobe.extraction import get_num_layers_from_config
+
+        num_layers = get_num_layers_from_config(tiny_model)
+        prompts = ["One short", "Two short", "Three short"]
+
+        def run(chunk_size):
+            backend = ChunkedLocalBackend(
+                tiny_model, "cpu", dtype=torch.bfloat16, chunk_size=chunk_size,
+            )
+            return backend.scan_forward(
+                prompts=prompts,
+                signals=["attn_delta"],
+                n_components=2,
+                batch_size=2,
+            )
+
+        _, bases_single, proj_single, _, _, _, _, _ = run(num_layers)
+        _, bases_chunk, proj_chunk, _, _, _, _, _ = run(1)
+
+        # bf16 stored in the memmap; compare as fp32.
+        assert np.isfinite(proj_chunk).all()
+        assert np.isfinite(bases_chunk["attn_delta"]).all()
+        np.testing.assert_allclose(
+            proj_chunk.astype(np.float32),
+            proj_single.astype(np.float32),
+            atol=5e-2, rtol=5e-2,
+        )
+        np.testing.assert_allclose(
+            bases_chunk["attn_delta"].astype(np.float32),
+            bases_single["attn_delta"].astype(np.float32),
+            atol=5e-2, rtol=5e-2,
+        )
+
+    def test_tempdir_cleaned_up_on_exception(self, tiny_model, monkeypatch):
+        """If scan_forward raises mid-scan, the TemporaryDirectory must
+        still be cleaned up — the try/finally around the body guarantees
+        this independent of GC timing. Inject the failure at
+        `_make_causal_mask`, which is called inside the chunk loop
+        after the tmpdir has been created and populated."""
+        import os
+        import tempfile
+
+        created_dirs: list[str] = []
+        real_tempdir = tempfile.TemporaryDirectory
+
+        class _TrackingTempDir(real_tempdir):  # type: ignore[misc, valid-type]
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_dirs.append(self.name)
+
+        monkeypatch.setattr(tempfile, "TemporaryDirectory", _TrackingTempDir)
+
+        import lmprobe.backends as bmod
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("forced test failure")
+
+        monkeypatch.setattr(bmod, "_make_causal_mask", boom)
+
+        backend = ChunkedLocalBackend(
+            tiny_model, "cpu", dtype=torch.float32, chunk_size=1,
+        )
+        with pytest.raises(RuntimeError, match="forced test failure"):
+            backend.scan_forward(
+                prompts=["One", "Two"],
+                signals=["attn_delta"],
+                n_components=2,
+                batch_size=2,
+            )
+
+        assert created_dirs, "scan_forward did not open a TemporaryDirectory"
+        for d in created_dirs:
+            assert not os.path.exists(d), (
+                f"temp dir leaked on exception path: {d}"
+            )

--- a/tests/test_reducers.py
+++ b/tests/test_reducers.py
@@ -1,0 +1,214 @@
+"""Unit tests for per-sample reducers (spec 003).
+
+Exercises the reducer protocol implementations in isolation — no model,
+no backend. Verifies LastTokenReducer / MeanReducer / MeanExclLastNReducer
+produce the expected per-sample outputs given synthetic projection
+microbatches and attention masks.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lmprobe.reducers import (
+    LastTokenReducer,
+    MeanExclLastNReducer,
+    MeanReducer,
+    Reducer,
+)
+
+
+def _mask(length: int, true_positions: list[int]) -> np.ndarray:
+    m = np.zeros(length, dtype=bool)
+    m[true_positions] = True
+    return m
+
+
+class TestLastTokenReducer:
+    def test_selects_last_true_position(self):
+        masks = [_mask(4, [0, 2]), _mask(5, [1, 4])]
+        red = LastTokenReducer(masks)
+        state = red.init_state(n_samples=2, n_layers=1, n_signals=1, k=3)
+
+        proj = np.array(
+            [
+                [
+                    [1.0, 1.0, 1.0],
+                    [2.0, 2.0, 2.0],
+                    [9.0, 9.0, 9.0],
+                    [0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                ],
+                [
+                    [0.0, 0.0, 0.0],
+                    [3.0, 3.0, 3.0],
+                    [4.0, 4.0, 4.0],
+                    [5.0, 5.0, 5.0],
+                    [7.0, 7.0, 7.0],
+                ],
+            ],
+            dtype=np.float16,
+        )
+        attention = np.array(
+            [
+                [1, 1, 1, 1, 0],
+                [1, 1, 1, 1, 1],
+            ],
+            dtype=bool,
+        )
+        red.update(state, proj, [0, 1], 0, 0, attention)
+        out = red.finalize(state)
+        assert out.shape == (2, 1, 1, 3)
+        np.testing.assert_array_equal(out[0, 0, 0], [9.0, 9.0, 9.0])
+        np.testing.assert_array_equal(out[1, 0, 0], [7.0, 7.0, 7.0])
+
+    def test_no_true_positions_yields_zero(self):
+        masks = [_mask(3, [])]
+        red = LastTokenReducer(masks)
+        state = red.init_state(1, 1, 1, 2)
+        proj = np.full((1, 3, 2), 5.0, dtype=np.float16)
+        attn = np.ones((1, 3), dtype=bool)
+        red.update(state, proj, [0], 0, 0, attn)
+        out = red.finalize(state)
+        np.testing.assert_array_equal(out[0, 0, 0], [0.0, 0.0])
+
+    def test_mismatch_between_mask_and_attention_raises(self):
+        masks = [_mask(10, [0, 9])]
+        red = LastTokenReducer(masks)
+        state = red.init_state(1, 1, 1, 2)
+        proj = np.zeros((1, 4, 2), dtype=np.float16)
+        attn = np.ones((1, 4), dtype=bool)
+        with pytest.raises(ValueError, match="last-true index"):
+            red.update(state, proj, [0], 0, 0, attn)
+
+    def test_wrong_n_samples_raises(self):
+        red = LastTokenReducer([_mask(3, [0])])
+        with pytest.raises(ValueError, match="Mask list length"):
+            red.init_state(n_samples=2, n_layers=1, n_signals=1, k=2)
+
+    def test_multi_layer_multi_signal_axes(self):
+        masks = [_mask(3, [2])]
+        red = LastTokenReducer(masks)
+        state = red.init_state(n_samples=1, n_layers=2, n_signals=3, k=2)
+        proj = np.array([[[1, 1], [2, 2], [3, 3]]], dtype=np.float16)
+        attn = np.ones((1, 3), dtype=bool)
+        red.update(state, proj, [0], layer_idx=1, sig_idx=2, attention_mask=attn)
+        out = red.finalize(state)
+        assert out.shape == (1, 2, 3, 2)
+        np.testing.assert_array_equal(out[0, 1, 2], [3, 3])
+        # Unvisited cells remain zero.
+        np.testing.assert_array_equal(out[0, 0, 0], [0, 0])
+
+
+class TestMeanReducer:
+    def test_mean_over_true_positions(self):
+        masks = [_mask(4, [0, 2, 3])]
+        red = MeanReducer(masks)
+        state = red.init_state(1, 1, 1, 2)
+        proj = np.array(
+            [[[2.0, 4.0], [10.0, 10.0], [4.0, 6.0], [6.0, 8.0]]],
+            dtype=np.float16,
+        )
+        attn = np.ones((1, 4), dtype=bool)
+        red.update(state, proj, [0], 0, 0, attn)
+        out = red.finalize(state)
+        # mean of (2,4,6) positions = (2,4), (4,6), (6,8) -> avg (4, 6)
+        np.testing.assert_allclose(out[0, 0, 0], [4.0, 6.0], atol=1e-2)
+
+    def test_empty_mask_produces_zero(self):
+        masks = [_mask(3, [])]
+        red = MeanReducer(masks)
+        state = red.init_state(1, 1, 1, 2)
+        proj = np.full((1, 3, 2), 42.0, dtype=np.float16)
+        attn = np.ones((1, 3), dtype=bool)
+        red.update(state, proj, [0], 0, 0, attn)
+        out = red.finalize(state)
+        np.testing.assert_array_equal(out[0, 0, 0], [0.0, 0.0])
+
+    def test_length_mismatch_raises(self):
+        masks = [_mask(5, [0, 4])]
+        red = MeanReducer(masks)
+        state = red.init_state(1, 1, 1, 2)
+        proj = np.zeros((1, 3, 2), dtype=np.float16)
+        attn = np.ones((1, 3), dtype=bool)
+        with pytest.raises(ValueError, match="mask length"):
+            red.update(state, proj, [0], 0, 0, attn)
+
+    def test_mean_aligns_with_right_padding(self):
+        masks = [_mask(3, [0, 2])]
+        red = MeanReducer(masks)
+        state = red.init_state(1, 1, 1, 2)
+        proj = np.array(
+            [[[2.0, 4.0], [99.0, 99.0], [6.0, 8.0], [0.0, 0.0]]],
+            dtype=np.float16,
+        )
+        attn = np.array([[1, 1, 1, 0]], dtype=bool)
+        red.update(state, proj, [0], 0, 0, attn)
+        out = red.finalize(state)
+        np.testing.assert_allclose(out[0, 0, 0], [4.0, 6.0], atol=1e-2)
+
+    def test_mean_aligns_with_left_padding(self):
+        # Left-padded microbatch: real tokens at positions 1..3; mask says
+        # first and third real token count.
+        masks = [_mask(3, [0, 2])]
+        red = MeanReducer(masks)
+        state = red.init_state(1, 1, 1, 2)
+        proj = np.array(
+            [[[0.0, 0.0], [2.0, 4.0], [99.0, 99.0], [6.0, 8.0]]],
+            dtype=np.float16,
+        )
+        attn = np.array([[0, 1, 1, 1]], dtype=bool)
+        red.update(state, proj, [0], 0, 0, attn)
+        out = red.finalize(state)
+        np.testing.assert_allclose(out[0, 0, 0], [4.0, 6.0], atol=1e-2)
+
+
+class TestMeanExclLastNReducer:
+    def test_excludes_last_n_true_positions(self):
+        masks = [_mask(6, [0, 1, 3, 4, 5])]  # 5 True positions
+        red = MeanExclLastNReducer(masks, n=2)
+        state = red.init_state(1, 1, 1, 1)
+        proj = np.array(
+            [[[1], [2], [0], [3], [100], [100]]], dtype=np.float16,
+        )
+        attn = np.ones((1, 6), dtype=bool)
+        red.update(state, proj, [0], 0, 0, attn)
+        out = red.finalize(state)
+        # After excluding last 2 True positions (indices 4, 5): True positions
+        # become [0, 1, 3]. Values: 1, 2, 3. Mean = 2.
+        np.testing.assert_allclose(out[0, 0, 0], [2.0], atol=1e-2)
+
+    def test_falls_back_when_le_n_true_positions(self):
+        masks = [_mask(4, [0, 3])]  # 2 True positions, n=5 -> fallback
+        red = MeanExclLastNReducer(masks, n=5)
+        state = red.init_state(1, 1, 1, 1)
+        proj = np.array([[[2], [0], [0], [4]]], dtype=np.float16)
+        attn = np.ones((1, 4), dtype=bool)
+        red.update(state, proj, [0], 0, 0, attn)
+        out = red.finalize(state)
+        np.testing.assert_allclose(out[0, 0, 0], [3.0], atol=1e-2)
+
+    def test_n_zero_equivalent_to_mean_reducer(self):
+        masks = [_mask(3, [0, 2])]
+        excl = MeanExclLastNReducer(masks, n=0)
+        mean = MeanReducer(masks)
+        s1 = excl.init_state(1, 1, 1, 1)
+        s2 = mean.init_state(1, 1, 1, 1)
+        proj = np.array([[[2], [0], [4]]], dtype=np.float16)
+        attn = np.ones((1, 3), dtype=bool)
+        excl.update(s1, proj, [0], 0, 0, attn)
+        mean.update(s2, proj, [0], 0, 0, attn)
+        np.testing.assert_array_equal(excl.finalize(s1), mean.finalize(s2))
+
+    def test_negative_n_raises(self):
+        with pytest.raises(ValueError):
+            MeanExclLastNReducer([_mask(3, [0])], n=-1)
+
+
+class TestProtocolConformance:
+    def test_builtins_satisfy_reducer_protocol(self):
+        masks = [_mask(3, [0, 2])]
+        assert isinstance(LastTokenReducer(masks), Reducer)
+        assert isinstance(MeanReducer(masks), Reducer)
+        assert isinstance(MeanExclLastNReducer(masks, n=1), Reducer)

--- a/tests/test_sample_scan.py
+++ b/tests/test_sample_scan.py
@@ -382,6 +382,142 @@ class TestProjectPrompt:
 
 
 # ---------------------------------------------------------------------------
+# Grouped batch projection
+# ---------------------------------------------------------------------------
+
+
+class TestBatchProjectGrouped:
+    """Verify fused multi-group projection — spec 001."""
+
+    @pytest.fixture
+    def scan(self, tmp_path):
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+        labels = [1, 1, 1, 0, 0, 0]
+
+        return SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "grouped_scan",
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+
+    def test_single_group_matches_batch_project(self, scan):
+        prompts = ["The dog ran fast", "The cat slept quietly"]
+
+        proj_ref, coords_ref, tokens_ref, lens_ref = scan.batch_project(prompts)
+        out = scan.batch_project_grouped({"only": prompts})
+
+        assert list(out.keys()) == ["only"]
+        proj, coords, tokens, lens = out["only"]
+
+        np.testing.assert_array_equal(proj, proj_ref)
+        assert tokens == tokens_ref
+        assert lens == lens_ref
+        for key in coords_ref:
+            assert list(coords[key]) == list(coords_ref[key])
+
+    def test_multi_group_matches_per_group(self, scan):
+        g_a = ["The dog ran fast"]
+        g_b = ["The cat slept", "A bird flew"]
+
+        proj_a, coords_a, tokens_a, lens_a = scan.batch_project(g_a)
+        proj_b, coords_b, tokens_b, lens_b = scan.batch_project(g_b)
+
+        out = scan.batch_project_grouped({"a": g_a, "b": g_b})
+
+        np.testing.assert_array_equal(out["a"][0], proj_a)
+        np.testing.assert_array_equal(out["b"][0], proj_b)
+        assert out["a"][2] == tokens_a
+        assert out["b"][2] == tokens_b
+        assert out["a"][3] == lens_a
+        assert out["b"][3] == lens_b
+        for key in coords_a:
+            assert list(out["a"][1][key]) == list(coords_a[key])
+        for key in coords_b:
+            assert list(out["b"][1][key]) == list(coords_b[key])
+
+    def test_sample_id_rebased(self, scan):
+        out = scan.batch_project_grouped({
+            "a": ["The dog ran"],
+            "b": ["The cat slept", "A bird flew"],
+        })
+        assert set(out["a"][1]["sample_id"]) == {0}
+        assert set(out["b"][1]["sample_id"]) == {0, 1}
+
+    def test_preserves_key_order(self, scan):
+        keys = ["z", "a", "m", "b"]
+        groups = {k: [f"prompt for {k}"] for k in keys}
+        out = scan.batch_project_grouped(groups)
+        assert list(out.keys()) == keys
+
+    def test_one_backend_call_for_n_groups(self, scan):
+        call_count = {"n": 0}
+        real_scan_forward = scan._get_backend().scan_forward
+
+        def counting_scan_forward(*args, **kwargs):
+            call_count["n"] += 1
+            return real_scan_forward(*args, **kwargs)
+
+        scan._get_backend().scan_forward = counting_scan_forward
+        try:
+            scan.batch_project_grouped({
+                "a": ["The dog ran"],
+                "b": ["The cat slept"],
+                "c": ["A bird flew"],
+            })
+        finally:
+            scan._get_backend().scan_forward = real_scan_forward
+
+        assert call_count["n"] == 1
+
+    def test_batch_project_warns_on_third_call(self, scan):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w1:
+            warnings.simplefilter("always")
+            scan.batch_project(["p1"])
+        assert not any("batch_project_grouped" in str(x.message) for x in w1)
+
+        with warnings.catch_warnings(record=True) as w2:
+            warnings.simplefilter("always")
+            scan.batch_project(["p2"])
+        assert not any("batch_project_grouped" in str(x.message) for x in w2)
+
+        with warnings.catch_warnings(record=True) as w3:
+            warnings.simplefilter("always")
+            scan.batch_project(["p3"])
+        matching = [x for x in w3 if "batch_project_grouped" in str(x.message)]
+        assert len(matching) == 1
+        assert issubclass(matching[0].category, UserWarning)
+
+    def test_batch_project_warning_fires_once(self, scan):
+        import warnings
+
+        for _ in range(3):
+            scan.batch_project(["p"])
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scan.batch_project(["p"])
+            scan.batch_project(["p"])
+        assert not any("batch_project_grouped" in str(x.message) for x in w)
+
+    def test_grouped_does_not_trigger_warning(self, scan):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            for _ in range(5):
+                scan.batch_project_grouped({"k": ["p"]})
+        assert not any("batch_project_grouped" in str(x.message) for x in w)
+
+
+# ---------------------------------------------------------------------------
 # Get projections from stored corpus data
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sample_scan.py
+++ b/tests/test_sample_scan.py
@@ -518,6 +518,105 @@ class TestBatchProjectGrouped:
 
 
 # ---------------------------------------------------------------------------
+# Spec 002: stream-project parity
+# ---------------------------------------------------------------------------
+
+
+class TestStreamProjectParity:
+    """Projecting through an external basis via the stream-project path
+    (delta @ basis on device, per-microbatch) must agree with projecting
+    through the legacy captures → stack → PCA.transform path, up to
+    fp16 / GPU-vs-CPU matmul tolerance."""
+
+    @pytest.fixture
+    def scan(self, tmp_path):
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+        labels = [1, 1, 1, 0, 0, 0]
+
+        return SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "parity_scan",
+            signals=["attn_delta", "mlp_delta"],
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+
+    def test_batch_project_matches_stored_projections(self, scan):
+        """Re-projecting the fit corpus through its own basis reproduces
+        the projections computed during the PCA-fit pass (legacy path).
+
+        The fit path does ``pca.transform(flat)`` on CPU in fp32. The
+        stream-project path does ``(delta.reshape(-1,H).float() @ basis)``
+        on the same device. The basis is identical (``pca.components_.T``),
+        so outputs should match within fp16 tolerance."""
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+
+        proj_stream, coords_stream, _, seq_lens = scan.batch_project(prompts)
+
+        # Assemble per-sample dense tensor from stream output:
+        # [seq_len, n_layers, n_signals, k]
+        n_layers = scan.n_layers
+        n_signals = len(scan.signals)
+        k = scan.n_components
+
+        sample_ids = np.asarray(coords_stream["sample_id"])
+        layers = np.asarray(coords_stream["layer"])
+        tokens = np.asarray(coords_stream["token_pos"])
+        sigs = np.asarray(coords_stream["signal"])
+
+        for i in range(len(prompts)):
+            ref = scan.get_projections(i)  # from stored legacy-fit projections
+            seq_len = ref.shape[0]
+
+            mask = sample_ids == i
+            stream_dense = np.zeros(
+                (seq_len, n_layers, n_signals, k), dtype=np.float32,
+            )
+            rows = np.where(mask)[0]
+            for r in rows:
+                t = int(tokens[r])
+                if t >= seq_len:
+                    continue  # padding token beyond real seq_len
+                L = int(layers[r])
+                s = int(sigs[r])
+                stream_dense[t, L, s, :] = proj_stream[r, 0, :].astype(
+                    np.float32,
+                )
+
+            np.testing.assert_allclose(
+                stream_dense, ref, atol=1e-2, rtol=1e-2,
+                err_msg=f"sample {i}: stream-project diverges from PCA-fit",
+            )
+
+    def test_stream_project_dominates_when_external_bases_given(self, scan):
+        """Instrument the backend: under stream-project, the
+        ``per_layer_captures`` / ``per_signal_captures`` bucket should
+        never accumulate cross-batch CPU tensors for signals that have a
+        basis. We verify indirectly: ``batch_project`` returns identical
+        shapes and non-zero projections."""
+        prompts = ["Hello world", "Another test prompt"]
+        proj, coords, _, seq_lens = scan.batch_project(prompts)
+
+        # Output shape: N_samples * max_seq_len (padded) * n_layers * n_signals
+        # rows of [k]-vectors. Rows for padded positions are projected but
+        # will get filtered by callers using seq_lens.
+        n_signals = len(scan.signals)
+        n_layers = scan.n_layers
+        max_seq = max(seq_lens)
+        expected_rows = len(prompts) * max_seq * n_layers * n_signals
+        assert proj.shape[0] == expected_rows
+        assert proj.shape[2] == scan.n_components
+        # At least some projections are non-zero (sanity: stream-project
+        # actually produced output rather than leaving zeros).
+        assert np.abs(proj).sum() > 0
+
+
+# ---------------------------------------------------------------------------
 # Get projections from stored corpus data
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sample_scan.py
+++ b/tests/test_sample_scan.py
@@ -745,8 +745,10 @@ class TestBatchProjectReduced:
             reducers=bound,
         )
         assert projections.shape[0] == 0
-        assert coords["sample_id"] == []
-        assert coords["token_pos"] == []
+        # Coords are now numpy arrays (teammate's pre-allocation refactor);
+        # verify emptiness via size, not list-equality.
+        assert coords["sample_id"].size == 0
+        assert coords["token_pos"].size == 0
 
     def test_reducers_without_external_bases_raises(self, scan):
         from lmprobe.reducers import LastTokenReducer

--- a/tests/test_sample_scan.py
+++ b/tests/test_sample_scan.py
@@ -518,6 +518,300 @@ class TestBatchProjectGrouped:
 
 
 # ---------------------------------------------------------------------------
+# Spec 003: per-sample reduced projection
+# ---------------------------------------------------------------------------
+
+
+class TestBatchProjectReduced:
+    """Fused projection with in-chunk per-sample reduction — spec 003."""
+
+    @pytest.fixture
+    def scan(self, tmp_path):
+        from lmprobe.sample_scan import SampleScan
+
+        prompts = POSITIVE_PROMPTS[:3] + NEGATIVE_PROMPTS[:3]
+        labels = [1, 1, 1, 0, 0, 0]
+
+        return SampleScan.run(
+            prompts=prompts,
+            labels=labels,
+            model_name=TEST_MODEL,
+            scan_dir=tmp_path / "reduced_scan",
+            signals=["attn_delta", "mlp_delta"],
+            n_components=4,
+            device="cpu",
+            batch_size=2,
+        )
+
+    def _tokenize_seq_lens(self, scan, prompts):
+        """Mirror the scan's tokenizer to build mask templates."""
+        from lmprobe._tokenizer_utils import load_tokenizer
+
+        tok = load_tokenizer(scan._metadata.model_id)
+        if tok.pad_token is None:
+            tok.pad_token = tok.eos_token
+        enc = tok(prompts, return_tensors="pt", padding=True)
+        mask = enc["attention_mask"].numpy().astype(bool)
+        return [int(m.sum()) for m in mask]
+
+    def test_last_token_parity_with_batch_project(self, scan):
+        """Per-sample last-token projection via reducer matches selecting
+        the last real token from a batch_project per-token output."""
+        from lmprobe.reducers import LastTokenReducer
+
+        prompts = ["The dog ran fast", "The cat slept", "Birds fly"]
+        seq_lens = self._tokenize_seq_lens(scan, prompts)
+        masks = [np.ones(L, dtype=bool) for L in seq_lens]
+
+        reducers = {"last_token": LastTokenReducer(masks)}
+        out = scan.batch_project_reduced(
+            {"g": prompts}, reducers=reducers, batch_size=2,
+        )
+        reduced = out["g"]["last_token"]
+
+        n_layers = scan._metadata.n_layers
+        n_signals = len(scan.signals)
+        k = scan._metadata.n_components
+        assert reduced.shape == (len(prompts), n_layers, n_signals, k)
+
+        # Reference: run batch_project per sample (so padding doesn't pollute
+        # the "last real token" index), and pull the final-real-token slice.
+        sig_to_idx = {s: i for i, s in enumerate(scan.signals)}
+        for i, p in enumerate(prompts):
+            proj, coords, _, lens = scan.batch_project([p])
+            sample_id = np.asarray(coords["sample_id"])
+            layer = np.asarray(coords["layer"])
+            tok_pos = np.asarray(coords["token_pos"])
+            sig = np.asarray(coords["signal"])
+            last_pos = lens[0] - 1
+            for sig_name in scan.signals:
+                for L in range(n_layers):
+                    mask = (
+                        (sample_id == 0)
+                        & (layer == L)
+                        & (tok_pos == last_pos)
+                        & (sig == sig_to_idx[sig_name])
+                    )
+                    if not mask.any():
+                        continue
+                    expected = proj[mask][0, 0, :]
+                    got = reduced[i, L, sig_to_idx[sig_name], :]
+                    np.testing.assert_allclose(
+                        got.astype(np.float32),
+                        expected.astype(np.float32),
+                        atol=5e-2,
+                    )
+
+    def test_mean_parity_with_batch_project(self, scan):
+        """MeanReducer with all-True masks matches the mean over real
+        tokens of a batch_project per-token output."""
+        from lmprobe.reducers import MeanReducer
+
+        prompts = ["A quick brown fox", "Another short one"]
+        seq_lens = self._tokenize_seq_lens(scan, prompts)
+        masks = [np.ones(L, dtype=bool) for L in seq_lens]
+
+        out = scan.batch_project_reduced(
+            {"g": prompts},
+            reducers={"mean_all": MeanReducer(masks)},
+            batch_size=2,
+        )
+        reduced = out["g"]["mean_all"]
+
+        sig_to_idx = {s: i for i, s in enumerate(scan.signals)}
+        n_layers = scan._metadata.n_layers
+        for i, p in enumerate(prompts):
+            proj, coords, _, lens = scan.batch_project([p])
+            sample_id = np.asarray(coords["sample_id"])
+            layer = np.asarray(coords["layer"])
+            tok_pos = np.asarray(coords["token_pos"])
+            sig = np.asarray(coords["signal"])
+            real_len = lens[0]
+            for sig_name in scan.signals:
+                for L in range(n_layers):
+                    sel = (
+                        (sample_id == 0)
+                        & (layer == L)
+                        & (sig == sig_to_idx[sig_name])
+                        & (tok_pos < real_len)
+                    )
+                    if not sel.any():
+                        continue
+                    expected = proj[sel][:, 0, :].astype(np.float32).mean(0)
+                    got = reduced[i, L, sig_to_idx[sig_name], :].astype(
+                        np.float32,
+                    )
+                    np.testing.assert_allclose(got, expected, atol=5e-2)
+
+    def test_mean_excl_last_n_parity(self, scan):
+        """MeanExclLastN(n=1) drops the final True position; matches a
+        mean over the first real_len-1 tokens of a batch_project output."""
+        from lmprobe.reducers import MeanExclLastNReducer
+
+        prompts = ["A quick brown fox", "Another short one"]
+        seq_lens = self._tokenize_seq_lens(scan, prompts)
+        masks = [np.ones(L, dtype=bool) for L in seq_lens]
+
+        out = scan.batch_project_reduced(
+            {"g": prompts},
+            reducers={"mean_excl1": MeanExclLastNReducer(masks, n=1)},
+            batch_size=2,
+        )
+        reduced = out["g"]["mean_excl1"]
+
+        sig_to_idx = {s: i for i, s in enumerate(scan.signals)}
+        n_layers = scan._metadata.n_layers
+        for i, p in enumerate(prompts):
+            proj, coords, _, lens = scan.batch_project([p])
+            sample_id = np.asarray(coords["sample_id"])
+            layer = np.asarray(coords["layer"])
+            tok_pos = np.asarray(coords["token_pos"])
+            sig = np.asarray(coords["signal"])
+            real_len = lens[0]
+            for sig_name in scan.signals:
+                for L in range(n_layers):
+                    sel = (
+                        (sample_id == 0)
+                        & (layer == L)
+                        & (sig == sig_to_idx[sig_name])
+                        & (tok_pos < real_len - 1)
+                    )
+                    if not sel.any():
+                        continue
+                    expected = proj[sel][:, 0, :].astype(np.float32).mean(0)
+                    got = reduced[i, L, sig_to_idx[sig_name], :].astype(
+                        np.float32,
+                    )
+                    np.testing.assert_allclose(got, expected, atol=5e-2)
+
+    def test_one_scan_forward_call_regardless_of_group_count(self, scan):
+        from lmprobe.reducers import LastTokenReducer
+
+        prompts_a = ["A quick brown fox"]
+        prompts_b = ["Another short one", "Even shorter"]
+        prompts_c = ["Third group prompt"]
+        seq_lens = self._tokenize_seq_lens(
+            scan, prompts_a + prompts_b + prompts_c,
+        )
+        masks = [np.ones(L, dtype=bool) for L in seq_lens]
+
+        call_count = {"n": 0}
+        real = scan._get_backend().scan_forward
+
+        def counting(*args, **kwargs):
+            call_count["n"] += 1
+            return real(*args, **kwargs)
+
+        scan._get_backend().scan_forward = counting
+        try:
+            scan.batch_project_reduced(
+                {"a": prompts_a, "b": prompts_b, "c": prompts_c},
+                reducers={"lt": LastTokenReducer(masks)},
+                batch_size=2,
+            )
+        finally:
+            scan._get_backend().scan_forward = real
+
+        assert call_count["n"] == 1
+
+    def test_returns_empty_coords_and_projections(self, scan):
+        """The reducers path must not populate per-token accumulators —
+        scan_forward returns an empty [0, 1, k] array and empty coords."""
+        from lmprobe.reducers import LastTokenReducer
+
+        prompts = ["A quick brown fox"]
+        seq_lens = self._tokenize_seq_lens(scan, prompts)
+        masks = [np.ones(L, dtype=bool) for L in seq_lens]
+        backend = scan._get_backend()
+
+        reducers = {"lt": LastTokenReducer(masks)}
+        n_layers = scan._metadata.n_layers
+        n_sig = len(scan.signals)
+        k = scan._metadata.n_components
+        bound = {
+            n: (r, r.init_state(1, n_layers, n_sig, k))
+            for n, r in reducers.items()
+        }
+        bases_subset = {s: scan._bases[s] for s in scan.signals}
+
+        (
+            _meta, _bases, projections, coords, _tok, _lens, _am, _sd,
+        ) = backend.scan_forward(
+            prompts,
+            signals=list(scan.signals),
+            n_components=scan._metadata.n_components,
+            batch_size=2,
+            external_bases=bases_subset,
+            reducers=bound,
+        )
+        assert projections.shape[0] == 0
+        assert coords["sample_id"] == []
+        assert coords["token_pos"] == []
+
+    def test_reducers_without_external_bases_raises(self, scan):
+        from lmprobe.reducers import LastTokenReducer
+
+        backend = scan._get_backend()
+        reducers = {"lt": LastTokenReducer([np.ones(3, dtype=bool)])}
+        bound = {n: (r, r.init_state(1, 1, 1, 1)) for n, r in reducers.items()}
+        with pytest.raises(ValueError, match="reducers=.* requires external_bases"):
+            backend.scan_forward(
+                ["x"],
+                signals=["attn_delta"],
+                n_components=4,
+                batch_size=1,
+                external_bases=None,
+                reducers=bound,
+            )
+
+    def test_key_order_preserved(self, scan):
+        from lmprobe.reducers import LastTokenReducer
+
+        prompts_flat = ["alpha one", "beta one", "beta two", "gamma one"]
+        seq_lens = self._tokenize_seq_lens(scan, prompts_flat)
+        masks = [np.ones(L, dtype=bool) for L in seq_lens]
+
+        out = scan.batch_project_reduced(
+            {"alpha": ["alpha one"], "beta": ["beta one", "beta two"], "gamma": ["gamma one"]},
+            reducers={"lt": LastTokenReducer(masks)},
+            batch_size=2,
+        )
+        assert list(out.keys()) == ["alpha", "beta", "gamma"]
+        assert out["alpha"]["lt"].shape[0] == 1
+        assert out["beta"]["lt"].shape[0] == 2
+        assert out["gamma"]["lt"].shape[0] == 1
+
+    def test_multiple_reducers_in_single_sweep(self, scan):
+        """All reducers fed from the same microbatch projections."""
+        from lmprobe.reducers import (
+            LastTokenReducer,
+            MeanExclLastNReducer,
+            MeanReducer,
+        )
+
+        prompts = ["A quick brown fox", "Another short one"]
+        seq_lens = self._tokenize_seq_lens(scan, prompts)
+        masks = [np.ones(L, dtype=bool) for L in seq_lens]
+
+        out = scan.batch_project_reduced(
+            {"g": prompts},
+            reducers={
+                "last": LastTokenReducer(masks),
+                "mean": MeanReducer(masks),
+                "excl1": MeanExclLastNReducer(masks, n=1),
+            },
+            batch_size=2,
+        )
+        for name in ("last", "mean", "excl1"):
+            assert out["g"][name].shape == (
+                2,
+                scan._metadata.n_layers,
+                len(scan.signals),
+                scan._metadata.n_components,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Spec 002: stream-project parity
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Collection of in-flight refactors on the way to fused multi-group projection and memory-scalable `scan_forward`.

- **[spec 001](specs/001-grouped-projection.md) — `batch_project_grouped`:** One layer sweep for the whole union of prompts, sliced back per group. Each per-group tuple is indistinguishable from a standalone `batch_project` on that group alone. Emits a `UserWarning` on the 3rd+ call to `batch_project` pointing at the grouped alternative.
- **[spec 002](specs/002-stream-project-external-bases.md) — stream-project deltas through external bases:** Basis stays on device; per-microbatch deltas are projected on GPU rather than accumulating `[N, S, H]` captures on CPU.
- **[spec 003](specs/003-per-sample-reduced-projection.md) — `batch_project_reduced`:** In-chunk per-sample reducers (`last_token`, `mean_asst`, `mean_excl5`) own the output; per-token projections never cross a chunk boundary.
- **[spec 004](specs/004-memmap-batch-hidden-states.md) — memmap-backed `batch_hidden_states`:** Chunk-boundary residuals are backed by an `np.memmap` (`[N, S_max, H]`, uint16 container for bf16) instead of `list[torch.Tensor]`. Linux's page cache handles residency — only the current chunk's active pages stay warm. Fixes #272.
- **cross-chunk output refactor:** `_fit_project_scan_pca` helper with optional cuml/cupy GPU path (zero-copy torch↔cupy via dlpack), sklearn CPU fallback. Pre-allocated `all_projections` / coord arrays in both chunked and disk-offload backends replace the append-to-list pattern (~1.3 GB/chunk saved on a 40-layer × 1000-sample × 611-token scan).
- **Minor:** tqdm label says "projecting" instead of "PCA fit" when an external basis is supplied.

## Motivation

The naive loop

```python
for key in keys:
    results[key] = scan.batch_project(prompts[key])
```

re-runs the outer layer-chunk loop N times. On 70B-class models this turns a 40-min run into multi-hour silently. `batch_project_grouped` fuses to one sweep:

```python
results = scan.batch_project_grouped({key: prompts[key] for key in keys})
```

For `scan_forward` itself, on a 9260-sample × 574-token × 5120-hidden run the list-of-tensors residual buffer alone weighs 54 GB. Combined with a 24B bf16 model (~48 GB) that blew a 128 GB box on chunk-2 forward (observed on RTX 5090 / Mistral-Small-3.1-24B). The memmap + per-sample reducer changes together make the chunked backend scale to arbitrary sample counts independent of CPU RAM.

## Test plan

- [x] Single-group grouped output identical to `batch_project`
- [x] Multi-group per-key output matches standalone per-group calls (values + coords + tokens + seq_lens)
- [x] Per-group `coord["sample_id"]` rebased to 0..N-1
- [x] Key insertion order preserved
- [x] N groups ⇒ 1 call to `backend.scan_forward`
- [x] 3rd `batch_project` call emits `UserWarning` containing "batch_project_grouped"; first two silent
- [x] Warning fires at most once per instance
- [x] `batch_project_grouped` does not trigger the warning even when called repeatedly
- [x] spec 003 reducer parity tests (`last_token`, `mean_asst`, `mean_excl5`) vs. per-prompt `batch_project`
- [x] spec 004: chunked (`chunk_size=1`) vs. single-chunk (`chunk_size=num_layers`) produce bit-identical projections + bases at fp32
- [x] spec 004: bf16 round-trip through the uint16 memmap container is finite and correctly shaped
- [x] spec 004: `TemporaryDirectory` is cleaned up when `scan_forward` returns
- [x] test_chunked_backend.py + test_sample_scan.py + test_reducers.py + test_readme_example.py all pass locally
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)