### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lmprobe"
-version = "0.9.4"
+version = "0.10.0"
 description = "Train probes on language model activations for AI safety monitoring"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.9.4 to 0.10.0 to release the disk-offload sweep loader work (#276) plus the preceding sweep consolidation (#274) and pre-flight memory estimate (#275).

## Test plan
- [ ] CI passes
- [ ] Release workflow picks up 0.10.0 via `release-no-bump` label (no further version mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)