### PR TITLE
Auto-load chat_template.json fallback in load_tokenizer (#278)

### DIFF
--- a/src/lmprobe/_tokenizer_utils.py
+++ b/src/lmprobe/_tokenizer_utils.py
@@ -6,10 +6,14 @@ workarounds (e.g. the Mistral regex bug) apply everywhere by default.
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizerBase
+
+_logger = logging.getLogger(__name__)
 
 # Mistral checkpoints with a tokenizer regex bug in transformers. For
 # these, ``AutoTokenizer.from_pretrained`` needs ``fix_mistral_regex=True``
@@ -21,15 +25,60 @@ MISTRAL_MODELS_WITH_REGEX_BUG = [
 ]
 
 
-def load_tokenizer(model_name: str, **kwargs: Any) -> PreTrainedTokenizerBase:
+def load_tokenizer(
+    model_name: str,
+    load_chat_template: bool = True,
+    **kwargs: Any,
+) -> PreTrainedTokenizerBase:
     """Load a tokenizer with per-model workarounds applied.
 
     Wraps ``AutoTokenizer.from_pretrained`` and injects
     ``fix_mistral_regex=True`` for checkpoints listed in
     :data:`MISTRAL_MODELS_WITH_REGEX_BUG`.
+
+    When ``load_chat_template`` is True (default) and the loaded tokenizer
+    has no ``chat_template`` attribute, attempt to fetch ``chat_template.json``
+    from the repo and attach it. This is the canonical path for multimodal
+    checkpoints (e.g. Pixtral / Mistral-Small-3.1) where ``AutoProcessor``
+    would load it but ``AutoTokenizer`` alone does not.
     """
     from transformers import AutoTokenizer
 
     if any(m in model_name for m in MISTRAL_MODELS_WITH_REGEX_BUG):
         kwargs.setdefault("fix_mistral_regex", True)
-    return AutoTokenizer.from_pretrained(model_name, **kwargs)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
+
+    if load_chat_template and getattr(tokenizer, "chat_template", None) is None:
+        _maybe_attach_chat_template(tokenizer, model_name)
+
+    return tokenizer
+
+
+def _maybe_attach_chat_template(tokenizer: PreTrainedTokenizerBase, model_name: str) -> None:
+    """Attach ``chat_template.json`` from the repo if present.
+
+    Silently no-ops if the repo doesn't ship a ``chat_template.json`` or if
+    the file is unreadable. Logs an INFO line on success so template
+    forensics stay traceable.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError
+
+    try:
+        path = hf_hub_download(model_name, "chat_template.json")
+    except EntryNotFoundError:
+        return
+    except Exception as e:  # network/auth/etc — don't fail the load
+        _logger.debug("chat_template.json fetch failed for %s: %s", model_name, e)
+        return
+
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        template = data["chat_template"]
+    except (OSError, KeyError, json.JSONDecodeError) as e:
+        _logger.debug("chat_template.json parse failed for %s: %s", model_name, e)
+        return
+
+    tokenizer.chat_template = template
+    _logger.info("Loaded chat_template from chat_template.json for %s", model_name)

--- a/tests/test_tokenizer_utils.py
+++ b/tests/test_tokenizer_utils.py
@@ -1,0 +1,71 @@
+"""Tests for ``lmprobe._tokenizer_utils``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from huggingface_hub.errors import EntryNotFoundError
+
+from lmprobe._tokenizer_utils import _maybe_attach_chat_template, load_tokenizer
+
+TEMPLATE = "{% for m in messages %}<{{ m.role }}>{{ m.content }}</{{ m.role }}>{% endfor %}"
+
+
+@pytest.fixture
+def chat_template_file(tmp_path: Path) -> Path:
+    p = tmp_path / "chat_template.json"
+    p.write_text(json.dumps({"chat_template": TEMPLATE}))
+    return p
+
+
+def test_load_tokenizer_no_chat_template_file(tiny_model):
+    """Tiny llama ships no chat_template.json — fallback is a silent no-op."""
+    tok = load_tokenizer(tiny_model)
+    assert tok.chat_template is None
+
+
+def test_attach_chat_template_sets_attribute(tiny_model, chat_template_file):
+    tok = load_tokenizer(tiny_model, load_chat_template=False)
+    assert tok.chat_template is None
+
+    with patch("huggingface_hub.hf_hub_download", return_value=str(chat_template_file)):
+        _maybe_attach_chat_template(tok, tiny_model)
+
+    assert tok.chat_template == TEMPLATE
+    rendered = tok.apply_chat_template([{"role": "user", "content": "hi"}], tokenize=False)
+    assert "<user>hi</user>" in rendered
+
+
+def test_attach_chat_template_silent_on_missing_file(tiny_model):
+    tok = load_tokenizer(tiny_model, load_chat_template=False)
+
+    def _raise(*_a, **_kw):
+        raise EntryNotFoundError("no such file")
+
+    with patch("huggingface_hub.hf_hub_download", side_effect=_raise):
+        _maybe_attach_chat_template(tok, tiny_model)
+
+    assert tok.chat_template is None
+
+
+def test_load_tokenizer_opt_out(tiny_model, chat_template_file):
+    """``load_chat_template=False`` skips the fallback even when a file exists."""
+    with patch("huggingface_hub.hf_hub_download", return_value=str(chat_template_file)) as mock_dl:
+        tok = load_tokenizer(tiny_model, load_chat_template=False)
+
+    assert tok.chat_template is None
+    mock_dl.assert_not_called()
+
+
+def test_attach_chat_template_silent_on_malformed_json(tiny_model, tmp_path):
+    tok = load_tokenizer(tiny_model, load_chat_template=False)
+    bad = tmp_path / "chat_template.json"
+    bad.write_text("not-json{")
+
+    with patch("huggingface_hub.hf_hub_download", return_value=str(bad)):
+        _maybe_attach_chat_template(tok, tiny_model)
+
+    assert tok.chat_template is None


### PR DESCRIPTION
## Summary
- Extend `load_tokenizer` in `src/lmprobe/_tokenizer_utils.py` to fetch `chat_template.json` via `hf_hub_download` when `tokenizer.chat_template is None`
- Opt-out via `load_chat_template=False`; INFO log on success for template provenance
- Silent no-op when the repo doesn't ship `chat_template.json` (`EntryNotFoundError`) or the file is malformed

Fixes #278.

## Why
Multimodal checkpoints like Pixtral / `mistralai/Mistral-Small-3.1-24B-Instruct-2503` ship a `chat_template.json` that only `AutoProcessor` picks up — not `AutoTokenizer`. Text-only activation-extraction users (the dominant `lmprobe` case) then hit `ValueError: Cannot use chat template functions because tokenizer.chat_template is not set` from `apply_chat_template`.

Verified upstream that the repo does ship `chat_template.json` with shape `{"chat_template": "<jinja>"}`, and confirmed the fallback resolves the `ValueError` end-to-end on `mistralai/Mistral-Small-3.1-24B-Instruct-2503` (template renders correctly).

## Test plan
- [x] `tests/test_tokenizer_utils.py` — 5 tests, all passing locally
  - Silent no-op when repo has no `chat_template.json`
  - Attaches template and `apply_chat_template` renders correctly
  - Silent on `EntryNotFoundError`
  - `load_chat_template=False` skips the download
  - Silent on malformed JSON
- [x] Manual repro: issue #278 snippet against `mistralai/Mistral-Small-3.1-24B-Instruct-2503` — `apply_chat_template` now returns a valid prompt
- [ ] CI full suite

## Notes
- `fix_mistral_regex=True` path (pre-existing) currently crashes on `transformers==5.3.0` due to an upstream "got multiple values for keyword argument" bug. Unrelated to this PR — exists on `main`. User's repro was on `transformers==5.0.0` where both paths work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)