### PR TITLE
Work around transformers>=5.3 fix_mistral_regex dup-kwarg crash (#280)

### DIFF
--- a/src/lmprobe/_tokenizer_utils.py
+++ b/src/lmprobe/_tokenizer_utils.py
@@ -46,12 +46,44 @@ def load_tokenizer(
 
     if any(m in model_name for m in MISTRAL_MODELS_WITH_REGEX_BUG):
         kwargs.setdefault("fix_mistral_regex", True)
-    tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
+
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
+    except TypeError as e:
+        # transformers>=5.3 has an upstream bug where `fix_mistral_regex`
+        # is passed to `_patch_mistral_regex` both explicitly and via
+        # `**kwargs`, raising "got multiple values for keyword argument
+        # 'fix_mistral_regex'". Fall back to loading without the flag
+        # and applying the patch post-load. See issue #280.
+        if "fix_mistral_regex" not in str(e):
+            raise
+        apply_fix = kwargs.pop("fix_mistral_regex", None) is True
+        tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
+        if apply_fix:
+            _apply_mistral_regex_fix(tokenizer, model_name)
 
     if load_chat_template and getattr(tokenizer, "chat_template", None) is None:
         _maybe_attach_chat_template(tokenizer, model_name)
 
     return tokenizer
+
+
+def _apply_mistral_regex_fix(tokenizer: PreTrainedTokenizerBase, model_name: str) -> None:
+    """Apply the Mistral pre-tokenizer regex fix to an already-loaded tokenizer.
+
+    Used as a fallback when passing ``fix_mistral_regex=True`` to
+    ``AutoTokenizer.from_pretrained`` raises on transformers>=5.3 (see #280).
+    Invokes the upstream ``TokenizersBackend._patch_mistral_regex`` classmethod
+    directly — private API, but the narrowest workaround available.
+    """
+    from transformers.tokenization_utils_tokenizers import TokenizersBackend
+
+    TokenizersBackend._patch_mistral_regex(
+        tokenizer,
+        pretrained_model_name_or_path=model_name,
+        fix_mistral_regex=True,
+    )
+    _logger.info("Applied Mistral pre-tokenizer regex fix post-load for %s", model_name)
 
 
 def _maybe_attach_chat_template(tokenizer: PreTrainedTokenizerBase, model_name: str) -> None:

--- a/tests/test_tokenizer_utils.py
+++ b/tests/test_tokenizer_utils.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from huggingface_hub.errors import EntryNotFoundError
 
-from lmprobe._tokenizer_utils import _maybe_attach_chat_template, load_tokenizer
+from lmprobe._tokenizer_utils import (
+    MISTRAL_MODELS_WITH_REGEX_BUG,
+    _maybe_attach_chat_template,
+    load_tokenizer,
+)
 
 TEMPLATE = "{% for m in messages %}<{{ m.role }}>{{ m.content }}</{{ m.role }}>{% endfor %}"
 
@@ -69,3 +73,75 @@ def test_attach_chat_template_silent_on_malformed_json(tiny_model, tmp_path):
         _maybe_attach_chat_template(tok, tiny_model)
 
     assert tok.chat_template is None
+
+
+def test_mistral_regex_falls_back_on_dup_kwarg_typeerror():
+    """On transformers>=5.3, passing fix_mistral_regex triggers a TypeError.
+
+    Verify load_tokenizer catches it, retries without the flag, and calls
+    the post-load patch helper. See issue #280.
+    """
+    mistral_name = MISTRAL_MODELS_WITH_REGEX_BUG[0]
+    fake_tok = MagicMock()
+    fake_tok.chat_template = "existing"  # skip chat_template fallback
+
+    call_count = {"n": 0}
+
+    def fake_from_pretrained(_name, **kwargs):
+        call_count["n"] += 1
+        if "fix_mistral_regex" in kwargs:
+            raise TypeError(
+                "_patch_mistral_regex() got multiple values for "
+                "keyword argument 'fix_mistral_regex'"
+            )
+        return fake_tok
+
+    with (
+        patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            side_effect=fake_from_pretrained,
+        ),
+        patch("lmprobe._tokenizer_utils._apply_mistral_regex_fix") as mock_apply,
+    ):
+        tok = load_tokenizer(mistral_name)
+
+    assert tok is fake_tok
+    assert call_count["n"] == 2  # first raised, second succeeded
+    mock_apply.assert_called_once_with(fake_tok, mistral_name)
+
+
+def test_unrelated_typeerror_is_re_raised():
+    """TypeErrors that aren't the fix_mistral_regex dup-kwarg bug must propagate."""
+
+    def fake_from_pretrained(*_a, **_kw):
+        raise TypeError("something else entirely")
+
+    with patch(
+        "transformers.AutoTokenizer.from_pretrained",
+        side_effect=fake_from_pretrained,
+    ):
+        with pytest.raises(TypeError, match="something else entirely"):
+            load_tokenizer(MISTRAL_MODELS_WITH_REGEX_BUG[0])
+
+
+def test_mistral_regex_not_applied_when_user_opts_out():
+    """If user passes fix_mistral_regex=False, the post-load patch is skipped."""
+    mistral_name = MISTRAL_MODELS_WITH_REGEX_BUG[0]
+    fake_tok = MagicMock()
+    fake_tok.chat_template = "existing"
+
+    def fake_from_pretrained(_name, **kwargs):
+        if "fix_mistral_regex" in kwargs:
+            raise TypeError("got multiple values for keyword argument 'fix_mistral_regex'")
+        return fake_tok
+
+    with (
+        patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            side_effect=fake_from_pretrained,
+        ),
+        patch("lmprobe._tokenizer_utils._apply_mistral_regex_fix") as mock_apply,
+    ):
+        load_tokenizer(mistral_name, fix_mistral_regex=False)
+
+    mock_apply.assert_not_called()


### PR DESCRIPTION
## Summary
- Catch the `TypeError: got multiple values for keyword argument 'fix_mistral_regex'` from `AutoTokenizer.from_pretrained` on transformers>=5.3
- Retry the load without the flag, then apply the regex patch manually via `TokenizersBackend._patch_mistral_regex`
- Re-raise any unrelated `TypeError` (narrow match on error message)

Fixes #280.

## Why
Upstream bug in `transformers` 5.3 (`tokenization_utils_tokenizers.py` around L149-155) passes `fix_mistral_regex` both explicitly and via `**kwargs` into `_patch_mistral_regex`, causing a hard crash whenever any caller passes the flag. `load_tokenizer` injects this flag automatically for checkpoints in `MISTRAL_MODELS_WITH_REGEX_BUG`, so every `load_tokenizer(\"mistralai/Mistral-Small-3.1-24B-Instruct-2503\")` call was broken on fresh installs.

Verified end-to-end:
- `load_tokenizer(MODEL)` no longer crashes on transformers 5.3
- `tokenizer.fix_mistral_regex` is `True` after load (patch applied)
- `backend_tokenizer.pre_tokenizer[0]` shows the fixed Unicode-aware Split regex
- `apply_chat_template` works (combined with the #278 chat_template fallback)

## Test plan
- [x] `tests/test_tokenizer_utils.py` — 8 tests, all passing locally
  - Fallback triggers on the dup-kwarg TypeError
  - Unrelated TypeErrors propagate unchanged
  - `fix_mistral_regex=False` opt-out skips the post-load patch
- [x] Manual verification against `mistralai/Mistral-Small-3.1-24B-Instruct-2503` on `transformers==5.3.0`
- [ ] CI full suite

## Notes
- Relies on the private `TokenizersBackend._patch_mistral_regex` classmethod. Not ideal, but it's the narrowest available workaround until upstream fixes the duplicate-kwarg spread. If the classmethod is removed/renamed in a future transformers release, the fallback will raise — that surfaces the regression immediately rather than silently dropping the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)