### PR TITLE
Support multimodal Mistral3 checkpoints in DiskOffloadBackend

### DIFF
--- a/src/lmprobe/_tokenizer_utils.py
+++ b/src/lmprobe/_tokenizer_utils.py
@@ -58,7 +58,10 @@ def load_tokenizer(
         if "fix_mistral_regex" not in str(e):
             raise
         apply_fix = kwargs.pop("fix_mistral_regex", None) is True
-        tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
+        # Suppress the "incorrect regex pattern" warning the fallback load
+        # emits — when we post-patch below, it's misleading noise.
+        with _suppress_mistral_regex_warning():
+            tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
         if apply_fix:
             _apply_mistral_regex_fix(tokenizer, model_name)
 
@@ -66,6 +69,45 @@ def load_tokenizer(
         _maybe_attach_chat_template(tokenizer, model_name)
 
     return tokenizer
+
+
+class _MistralRegexWarningFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        return "incorrect regex pattern" not in record.getMessage()
+
+
+def _suppress_mistral_regex_warning() -> Any:
+    """Context manager that drops the transformers mistral-regex warning.
+
+    The warning fires inside :func:`AutoTokenizer.from_pretrained` whenever
+    ``fix_mistral_regex`` isn't passed. We take that code path in the
+    dup-kwarg fallback and then apply the patch ourselves, so the warning
+    is misleading noise for downstream users.
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _cm() -> Any:
+        # The warning is emitted from
+        # ``transformers.tokenization_utils_tokenizers``. Logger-level filters
+        # don't apply to records propagated from children, so attach directly
+        # to that logger. Also attach to the parent handler as a safety net
+        # in case transformers restructures the logger hierarchy.
+        emitter = logging.getLogger("transformers.tokenization_utils_tokenizers")
+        parent = logging.getLogger("transformers")
+        flt = _MistralRegexWarningFilter()
+        emitter.addFilter(flt)
+        parent_handlers = list(parent.handlers)
+        for h in parent_handlers:
+            h.addFilter(flt)
+        try:
+            yield
+        finally:
+            emitter.removeFilter(flt)
+            for h in parent_handlers:
+                h.removeFilter(flt)
+
+    return _cm()
 
 
 def _apply_mistral_regex_fix(tokenizer: PreTrainedTokenizerBase, model_name: str) -> None:

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -2643,11 +2643,15 @@ class DiskOffloadBackend(ExtractionBackend):
             for part in rotary_name.split("."):
                 rotary_mod = getattr(rotary_mod, part)
 
-            # Re-initialize rotary from config (meta tensors have no data)
+            # Re-initialize rotary from config (meta tensors have no data).
+            # Prefer explicit ``head_dim`` (e.g. Mistral-Small-3.1 sets 128 even
+            # though hidden_size/num_heads = 160) before falling back to the
+            # ratio default.
             dim = getattr(text_config, "qk_rope_head_dim", None)
             if dim is None:
-                head_dim = text_config.hidden_size // text_config.num_attention_heads
-                dim = head_dim
+                dim = getattr(text_config, "head_dim", None)
+            if dim is None:
+                dim = text_config.hidden_size // text_config.num_attention_heads
             base = getattr(text_config, "rope_theta", 10000.0)
             inv_freq = 1.0 / (
                 base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
@@ -2947,8 +2951,9 @@ class DiskOffloadBackend(ExtractionBackend):
             text_cfg = getattr(config, "text_config", config)
             dim = getattr(text_cfg, "qk_rope_head_dim", None)
             if dim is None:
-                head_dim = text_cfg.hidden_size // text_cfg.num_attention_heads
-                dim = head_dim
+                dim = getattr(text_cfg, "head_dim", None)
+            if dim is None:
+                dim = text_cfg.hidden_size // text_cfg.num_attention_heads
             base = getattr(text_cfg, "rope_theta", 10000.0)
             inv_freq = 1.0 / (
                 base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)

--- a/src/lmprobe/backends.py
+++ b/src/lmprobe/backends.py
@@ -2390,6 +2390,29 @@ class DiskOffloadBackend(ExtractionBackend):
             self._config = AutoConfig.from_pretrained(self.model_name)
         return self._config
 
+    def _get_text_config(self) -> Any:
+        """Return the text-transformer config.
+
+        For multimodal checkpoints (e.g. Mistral3, Pixtral) this is
+        ``config.text_config``. For text-only models it's the config itself.
+        """
+        cfg = self._get_config()
+        return getattr(cfg, "text_config", None) or cfg
+
+    @property
+    def _skeleton_prefix(self) -> str:
+        """Prefix that safetensors use ahead of the text skeleton's module paths.
+
+        Mistral3 / Pixtral checkpoints store text weights under
+        ``language_model.*`` while the text-only skeleton we build uses plain
+        ``model.*`` / ``lm_head.*`` paths. We strip this prefix at shard-map
+        time and reapply it when reading from the underlying safetensors.
+        """
+        cfg = self._get_config()
+        if getattr(cfg, "text_config", None) is not None:
+            return "language_model."
+        return ""
+
     def _get_snapshot_dir(self) -> Any:
         if self._snapshot_dir is None:
             from pathlib import Path
@@ -2411,20 +2434,36 @@ class DiskOffloadBackend(ExtractionBackend):
             with open(index_path) as f:
                 index = json.load(f)
 
+            prefix = self._skeleton_prefix
+            # For multimodal checkpoints, drop tensors that belong to the
+            # vision tower / multi-modal projector — the text-only skeleton
+            # has no modules for them.
+            drop_prefixes = (
+                ("vision_tower.", "multi_modal_projector.") if prefix else ()
+            )
+
             layers: dict[int, list[tuple[str, str]]] = defaultdict(list)
             non_layer: list[tuple[str, str]] = []
 
             for tensor_name, shard_file in index["weight_map"].items():
-                parts = tensor_name.split(".")
+                if drop_prefixes and tensor_name.startswith(drop_prefixes):
+                    continue
+                if prefix:
+                    if not tensor_name.startswith(prefix):
+                        continue
+                    stripped = tensor_name[len(prefix):]
+                else:
+                    stripped = tensor_name
+                parts = stripped.split(".")
                 if (
                     len(parts) >= 3
                     and parts[0] == "model"
                     and parts[1] == "layers"
                     and parts[2].isdigit()
                 ):
-                    layers[int(parts[2])].append((tensor_name, shard_file))
+                    layers[int(parts[2])].append((stripped, shard_file))
                 else:
-                    non_layer.append((tensor_name, shard_file))
+                    non_layer.append((stripped, shard_file))
 
             self._layer_to_tensors = dict(layers)
             self._non_layer_tensors = non_layer
@@ -2434,11 +2473,19 @@ class DiskOffloadBackend(ExtractionBackend):
     def _load_tensors(
         self, tensor_list: list[tuple[str, str]], device: str,
     ) -> dict[str, torch.Tensor]:
-        """Load tensors from safetensors shards to *device*."""
+        """Load tensors from safetensors shards to *device*.
+
+        ``tensor_list`` uses skeleton-relative names (``model.layers.N.*``).
+        For multimodal checkpoints the stored safetensors keys are prefixed
+        with :attr:`_skeleton_prefix` (e.g. ``language_model.``); we reattach
+        it here when looking up the shard, and key the result dict by the
+        skeleton-relative name so ``_materialize_module`` finds it.
+        """
         from collections import defaultdict
 
         from safetensors.torch import load_file as st_load_file
 
+        prefix = self._skeleton_prefix
         shard_to_keys: dict[str, list[str]] = defaultdict(list)
         for tensor_name, shard_file in tensor_list:
             shard_to_keys[shard_file].append(tensor_name)
@@ -2448,22 +2495,32 @@ class DiskOffloadBackend(ExtractionBackend):
         for shard_file, keys in shard_to_keys.items():
             shard_data = st_load_file(str(snap / shard_file), device=device)
             for k in keys:
-                if k in shard_data:
+                original = prefix + k
+                if original in shard_data:
+                    result[k] = shard_data[original]
+                elif k in shard_data:
                     result[k] = shard_data[k]
             del shard_data
         return result
 
     def _get_model_skeleton(self) -> Any:
-        """Create an empty model (meta device) for the forward graph."""
+        """Create an empty model (meta device) for the forward graph.
+
+        For multimodal checkpoints (e.g. Mistral3) the outer config class
+        isn't registered for ``AutoModelForCausalLM``; we build the
+        text-only skeleton from ``config.text_config`` and let
+        :meth:`_load_tensors` strip the ``language_model.`` prefix when
+        reading safetensors.
+        """
         if self._model_skeleton is None:
             from accelerate import init_empty_weights
             from transformers import AutoModelForCausalLM
 
-            config = self._get_config()
+            skeleton_config = self._get_text_config()
             # Disable quantizer so we get standard nn.Linear modules
-            config.quantization_config = None
+            skeleton_config.quantization_config = None
             with init_empty_weights():
-                self._model_skeleton = AutoModelForCausalLM.from_config(config)
+                self._model_skeleton = AutoModelForCausalLM.from_config(skeleton_config)
             self._model_skeleton.eval()
         return self._model_skeleton
 
@@ -2527,11 +2584,12 @@ class DiskOffloadBackend(ExtractionBackend):
         from .activation_types import ExtractedBatch
 
         config = self._get_config()
+        text_config = self._get_text_config()
         model = self._get_model_skeleton()
         layer_map, non_layer = self._get_shard_map()
         device = self.device
 
-        num_layers = config.num_hidden_layers
+        num_layers = text_config.num_hidden_layers
         hidden_target = set(spec.hidden_layers)
         router_target = set(spec.router_layers or [])
         n_experts = getattr(config, "n_routed_experts", None)
@@ -2556,7 +2614,7 @@ class DiskOffloadBackend(ExtractionBackend):
 
         # Process all batches through embedding
         all_hidden = torch.zeros(
-            n_prompts, seq_len, config.hidden_size, dtype=self.dtype,
+            n_prompts, seq_len, text_config.hidden_size, dtype=self.dtype,
         )
         with torch.no_grad():
             for b in range(n_batches):
@@ -2586,11 +2644,11 @@ class DiskOffloadBackend(ExtractionBackend):
                 rotary_mod = getattr(rotary_mod, part)
 
             # Re-initialize rotary from config (meta tensors have no data)
-            dim = getattr(config, "qk_rope_head_dim", None)
+            dim = getattr(text_config, "qk_rope_head_dim", None)
             if dim is None:
-                head_dim = config.hidden_size // config.num_attention_heads
+                head_dim = text_config.hidden_size // text_config.num_attention_heads
                 dim = head_dim
-            base = getattr(config, "rope_theta", 10000.0)
+            base = getattr(text_config, "rope_theta", 10000.0)
             inv_freq = 1.0 / (
                 base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
             )
@@ -2842,10 +2900,11 @@ class DiskOffloadBackend(ExtractionBackend):
         import gc
 
         config = self._get_config()
+        text_config = self._get_text_config()
         model = self._get_model_skeleton()
         layer_map, non_layer = self._get_shard_map()
         device = self.device
-        num_layers = config.num_hidden_layers
+        num_layers = text_config.num_hidden_layers
 
         # Tokenize
         tokenized = self.tokenizer(

--- a/tests/test_disk_offload_mistral3.py
+++ b/tests/test_disk_offload_mistral3.py
@@ -1,0 +1,156 @@
+"""Mistral3 / multimodal support in :class:`DiskOffloadBackend`.
+
+The 24B Mistral-Small-3.1 checkpoint exposes a ``Mistral3Config`` (unregistered
+for ``AutoModelForCausalLM``) and stores text weights under
+``language_model.*``. These tests pin the shard-map / skeleton logic that lets
+the disk_offload backend handle that layout without needing the 48 GB of
+weights.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from lmprobe.backends import DiskOffloadBackend
+
+
+def _make_mistral3_like_config() -> SimpleNamespace:
+    """Approximate shape of ``Mistral3Config``: outer wrapper + text_config."""
+    text = SimpleNamespace(
+        num_hidden_layers=2,
+        hidden_size=8,
+        num_attention_heads=2,
+        quantization_config=None,
+    )
+    return SimpleNamespace(text_config=text, quantization_config=None)
+
+
+def _write_index(path: Path, weight_map: dict[str, str]) -> None:
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map})
+    )
+
+
+def test_shard_map_strips_language_model_prefix(tmp_path: Path) -> None:
+    """``language_model.`` prefix is stripped so the text skeleton sees plain names."""
+    _write_index(tmp_path, {
+        "language_model.model.embed_tokens.weight": "a.safetensors",
+        "language_model.model.layers.0.self_attn.q_proj.weight": "a.safetensors",
+        "language_model.model.layers.1.mlp.down_proj.weight": "a.safetensors",
+        "language_model.model.norm.weight": "a.safetensors",
+        "language_model.lm_head.weight": "a.safetensors",
+    })
+
+    b = DiskOffloadBackend("fake/model", device="cpu", dtype=torch.bfloat16)
+    with (
+        patch.object(b, "_get_config", return_value=_make_mistral3_like_config()),
+        patch.object(b, "_get_snapshot_dir", return_value=tmp_path),
+    ):
+        layer_map, non_layer = b._get_shard_map()
+
+    layer_names = {n for entries in layer_map.values() for n, _ in entries}
+    non_layer_names = {n for n, _ in non_layer}
+
+    assert layer_names == {
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.1.mlp.down_proj.weight",
+    }
+    assert non_layer_names == {
+        "model.embed_tokens.weight",
+        "model.norm.weight",
+        "lm_head.weight",
+    }
+
+
+def test_shard_map_drops_vision_and_projector_tensors(tmp_path: Path) -> None:
+    """Vision tower / multi-modal projector weights must not enter the text skeleton."""
+    _write_index(tmp_path, {
+        "language_model.model.layers.0.self_attn.q_proj.weight": "a.safetensors",
+        "vision_tower.patch_conv.weight": "b.safetensors",
+        "vision_tower.transformer.layers.0.attention.q_proj.weight": "b.safetensors",
+        "multi_modal_projector.linear_1.weight": "c.safetensors",
+    })
+
+    b = DiskOffloadBackend("fake/model", device="cpu", dtype=torch.bfloat16)
+    with (
+        patch.object(b, "_get_config", return_value=_make_mistral3_like_config()),
+        patch.object(b, "_get_snapshot_dir", return_value=tmp_path),
+    ):
+        layer_map, non_layer = b._get_shard_map()
+
+    all_names = {n for entries in layer_map.values() for n, _ in entries}
+    all_names |= {n for n, _ in non_layer}
+    assert all_names == {"model.layers.0.self_attn.q_proj.weight"}
+
+
+def test_shard_map_text_only_model_unchanged(tmp_path: Path) -> None:
+    """Single-config models keep original names; no prefix is stripped."""
+    _write_index(tmp_path, {
+        "model.embed_tokens.weight": "a.safetensors",
+        "model.layers.0.self_attn.q_proj.weight": "a.safetensors",
+        "lm_head.weight": "a.safetensors",
+    })
+
+    text_only = SimpleNamespace(
+        num_hidden_layers=1, hidden_size=8, num_attention_heads=2,
+        quantization_config=None,
+    )
+    b = DiskOffloadBackend("fake/text-only", device="cpu", dtype=torch.bfloat16)
+    with (
+        patch.object(b, "_get_config", return_value=text_only),
+        patch.object(b, "_get_snapshot_dir", return_value=tmp_path),
+    ):
+        assert b._skeleton_prefix == ""
+        layer_map, non_layer = b._get_shard_map()
+
+    layer_names = {n for entries in layer_map.values() for n, _ in entries}
+    assert layer_names == {"model.layers.0.self_attn.q_proj.weight"}
+    assert {n for n, _ in non_layer} == {
+        "model.embed_tokens.weight",
+        "lm_head.weight",
+    }
+
+
+def test_get_text_config_returns_text_config_when_present() -> None:
+    b = DiskOffloadBackend("fake/model", device="cpu", dtype=torch.bfloat16)
+    outer = _make_mistral3_like_config()
+    with patch.object(b, "_get_config", return_value=outer):
+        assert b._get_text_config() is outer.text_config
+        assert b._skeleton_prefix == "language_model."
+
+
+def test_get_text_config_falls_back_when_absent() -> None:
+    b = DiskOffloadBackend("fake/text-only", device="cpu", dtype=torch.bfloat16)
+    text_only = SimpleNamespace(num_hidden_layers=1, hidden_size=8)
+    with patch.object(b, "_get_config", return_value=text_only):
+        assert b._get_text_config() is text_only
+        assert b._skeleton_prefix == ""
+
+
+def test_load_tensors_reattaches_prefix_for_shard_lookup(tmp_path: Path) -> None:
+    """Shard lookup uses the prefixed key; the result dict uses the stripped key."""
+    from safetensors.torch import save_file
+
+    t = torch.ones(2, 2)
+    save_file(
+        {"language_model.model.layers.0.self_attn.q_proj.weight": t},
+        str(tmp_path / "a.safetensors"),
+    )
+
+    b = DiskOffloadBackend("fake/model", device="cpu", dtype=torch.bfloat16)
+    with (
+        patch.object(b, "_get_config", return_value=_make_mistral3_like_config()),
+        patch.object(b, "_get_snapshot_dir", return_value=tmp_path),
+    ):
+        result = b._load_tensors(
+            [("model.layers.0.self_attn.q_proj.weight", "a.safetensors")],
+            device="cpu",
+        )
+
+    assert list(result.keys()) == ["model.layers.0.self_attn.q_proj.weight"]
+    assert torch.equal(result["model.layers.0.self_attn.q_proj.weight"], t)

--- a/tests/test_tokenizer_utils.py
+++ b/tests/test_tokenizer_utils.py
@@ -124,6 +124,48 @@ def test_unrelated_typeerror_is_re_raised():
             load_tokenizer(MISTRAL_MODELS_WITH_REGEX_BUG[0])
 
 
+def test_mistral_regex_warning_silenced_on_dup_kwarg_fallback(caplog):
+    """The noisy 'incorrect regex pattern' warning must not reach downstream loggers.
+
+    When the dup-kwarg fallback loads the tokenizer without the flag,
+    transformers emits a misleading warning before we post-patch. It should
+    be filtered out.
+    """
+    import logging as _logging
+
+    mistral_name = MISTRAL_MODELS_WITH_REGEX_BUG[0]
+    fake_tok = MagicMock()
+    fake_tok.chat_template = "existing"
+
+    emitter = _logging.getLogger("transformers.tokenization_utils_tokenizers")
+
+    def fake_from_pretrained(_name, **kwargs):
+        if "fix_mistral_regex" in kwargs:
+            raise TypeError(
+                "got multiple values for keyword argument 'fix_mistral_regex'"
+            )
+        # Mimic the transformers warning that our suppressor targets.
+        emitter.warning(
+            "The tokenizer you are loading from '%s' with an incorrect "
+            "regex pattern: ...",
+            mistral_name,
+        )
+        return fake_tok
+
+    with (
+        patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            side_effect=fake_from_pretrained,
+        ),
+        patch("lmprobe._tokenizer_utils._apply_mistral_regex_fix"),
+        caplog.at_level(_logging.WARNING, logger="transformers.tokenization_utils_tokenizers"),
+    ):
+        load_tokenizer(mistral_name)
+
+    noisy = [r for r in caplog.records if "incorrect regex pattern" in r.getMessage()]
+    assert noisy == [], f"expected warning to be silenced, got: {[r.getMessage() for r in noisy]}"
+
+
 def test_mistral_regex_not_applied_when_user_opts_out():
     """If user passes fix_mistral_regex=False, the post-load patch is skipped."""
     mistral_name = MISTRAL_MODELS_WITH_REGEX_BUG[0]


### PR DESCRIPTION
## Summary
- `DiskOffloadBackend` now handles Mistral-Small-3.1 (and other multimodal configs that nest text weights under `config.text_config`): the skeleton is built from `text_config`, the shard map strips a `language_model.` prefix, and `vision_tower.*` / `multi_modal_projector.*` tensors are dropped.
- Silenced the cosmetic `incorrect regex pattern` warning transformers emits on our dup-kwarg fallback path — the regex fix is still applied via `_apply_mistral_regex_fix`, so the warning was misleading noise in demo notebooks.

## Why
Loading Mistral-Small-3.1 through `resolve_backend(backend="disk_offload", ...)` failed with `Unrecognized configuration class Mistral3Config for this kind of AutoModel: AutoModelForCausalLM`, because the outer multimodal config isn't registered for `AutoModelForCausalLM` and the safetensors index uses `language_model.model.layers.N.*` paths that the shard-map didn't recognize.

## Test plan
- [x] `tests/test_disk_offload_mistral3.py` covers prefix stripping, vision/projector filtering, plain text-model fallback, text_config resolution, and `_load_tensors` prefix reattachment — no weight download required.
- [x] `tests/test_tokenizer_utils.py::test_mistral_regex_warning_silenced_on_dup_kwarg_fallback` pins the warning suppression.
- [x] All 15 targeted tests pass locally; CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)